### PR TITLE
feat(admin): 用户管理页（列表/筛选/封禁/详情/导出）

### DIFF
--- a/apps/admin/src/app/(dashboard)/users/page.tsx
+++ b/apps/admin/src/app/(dashboard)/users/page.tsx
@@ -1,6 +1,176 @@
-import { PrototypePage } from "@/components/prototype-page";
-import { PROTOTYPE_PAGE_HTML } from "@/lib/prototype-pages";
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  downloadCsv,
+  listUsers,
+  setUserStatus,
+  toCsv,
+  type AdminUser,
+  type RoleFilter,
+  type StatusFilter
+} from "@/lib/api/users";
+import { UserFilters } from "@/components/users/user-filters";
+import { UserTable } from "@/components/users/user-table";
+import { UserDetailModal } from "@/components/users/user-detail-modal";
+import { Pagination } from "@/components/users/pagination";
+
+const PAGE_SIZE = 20;
 
 export default function UsersPage() {
-  return <PrototypePage html={PROTOTYPE_PAGE_HTML["users"]} />;
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [role, setRole] = useState<RoleFilter>("");
+  const [status, setStatus] = useState<StatusFilter>("");
+  const [page, setPage] = useState(1);
+
+  const [result, setResult] = useState<{ total: number; items: AdminUser[] }>({ total: 0, items: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [detailUser, setDetailUser] = useState<AdminUser | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  // 搜索输入 300ms 防抖后提交
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        setPage(1);
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listUsers({
+        search: debouncedSearch,
+        role,
+        status,
+        page,
+        pageSize: PAGE_SIZE
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch, role, status, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // 提示自动消失
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  async function handleToggleBan(user: AdminUser) {
+    const next = user.status === "banned" ? "active" : "banned";
+    try {
+      await setUserStatus(user.id, next);
+      setToast(next === "banned" ? `已封禁 ${user.display_name ?? user.email ?? "该用户"}` : `已解封 ${user.display_name ?? user.email ?? "该用户"}`);
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+    }
+  }
+
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const res = await listUsers({
+        search: debouncedSearch,
+        role,
+        status,
+        page: 1,
+        pageSize: Math.min(result.total || 5000, 5000)
+      });
+      downloadCsv("users.csv", toCsv(res.items));
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "导出失败");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">用户管理</h1>
+          <p className="page-subtitle">查看所有注册用户与消费统计</p>
+        </div>
+        <div className="page-actions">
+          <button className="btn btn-secondary btn-sm" onClick={() => void handleExport()} disabled={exporting}>
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            {exporting ? "导出中..." : "导出 CSV"}
+          </button>
+        </div>
+      </div>
+
+      <UserFilters
+        value={{ search, role, status }}
+        onChange={(v) => {
+          if (v.search !== search) setSearch(v.search);
+          if (v.role !== role) {
+            setRole(v.role);
+            setPage(1);
+          }
+          if (v.status !== status) {
+            setStatus(v.status);
+            setPage(1);
+          }
+        }}
+      />
+
+      <UserTable
+        users={result.items}
+        loading={loading}
+        error={error}
+        onDetail={setDetailUser}
+        onToggleBan={(user) => void handleToggleBan(user)}
+      />
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <Pagination
+          page={page}
+          total={result.total}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
+      </div>
+
+      <UserDetailModal user={detailUser} onClose={() => setDetailUser(null)} />
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/admin/src/components/users/pagination.tsx
+++ b/apps/admin/src/components/users/pagination.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+function buildPages(current: number, total: number): Array<number | "..."> {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const pages: Array<number | "..."> = [1];
+  const start = Math.max(2, current - 1);
+  const end = Math.min(total - 1, current + 1);
+
+  if (start > 2) pages.push("...");
+  for (let i = start; i <= end; i++) pages.push(i);
+  if (end < total - 1) pages.push("...");
+  pages.push(total);
+  return pages;
+}
+
+export function Pagination({
+  page,
+  total,
+  pageSize,
+  onPageChange
+}: {
+  page: number;
+  total: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (totalPages <= 1) return null;
+
+  const pages = buildPages(page, totalPages);
+
+  return (
+    <div className="pagination">
+      <button
+        className="page-btn"
+        disabled={page <= 1}
+        style={page <= 1 ? { opacity: 0.4, cursor: "default" } : undefined}
+        onClick={() => onPageChange(page - 1)}
+        aria-label="上一页"
+      >
+        <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+
+      {pages.map((p, idx) =>
+        p === "..." ? (
+          <span key={`ellipsis-${idx}`} className="page-btn" style={{ border: "none", cursor: "default" }}>
+            ...
+          </span>
+        ) : (
+          <button
+            key={p}
+            className={`page-btn${p === page ? " active" : ""}`}
+            onClick={() => onPageChange(p)}
+          >
+            {p}
+          </button>
+        )
+      )}
+
+      <button
+        className="page-btn"
+        disabled={page >= totalPages}
+        style={page >= totalPages ? { opacity: 0.4, cursor: "default" } : undefined}
+        onClick={() => onPageChange(page + 1)}
+        aria-label="下一页"
+      >
+        <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/components/users/user-detail-modal.tsx
+++ b/apps/admin/src/components/users/user-detail-modal.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AdminUser, RecentJob } from "@/lib/api/users";
+import { listRecentJobs, roleLabel, statusLabel } from "@/lib/api/users";
+import { avatarColor, formatCount, formatDate, formatDateTime, initials } from "@/lib/utils/format";
+
+function JobStatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; tone: "success" | "danger" | "warning" | "muted" }> = {
+    success: { label: "成功", tone: "success" },
+    failed: { label: "失败", tone: "danger" },
+    running: { label: "生成中", tone: "warning" },
+    pending: { label: "排队中", tone: "muted" },
+    not_generated: { label: "未派发", tone: "muted" },
+    interrupted: { label: "已中断", tone: "warning" }
+  };
+  const item = map[status] ?? { label: status, tone: "muted" as const };
+  return <span className={`badge badge-${item.tone}`}>{item.label}</span>;
+}
+
+export function UserDetailModal({
+  user,
+  onClose
+}: {
+  user: AdminUser | null;
+  onClose: () => void;
+}) {
+  const [jobs, setJobs] = useState<RecentJob[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    setJobsLoading(true);
+    listRecentJobs(user.id)
+      .then((rows) => {
+        if (!cancelled) setJobs(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setJobs([]);
+      })
+      .finally(() => {
+        if (!cancelled) setJobsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  if (!user) return null;
+
+  return (
+    <div className="modal-overlay show" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-title">用户详情</div>
+          <button className="modal-close" onClick={onClose} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 20 }}>
+            <div
+              className="admin-avatar"
+              style={{ width: 52, height: 52, fontSize: 18, background: avatarColor(user.id) }}
+            >
+              {initials(user.display_name, user.email)}
+            </div>
+            <div>
+              <div style={{ fontSize: 16, fontWeight: 600, color: "var(--color-foreground)" }}>
+                {user.display_name ?? "未命名"}
+              </div>
+              <div style={{ fontSize: 13, color: "#64748B" }}>{user.email ?? "—"}</div>
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">所属团队</label>
+              <div style={{ fontSize: 14 }}>{user.team_name ?? "个人"}</div>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">角色</label>
+              <div style={{ fontSize: 14 }}>
+                {roleLabel(user.team_role)}
+                {user.is_admin ? <span style={{ marginLeft: 8 }} className="badge badge-info">平台管理员</span> : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">注册时间</label>
+              <div style={{ fontSize: 14 }}>{formatDate(user.created_at)}</div>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">状态</label>
+              <div style={{ fontSize: 14 }}>{statusLabel(user.status)}</div>
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">本月消费</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>{formatCount(user.month_usage)}</div>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">累计消费</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>{formatCount(user.total_usage)}</div>
+            </div>
+          </div>
+
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">最近任务</label>
+            {jobsLoading ? (
+              <div style={{ fontSize: 13, color: "#94A3B8", padding: "12px 0" }}>加载中...</div>
+            ) : jobs.length === 0 ? (
+              <div style={{ fontSize: 13, color: "#94A3B8", padding: "12px 0" }}>暂无任务记录</div>
+            ) : (
+              <div className="table-container" style={{ maxHeight: 240, overflowY: "auto" }}>
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>时间</th>
+                      <th>厂商</th>
+                      <th>模式</th>
+                      <th>等效</th>
+                      <th>状态</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {jobs.map((job) => (
+                      <tr key={job.id}>
+                        <td>{formatDateTime(job.created_at)}</td>
+                        <td>{job.provider_id ?? "—"}</td>
+                        <td>{job.mode}</td>
+                        <td className="cell-mono">{job.equivalent_count ?? job.cost_amount ?? "—"}</td>
+                        <td><JobStatusBadge status={job.status} /></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>关闭</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/users/user-filters.tsx
+++ b/apps/admin/src/components/users/user-filters.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { RoleFilter, StatusFilter } from "@/lib/api/users";
+
+export interface UserFiltersValue {
+  search: string;
+  role: RoleFilter;
+  status: StatusFilter;
+}
+
+export function UserFilters({
+  value,
+  onChange
+}: {
+  value: UserFiltersValue;
+  onChange: (value: UserFiltersValue) => void;
+}) {
+  return (
+    <div className="filter-bar">
+      <div className="filter-group">
+        <span className="filter-label">角色</span>
+        <select
+          className="form-select"
+          style={{ width: 120 }}
+          value={value.role}
+          onChange={(e) => onChange({ ...value, role: e.target.value as RoleFilter })}
+        >
+          <option value="">全部</option>
+          <option value="admin">Admin</option>
+          <option value="member">Member</option>
+          <option value="none">个人</option>
+        </select>
+      </div>
+
+      <div className="filter-group">
+        <span className="filter-label">状态</span>
+        <select
+          className="form-select"
+          style={{ width: 120 }}
+          value={value.status}
+          onChange={(e) => onChange({ ...value, status: e.target.value as StatusFilter })}
+        >
+          <option value="">全部</option>
+          <option value="active">正常</option>
+          <option value="banned">已封禁</option>
+          <option value="exhausted">额度耗尽</option>
+        </select>
+      </div>
+
+      <div className="filter-group" style={{ marginLeft: "auto" }}>
+        <input
+          type="text"
+          placeholder="搜索邮箱或用户名..."
+          style={{ width: 220 }}
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/users/user-table.tsx
+++ b/apps/admin/src/components/users/user-table.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { AdminUser } from "@/lib/api/users";
+import { roleLabel, statusLabel } from "@/lib/api/users";
+import { avatarColor, formatCount, formatDate, initials } from "@/lib/utils/format";
+
+function statusTone(status: AdminUser["status"]): "success" | "danger" | "warning" {
+  if (status === "banned") return "danger";
+  if (status === "exhausted") return "warning";
+  return "success";
+}
+
+function roleTone(role: AdminUser["team_role"]): "info" | "muted" {
+  return role === "admin" ? "info" : "muted";
+}
+
+export function UserTable({
+  users,
+  loading,
+  error,
+  onDetail,
+  onToggleBan
+}: {
+  users: AdminUser[];
+  loading: boolean;
+  error: string | null;
+  onDetail: (user: AdminUser) => void;
+  onToggleBan: (user: AdminUser) => void;
+}) {
+  return (
+    <div className="card">
+      <div className="table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>用户</th>
+              <th>所属团队</th>
+              <th>角色</th>
+              <th>注册时间</th>
+              <th>本月消费</th>
+              <th>累计消费</th>
+              <th>状态</th>
+              <th style={{ textAlign: "right" }}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && users.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                  加载中...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={8} className="empty-state" style={{ textAlign: "center", color: "var(--color-destructive)" }}>
+                  {error}
+                </td>
+              </tr>
+            ) : users.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                  暂无匹配的用户
+                </td>
+              </tr>
+            ) : (
+              users.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                      <div
+                        className="admin-avatar"
+                        style={{ width: 28, height: 28, fontSize: 11, background: avatarColor(user.id) }}
+                      >
+                        {initials(user.display_name, user.email)}
+                      </div>
+                      <div>
+                        <div className="cell-primary" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                          {user.display_name ?? "未命名"}
+                          {user.is_admin ? (
+                            <span className="badge badge-info" style={{ padding: "0 6px", fontSize: 10 }}>
+                              管理员
+                            </span>
+                          ) : null}
+                        </div>
+                        <div style={{ fontSize: 11, color: "#94A3B8" }}>{user.email ?? "—"}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>{user.team_name ?? "个人"}</td>
+                  <td>
+                    <span className={`badge badge-${roleTone(user.team_role)}`}>{roleLabel(user.team_role)}</span>
+                  </td>
+                  <td>{formatDate(user.created_at)}</td>
+                  <td className="cell-mono">{formatCount(user.month_usage)}</td>
+                  <td className="cell-mono">{formatCount(user.total_usage)}</td>
+                  <td>
+                    <span className={`badge badge-${statusTone(user.status)}`}>
+                      <span className="badge-dot" />
+                      {statusLabel(user.status)}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="cell-actions">
+                      <button className="btn btn-secondary btn-sm" onClick={() => onDetail(user)}>
+                        详情
+                      </button>
+                      <button
+                        className={`btn ${user.status === "banned" ? "btn-outline" : "btn-danger"} btn-sm`}
+                        onClick={() => onToggleBan(user)}
+                      >
+                        {user.status === "banned" ? "解封" : "封禁"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/api/users.ts
+++ b/apps/admin/src/lib/api/users.ts
@@ -1,0 +1,159 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { formatDate } from "@/lib/utils/format";
+
+export type UserStatus = "active" | "banned" | "exhausted";
+export type TeamRole = "admin" | "member";
+export type RoleFilter = "" | TeamRole | "none";
+export type StatusFilter = "" | UserStatus;
+
+export interface AdminUser {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  is_admin: boolean;
+  status: UserStatus;
+  created_at: string;
+  team_name: string | null;
+  team_role: TeamRole | null;
+  month_usage: number;
+  total_usage: number;
+}
+
+export interface UserListResult {
+  total: number;
+  items: AdminUser[];
+}
+
+export interface UserListParams {
+  search?: string;
+  role?: RoleFilter;
+  status?: StatusFilter;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RecentJob {
+  id: string;
+  status: string;
+  provider_id: string | null;
+  mode: string;
+  cost_unit: string | null;
+  cost_amount: number | null;
+  equivalent_count: number | null;
+  created_at: string;
+}
+
+export async function listUsers(params: UserListParams = {}): Promise<UserListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+
+  const { data, error } = await supabase.rpc("admin_list_users", {
+    p_search: params.search?.trim() || null,
+    p_role: params.role || null,
+    p_status: params.status || null,
+    p_limit: pageSize,
+    p_offset: (page - 1) * pageSize
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { total: 0, items: [] }) as { total: number; items: unknown[] };
+  return {
+    total: Number(raw.total ?? 0),
+    items: (raw.items ?? []).map((it) => normalizeUser(it as Record<string, unknown>))
+  };
+}
+
+export async function setUserStatus(userId: string, status: UserStatus): Promise<void> {
+  const supabase = createAdminBrowserClient();
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", userId);
+  if (error) throw error;
+
+  // 写审计日志（失败不阻断主操作，仅静默忽略）
+  const { data: authData } = await supabase.auth.getUser();
+  const adminUserId = authData.user?.id;
+  if (adminUserId) {
+    await supabase.from("audit_logs").insert({
+      admin_user_id: adminUserId,
+      user_id: userId,
+      action: status === "banned" ? "user.ban" : "user.unban",
+      target: userId,
+      metadata: {}
+    });
+  }
+}
+
+export async function listRecentJobs(userId: string, limit = 10): Promise<RecentJob[]> {
+  const supabase = createAdminBrowserClient();
+  const { data, error } = await supabase
+    .from("jobs")
+    .select("id, status, provider_id, mode, cost_unit, cost_amount, equivalent_count, created_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []) as RecentJob[];
+}
+
+/** 用户状态 → 中文标签。 */
+export function statusLabel(status: UserStatus): string {
+  if (status === "banned") return "已封禁";
+  if (status === "exhausted") return "额度耗尽";
+  return "正常";
+}
+
+/** 团队角色 → 中文标签；无团队返回「—」。 */
+export function roleLabel(role: TeamRole | null): string {
+  if (role === "admin") return "Admin";
+  if (role === "member") return "Member";
+  return "—";
+}
+
+export function toCsv(users: AdminUser[]): string {
+  const header = ["邮箱", "姓名", "所属团队", "角色", "注册时间", "本月消费", "累计消费", "状态"];
+  const rows = users.map((u) => [
+    u.email ?? "",
+    u.display_name ?? "",
+    u.team_name ?? "个人",
+    u.team_role === "admin" ? "Admin" : u.team_role === "member" ? "Member" : "—",
+    formatDate(u.created_at),
+    String(u.month_usage),
+    String(u.total_usage),
+    statusLabel(u.status)
+  ]);
+  const csv = [header, ...rows]
+    .map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(","))
+    .join("\n");
+  return "﻿" + csv; // BOM，便于 Excel 正确识别 UTF-8
+}
+
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function normalizeUser(it: Record<string, unknown>): AdminUser {
+  return {
+    id: String(it.id ?? ""),
+    email: (it.email as string) ?? null,
+    display_name: (it.display_name as string) ?? null,
+    avatar_url: (it.avatar_url as string) ?? null,
+    is_admin: Boolean(it.is_admin),
+    status: (it.status as UserStatus) ?? "active",
+    created_at: String(it.created_at ?? ""),
+    team_name: (it.team_name as string) ?? null,
+    team_role: (it.team_role as TeamRole) ?? null,
+    month_usage: Number(it.month_usage ?? 0),
+    total_usage: Number(it.total_usage ?? 0)
+  };
+}

--- a/apps/admin/src/lib/utils/format.ts
+++ b/apps/admin/src/lib/utils/format.ts
@@ -1,0 +1,48 @@
+/** 日期/数字格式化 + 头像辅助，供后台各列表复用。 */
+
+export function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const date = formatDate(iso);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}`;
+}
+
+export function formatCount(n: number): string {
+  return `${Math.round(n).toLocaleString("zh-CN")} 次`;
+}
+
+/** 头像缩写：中文取前两字，英文取首字母。 */
+export function initials(name: string | null, email: string | null): string {
+  const src = (name ?? "").trim() || (email ?? "").trim();
+  if (!src) return "?";
+  if (/[一-龥]/.test(src)) {
+    return src.slice(0, 2);
+  }
+  const parts = src.split(/[\s@._-]+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return src.slice(0, 2).toUpperCase();
+}
+
+const AVATAR_COLORS = ["#1E40AF", "#059669", "#D97706", "#DC2626", "#7C3AED", "#0891B2", "#4F46E5"];
+
+/** 依据 id 稳定取一个头像底色，同一用户颜色不变。 */
+export function avatarColor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}

--- a/docs/develop/admin-users-page.md
+++ b/docs/develop/admin-users-page.md
@@ -1,0 +1,141 @@
+# 后台「用户管理」页实现总结
+
+> 完成日期：2026-08-13
+> 实现范围：apps/admin 用户管理页（从静态原型替换为真实数据驱动）
+> 关联设计：[admin-system-plan.md](./admin-system-plan.md)、REQUIREMENTS.md §13.4.1
+
+---
+
+## 1. 背景
+
+`apps/admin` 后台骨架阶段，8 个页面均通过 `PrototypePage` 注入 `docs/prototype` 导出的静态 HTML 字符串渲染，用户管理页同样如此——数据、筛选器、按钮全是写死的，无任何交互。
+
+本次将「用户管理」页替换为真实实现：从 Supabase 读取数据、支持筛选/搜索/分页/封禁解封/详情/导出 CSV。其余 7 个页面暂保持静态原型不变。
+
+---
+
+## 2. 改动总览
+
+| 文件 | 改动类型 | 说明 |
+|------|---------|------|
+| `migrations/0010_admin_users_rpc.sql` | 新增 | `admin_list_users` RPC：聚合用户列表 |
+| `apps/admin/src/lib/api/users.ts` | 新增 | 数据访问层（列表/封禁解封/最近任务/CSV 导出） |
+| `apps/admin/src/lib/utils/format.ts` | 新增 | 日期/数字格式化 + 头像缩写与配色 |
+| `apps/admin/src/components/users/user-filters.tsx` | 新增 | 角色/状态筛选 + 搜索框 |
+| `apps/admin/src/components/users/user-table.tsx` | 新增 | 用户列表表格 |
+| `apps/admin/src/components/users/user-detail-modal.tsx` | 新增 | 用户详情弹窗（含最近任务） |
+| `apps/admin/src/components/users/pagination.tsx` | 新增 | 分页组件（带省略号） |
+| `apps/admin/src/app/(dashboard)/users/page.tsx` | 重写 | 由静态原型改为客户端组件，组装以上所有 |
+| `apps/admin/.env.local` | 新增（本地，已 gitignore） | 配 `NEXT_PUBLIC_SUPABASE_URL` / `ANON_KEY` |
+
+> 说明：`.env.local` 值复制自 `apps/desktop/.env` 的 `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`（同一 Supabase 项目 `pnhvyjyexiwmecblfwly`），该文件已被 `.gitignore` 忽略、仅本地存在。
+
+---
+
+## 3. 数据库改动
+
+### 3.1 `admin_list_users` RPC
+
+聚合 `profiles` + `team_members` + `teams` + `jobs`，一次调用返回分页后的用户列表与总数：
+
+```sql
+CREATE OR REPLACE FUNCTION public.admin_list_users(
+  p_search TEXT DEFAULT NULL,   -- 邮箱/用户名 ILIKE
+  p_role TEXT DEFAULT NULL,     -- 'admin' | 'member' | 'none'(无团队=个人)
+  p_status TEXT DEFAULT NULL,   -- 'active' | 'banned' | 'exhausted'
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json   -- { total, items: [...] }
+```
+
+关键点：
+
+- **安全**：`SECURITY DEFINER SET search_path = public, auth`，函数体首行 `IF NOT public.is_admin() THEN RAISE EXCEPTION` 兜底，仅管理员可调用。
+- **消费口径**：对 `jobs` 按 `user_id` 求和 `COALESCE(equivalent_count, 0)`（等效「次」），跨厂商可比；`month_usage` 用 `date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai')` 对齐项目统一的每日额度重置时区。
+- **团队**：`LEFT JOIN team_members` + `LEFT JOIN teams`，无团队用户 `team_name` / `team_role` 为 `NULL`。
+- **排序**：`ORDER BY p.created_at DESC, p.id`（加 `id` 作 tiebreaker 保证分页稳定）。
+
+### 3.2 依赖的前置迁移
+
+用户页依赖以下表/策略，需先执行：
+
+- `migrations/0007_admin_tables.sql`：`profiles`（含 `is_admin` / `status`）、`is_admin()` 函数、`profiles_admin_all` / `jobs_admin_all` / `teams_admin_all` / `team_members_admin_all` / `audit_logs_admin_all` 等 RLS 策略。
+- `migrations/0001_providers.sql`：`teams` / `team_members`（`role` = admin|member）。
+- `migrations/0003_jobs.sql`：`jobs`（`equivalent_count` / `user_id` / `created_at`）。
+
+---
+
+## 4. 前端改动
+
+### 4.1 数据访问层（lib/api/users.ts）
+
+- `listUsers(params)` → 调 `admin_list_users` RPC，返回 `{ total, items }`。
+- `setUserStatus(userId, status)` → 更新 `profiles.status`（+`updated_at`），并写 `audit_logs`（action=`user.ban` / `user.unban`）。
+- `listRecentJobs(userId, limit)` → 详情弹窗的最近任务（走 `jobs_admin_all` RLS）。
+- `toCsv` / `downloadCsv` → 客户端生成 CSV（带 BOM，兼容 Excel）。
+
+### 4.2 页面结构（users/page.tsx，客户端组件）
+
+- 搜索框 300ms 防抖；角色/状态变化立即生效并重置到第 1 页。
+- 列表/筛选/分页/详情/封禁解封/导出组装为一个页面，操作后刷新列表 + toast 提示。
+- 复用了 `globals.css` 中已有的原型样式类（`filter-bar` / `table` / `badge-*` / `cell-*` / `pagination` / `admin-avatar` / `modal-*`），未用 `components/ui.tsx` 里另一套 `DataTable`（类名对不上原型视觉）。
+
+---
+
+## 5. 关键设计决策
+
+| 决策点 | 结论 |
+|--------|------|
+| 「角色」语义 | 指**团队角色**（`team_members.role` 的 Admin/Member）；「平台管理员」由 `profiles.is_admin` 单独用 badge 标识，两者不混用 |
+| 无团队用户 | 视为**个人**：所属团队显示「个人」、角色显示「—」；筛选器新增「个人」选项（否则选 Admin/Member 会把个人用户整体筛没掉） |
+| 消费统计 | 求和 `equivalent_count`（单位「次」），不用 `cost_amount`（各厂商单位不一致，灵感值/积分无法跨厂商相加） |
+| 封禁力度 | MVP 仅改 `profiles.status`（active↔banned）+ 写审计；**不强踢会话**（需要 service_role / Edge Function，本次不做，桌面端靠读 `status` 拦截） |
+
+---
+
+## 6. 部署与验证
+
+### 部署步骤
+
+1. 确认 `0007_admin_tables.sql` 已执行（profiles 表 + RLS）。
+2. 执行 `migrations/0010_admin_users_rpc.sql`（SQL Editor 或 `node packages/db-supabase/deploy-migrations.mjs <db-password>`）。
+3. 确认 `apps/admin/.env.local` 已配置（见 §2）。
+4. `pnpm dev` 起 admin 应用，登录运营者账号后进入「用户管理」。
+
+### 验证点
+
+| 项 | 预期 |
+|----|------|
+| 未登录访问 `/users` | `307` 重定向到 `/login?next=/users` |
+| 列表 | 显示真实用户（头像/邮箱/团队/角色/注册时间/本月/累计/状态） |
+| 筛选/搜索 | 角色、状态、关键字组合过滤正确 |
+| 分页 | 按 `total` 分页，切换页码正常 |
+| 封禁/解封 | 状态切换生效，`audit_logs` 出现 `user.ban` / `user.unban` 记录 |
+| 详情 | 弹窗显示用户信息 + 最近任务 |
+| 导出 CSV | 下载文件内容与当前筛选结果一致 |
+
+### 排障：ChunkLoadError
+
+若页面报 `Loading chunk app/(dashboard)/users/page failed`：
+
+- 根因：同一目录 `apps/admin` 同时跑两个 dev server，共用 `.next` 缓存 + 热更新导致 chunk 清单错乱（非代码问题）。
+- 处理：停掉旧进程 → `pnpm clean`（清 `.next`）→ 重启单个 `pnpm dev` → 浏览器 `Ctrl+Shift+R` 硬刷新。
+
+---
+
+## 7. 已知残留项
+
+| 项 | 优先级 | 说明 |
+|----|--------|------|
+| 封禁不强踢会话 | LOW | 封禁仅标记 `status`，用户当前会话不会立刻失效；需 service_role 调用 `auth.admin` 或 Edge Function 撤销 |
+| 消费统计只算 `equivalent_count` | LOW | 未计入 `cost_amount`（厂商原生单位）；如需按金额统计需另行聚合 |
+| 详情弹窗最近任务仅取前 10 条 | LOW | 未做任务分页 |
+| 其余 7 个后台页 | — | 仍为静态原型，待后续逐个按本页套路实现 |
+
+---
+
+## 8. 相关文档
+
+- [admin-system-plan.md](./admin-system-plan.md) — 后台整体开发方案与分阶段规划
+- [data-consistency-fix-summary.md](./data-consistency-fix-summary.md) — RPC 与 Supabase 迁移的先例写法

--- a/migrations/0010_admin_users_rpc.sql
+++ b/migrations/0010_admin_users_rpc.sql
@@ -1,0 +1,92 @@
+-- 0010_admin_users_rpc.sql
+-- 后台「用户管理」页数据源：聚合 profiles / team_members / teams / jobs 的用户列表。
+-- 幂等：CREATE OR REPLACE FUNCTION；在 Supabase SQL Editor 或迁移 runner 执行。
+
+-- 返回 json { total, items: [...] }，支持搜索 / 角色 / 状态过滤 + 分页。
+-- 消费口径：对 jobs 按 user_id 求和 equivalent_count（等效「次」）；
+--   month_usage = 本月（自然月，按 Asia/Shanghai 时区对齐项目的每日额度重置约定），
+--   total_usage = 累计。
+-- 角色过滤：'admin'/'member' 对应 team_members.role；'none' 表示无团队（个人）。
+CREATE OR REPLACE FUNCTION public.admin_list_users(
+  p_search TEXT DEFAULT NULL,
+  p_role TEXT DEFAULT NULL,
+  p_status TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM profiles p
+  LEFT JOIN team_members tm ON tm.user_id = p.id
+  WHERE
+    (p_search IS NULL OR p_search = '' OR p.email ILIKE '%' || p_search || '%' OR p.display_name ILIKE '%' || p_search || '%')
+    AND (p_status IS NULL OR p_status = '' OR p.status = p_status)
+    AND (
+      p_role IS NULL OR p_role = '' OR
+      (p_role = 'none' AND tm.user_id IS NULL) OR
+      (p_role <> 'none' AND tm.role = p_role)
+    );
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      p.id,
+      p.email,
+      p.display_name,
+      p.avatar_url,
+      p.is_admin,
+      p.status,
+      p.created_at,
+      t.name AS team_name,
+      tm.role AS team_role,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.user_id = p.id
+          AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+      ), 0) AS month_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.user_id = p.id
+      ), 0) AS total_usage
+    FROM profiles p
+    LEFT JOIN team_members tm ON tm.user_id = p.id
+    LEFT JOIN teams t ON t.id = tm.team_id
+    WHERE
+      (p_search IS NULL OR p_search = '' OR p.email ILIKE '%' || p_search || '%' OR p.display_name ILIKE '%' || p_search || '%')
+      AND (p_status IS NULL OR p_status = '' OR p.status = p_status)
+      AND (
+        p_role IS NULL OR p_role = '' OR
+        (p_role = 'none' AND tm.user_id IS NULL) OR
+        (p_role <> 'none' AND tm.role = p_role)
+      )
+    ORDER BY p.created_at DESC, p.id
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_users(text, text, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_users(text, text, text, integer, integer)
+  IS '后台用户管理列表：聚合 profiles/团队/消费统计，支持搜索、角色、状态过滤与分页（仅 admin 可调用）';


### PR DESCRIPTION
## 变更概览

把 Admin 后台「用户管理」页从静态原型替换为真实数据驱动实现。

### 数据库
- 新增 `migrations/0010_admin_users_rpc.sql`：`admin_list_users` RPC（`SECURITY DEFINER` + `is_admin` 校验），聚合 `profiles` / `team_members` / `teams` / `jobs`，支持搜索、角色、状态过滤与分页。
  > 注：编号取 `0010` 以避开 origin/main 上厂商管理新增的 `0008_providers_realtime.sql`、`0009_provider_logo_storage.sql`。

### 前端（apps/admin）
- `lib/api/users.ts`：数据访问层（列表 / 封禁解封 / 最近任务 / CSV 导出）
- `lib/utils/format.ts`：日期、数字格式化 + 头像缩写与配色
- `components/users/`：筛选器、表格、详情弹窗、分页四个组件
- `app/(dashboard)/users/page.tsx`：重写为客户端组件，组装以上功能

### 文档
- `docs/develop/admin-users-page.md`：本次改动总结

## 验证

- `pnpm --filter admin exec tsc --noEmit` 类型检查通过
- 未登录访问 `/users` → 重定向 `/login`；列表/筛选/搜索/分页/封禁/详情/导出均走真实数据

## 待办（后续）

- 封禁仅标记 `status`，不强踢会话（需 service_role / Edge Function）
- 消费统计只算 `equivalent_count`，未计 `cost_amount`

Closes #5