### PR TITLE
feat: 公告通知与桌面端应用自动更新

### DIFF
--- a/apps/admin/src/app/(dashboard)/announcements/page.tsx
+++ b/apps/admin/src/app/(dashboard)/announcements/page.tsx
@@ -1,6 +1,364 @@
-import { PrototypePage } from "@/components/prototype-page";
-import { PROTOTYPE_PAGE_HTML } from "@/lib/prototype-pages";
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  kindLabel,
+  listAnnouncements,
+  publishedLabel,
+  toggleAnnouncementPublished,
+  updateAnnouncement,
+  type AdminAnnouncement,
+  type AnnouncementInput,
+  type AnnouncementKind,
+  type AnnouncementKindFilter
+} from "@/lib/api/announcements";
 
 export default function AnnouncementsPage() {
-  return <PrototypePage html={PROTOTYPE_PAGE_HTML["announcements"]} />;
+  const [items, setItems] = useState<AdminAnnouncement[]>([]);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [kind, setKind] = useState<AnnouncementKindFilter>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [editor, setEditor] = useState<{ mode: "create" } | { mode: "edit"; item: AdminAnnouncement } | null>(null);
+  const [deleting, setDeleting] = useState<AdminAnnouncement | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setItems(await listAnnouncements({ search: debouncedSearch, kind }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch, kind]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  async function handleSave(input: AnnouncementInput) {
+    try {
+      if (editor?.mode === "edit") {
+        await updateAnnouncement(editor.item.id, input);
+        setToast("公告已更新");
+      } else {
+        await createAnnouncement(input);
+        setToast("公告已发布");
+      }
+      setEditor(null);
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+    }
+  }
+
+  async function handleToggle(item: AdminAnnouncement) {
+    try {
+      await toggleAnnouncementPublished(item.id, !item.published, item.title);
+      setToast(item.published ? "公告已下架" : "公告已发布");
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+    }
+  }
+
+  async function handleDelete(item: AdminAnnouncement) {
+    try {
+      await deleteAnnouncement(item.id, item.title);
+      setDeleting(null);
+      setToast("公告已删除");
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">公告通知</h1>
+          <p className="page-subtitle">向所有用户发布系统公告或版本更新说明</p>
+        </div>
+        <div className="page-actions">
+          <button className="btn btn-primary btn-sm" onClick={() => setEditor({ mode: "create" })}>
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            发布公告
+          </button>
+        </div>
+      </div>
+
+      <div className="filter-bar">
+        <div className="filter-group">
+          <span className="filter-label">搜索标题</span>
+          <input
+            className="form-input"
+            type="search"
+            placeholder="输入公告标题"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="filter-group">
+          <span className="filter-label">类型</span>
+          <select className="form-select" value={kind} onChange={(e) => setKind(e.target.value as AnnouncementKindFilter)}>
+            <option value="">全部</option>
+            <option value="notice">公告</option>
+            <option value="update">版本更新</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body" style={{ paddingTop: "var(--space-3)" }}>
+          {loading ? (
+            <AnnouncementSkeleton />
+          ) : error ? (
+            <div className="empty-state">
+              <h3>加载失败</h3>
+              <p>{error}</p>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="empty-state">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+              </svg>
+              <h3>暂无公告</h3>
+              <p>点击右上角“发布公告”创建第一条通知。</p>
+            </div>
+          ) : (
+            <div className="table-container">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>类型</th>
+                    <th>标题</th>
+                    <th>状态</th>
+                    <th>发布时间</th>
+                    <th style={{ textAlign: "right" }}>操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <tr key={item.id}>
+                      <td>
+                        <span className={`badge ${item.kind === "update" ? "badge-info" : "badge-success"}`}>
+                          {kindLabel(item.kind)}
+                        </span>
+                      </td>
+                      <td>
+                        <strong>{item.title}</strong>
+                        <div className="text-muted" style={{ fontSize: 12, marginTop: 2, maxWidth: 560 }}>
+                          {item.content.length > 120 ? `${item.content.slice(0, 120)}...` : item.content}
+                        </div>
+                      </td>
+                      <td>
+                        <span className={`badge ${item.published ? "badge-success" : "badge-warning"}`}>
+                          {publishedLabel(item.published)}
+                        </span>
+                      </td>
+                      <td>{formatDate(item.created_at)}</td>
+                      <td>
+                        <div className="cell-actions" style={{ justifyContent: "flex-end" }}>
+                          <button className="btn btn-secondary btn-sm" onClick={() => setEditor({ mode: "edit", item })}>
+                            编辑
+                          </button>
+                          <button className="btn btn-secondary btn-sm" onClick={() => void handleToggle(item)}>
+                            {item.published ? "下架" : "发布"}
+                          </button>
+                          <button className="btn btn-danger btn-sm" onClick={() => setDeleting(item)}>
+                            删除
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {editor ? (
+        <AnnouncementEditorModal
+          item={editor.mode === "edit" ? editor.item : null}
+          onClose={() => setEditor(null)}
+          onSave={(input) => void handleSave(input)}
+        />
+      ) : null}
+
+      {deleting ? (
+        <DeleteAnnouncementModal
+          item={deleting}
+          onCancel={() => setDeleting(null)}
+          onConfirm={() => void handleDelete(deleting)}
+        />
+      ) : null}
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AnnouncementSkeleton() {
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} style={{ height: 64, borderRadius: 8, background: "var(--color-muted)", opacity: 0.5 }} />
+      ))}
+    </div>
+  );
+}
+
+function AnnouncementEditorModal({
+  item,
+  onClose,
+  onSave
+}: {
+  item: AdminAnnouncement | null;
+  onClose: () => void;
+  onSave: (input: AnnouncementInput) => void;
+}) {
+  const [title, setTitle] = useState(item?.title ?? "");
+  const [content, setContent] = useState(item?.content ?? "");
+  const [kind, setKind] = useState<AnnouncementKind>(item?.kind ?? "notice");
+  const [published, setPublished] = useState(item?.published ?? true);
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    if (!title.trim() || !content.trim()) return;
+    setBusy(true);
+    onSave({ title, content, kind, published });
+    setBusy(false);
+  }
+
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">{item ? "编辑公告" : "发布公告"}</div>
+          <button className="modal-close" type="button" onClick={onClose} disabled={busy} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="modal-body">
+          <div className="form-group">
+            <label className="form-label">类型</label>
+            <select className="form-select form-input" value={kind} onChange={(e) => setKind(e.target.value as AnnouncementKind)}>
+              <option value="notice">公告</option>
+              <option value="update">版本更新</option>
+            </select>
+          </div>
+          <div className="form-group">
+            <label className="form-label">标题 <span className="required">*</span></label>
+            <input className="form-input" type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="输入公告标题" />
+          </div>
+          <div className="form-group">
+            <label className="form-label">内容 <span className="required">*</span></label>
+            <textarea className="form-input" rows={6} value={content} onChange={(e) => setContent(e.target.value)} placeholder="输入公告内容..." />
+          </div>
+          <label className="form-check">
+            <input type="checkbox" checked={published} onChange={(e) => setPublished(e.target.checked)} />
+            立即发布
+          </label>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" type="button" onClick={onClose} disabled={busy}>取消</button>
+          <button className="btn btn-primary" type="button" onClick={() => void submit()} disabled={busy || !title.trim() || !content.trim()}>
+            {item ? "保存" : "发布"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DeleteAnnouncementModal({
+  item,
+  onCancel,
+  onConfirm
+}: {
+  item: AdminAnnouncement;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">删除公告</div>
+          <button className="modal-close" type="button" onClick={onCancel} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="modal-body">
+          <p style={{ margin: 0 }}>确认删除“{item.title}”吗？删除后桌面端将不再显示。</p>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" type="button" onClick={onCancel}>取消</button>
+          <button className="btn btn-danger" type="button" onClick={onConfirm}>确认删除</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return new Intl.DateTimeFormat("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(d);
 }

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -952,6 +952,19 @@ input:focus, select:focus, textarea:focus {
   margin-left: 2px;
 }
 
+.form-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-foreground);
+  cursor: pointer;
+}
+
+.text-muted {
+  color: var(--color-muted-foreground);
+}
+
 .form-hint {
   font-size: 12px;
   color: #94A3B8;

--- a/apps/admin/src/components/sidebar.tsx
+++ b/apps/admin/src/components/sidebar.tsx
@@ -123,7 +123,6 @@ const NAV_SECTIONS: Array<{
       {
         href: "/announcements",
         label: "公告通知",
-        badge: "3",
         icon: (
           <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />

--- a/apps/admin/src/lib/api/announcements.ts
+++ b/apps/admin/src/lib/api/announcements.ts
@@ -1,0 +1,159 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+
+export type AnnouncementKind = "notice" | "update";
+export type AnnouncementKindFilter = "" | AnnouncementKind;
+
+export interface AdminAnnouncement {
+  id: string;
+  title: string;
+  content: string;
+  kind: AnnouncementKind;
+  target: "all" | "team";
+  team_id: string | null;
+  created_by: string | null;
+  published: boolean;
+  created_at: string;
+  updated_at: string | null;
+  deleted_at: string | null;
+}
+
+export interface AnnouncementInput {
+  title: string;
+  content: string;
+  kind: AnnouncementKind;
+  published: boolean;
+}
+
+export interface AnnouncementListParams {
+  search?: string;
+  kind?: AnnouncementKindFilter;
+}
+
+export async function listAnnouncements(params: AnnouncementListParams = {}): Promise<AdminAnnouncement[]> {
+  const supabase = createAdminBrowserClient();
+  let query = supabase
+    .from("announcements")
+    .select("*")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  const search = params.search?.trim();
+  if (search) {
+    query = query.ilike("title", `%${search}%`);
+  }
+  if (params.kind) {
+    query = query.eq("kind", params.kind);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as AdminAnnouncement[];
+}
+
+export async function createAnnouncement(input: AnnouncementInput): Promise<AdminAnnouncement> {
+  const supabase = createAdminBrowserClient();
+  const { data: authData } = await supabase.auth.getUser();
+  const now = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("announcements")
+    .insert({
+      title: input.title.trim(),
+      content: input.content.trim(),
+      kind: input.kind,
+      target: "all",
+      published: input.published,
+      created_by: authData.user?.id ?? null,
+      updated_at: now
+    })
+    .select("*")
+    .single();
+  if (error) throw error;
+
+  await insertAuditLog("announcement.create", data.id, {
+    title: data.title,
+    kind: data.kind,
+    published: data.published
+  });
+  return data as AdminAnnouncement;
+}
+
+export async function updateAnnouncement(id: string, input: AnnouncementInput): Promise<AdminAnnouncement> {
+  const supabase = createAdminBrowserClient();
+
+  const { data, error } = await supabase
+    .from("announcements")
+    .update({
+      title: input.title.trim(),
+      content: input.content.trim(),
+      kind: input.kind,
+      published: input.published,
+      updated_at: new Date().toISOString()
+    })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) throw error;
+
+  await insertAuditLog("announcement.update", id, {
+    title: data.title,
+    kind: data.kind,
+    published: data.published
+  });
+  return data as AdminAnnouncement;
+}
+
+export async function deleteAnnouncement(id: string, title: string): Promise<void> {
+  const supabase = createAdminBrowserClient();
+
+  const { error } = await supabase
+    .from("announcements")
+    .update({
+      deleted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    })
+    .eq("id", id);
+  if (error) throw error;
+
+  await insertAuditLog("announcement.delete", id, { title });
+}
+
+export async function toggleAnnouncementPublished(id: string, published: boolean, title: string): Promise<void> {
+  const supabase = createAdminBrowserClient();
+
+  const { error } = await supabase
+    .from("announcements")
+    .update({
+      published,
+      updated_at: new Date().toISOString()
+    })
+    .eq("id", id);
+  if (error) throw error;
+
+  await insertAuditLog(published ? "announcement.publish" : "announcement.unpublish", id, { title });
+}
+
+export function kindLabel(kind: AnnouncementKind): string {
+  return kind === "update" ? "版本更新" : "公告";
+}
+
+export function publishedLabel(published: boolean): string {
+  return published ? "已发布" : "草稿";
+}
+
+async function insertAuditLog(action: string, target: string, metadata: Record<string, unknown>): Promise<void> {
+  try {
+    const supabase = createAdminBrowserClient();
+    const { data: authData } = await supabase.auth.getUser();
+    if (!authData.user?.id) return;
+    await supabase.from("audit_logs").insert({
+      admin_user_id: authData.user.id,
+      action,
+      target,
+      metadata
+    });
+  } catch {
+    // 审计失败不阻断主操作，避免公告管理被日志写入影响。
+  }
+}

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -32,3 +32,8 @@ nsis:
   artifactName: ${productName} Setup ${version}.${ext}
 portable:
   artifactName: ${productName} Portable ${version}.${ext}
+publish:
+  provider: github
+  owner: Shaun520
+  repo: quota-flow
+  private: false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@quota-flow/auth": "workspace:^",
-    "@quota-flow/db-supabase": "workspace:^"
+    "@quota-flow/db-supabase": "workspace:^",
+    "electron-updater": "^6.6.2"
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,8 +6,10 @@ import type { AddressInfo } from 'node:net'
 import { initWebviewTest } from './webview-test'
 import { initProviders } from './providers'
 import { initCookieRenew } from './cookie-renew'
+import { checkForUpdatesNow, initAutoUpdater, quitAndInstall as quitAndInstallUpdater } from './updater'
 import { runGenerate } from './dispatch'
 import type { DispatchEvent } from './dispatch'
+import type { UpdaterStatus } from './updater'
 
 /** 活跃生成任务注册表：jobId → 取消/已提交状态（用于「终止生成」与「关闭确认」） */
 interface ActiveRunState {
@@ -31,6 +33,14 @@ app.disableHardwareAcceleration()
 //  - 根路径：userData/videos 下 <uuid>.mp4（视频，支持 Range）
 //  - /images/：userData/images 下 <jobId>-<n>.<ext>（图生视频上传的图片副本）
 let mediaPortPromise: Promise<number> | null = null
+
+function sendUpdaterStatus(status: UpdaterStatus): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) {
+      win.webContents.send('updater:status', status)
+    }
+  }
+}
 
 function startMediaServer(): Promise<number> {
   if (!mediaPortPromise) {
@@ -248,6 +258,10 @@ app.whenReady().then(() => {
     })
   })
   ipcMain.handle('auth:clear-session', () => clearStoredSession())
+  ipcMain.handle('updater:check', () => checkForUpdatesNow(sendUpdaterStatus))
+  ipcMain.handle('updater:quit-and-install', () => {
+    quitAndInstallUpdater()
+  })
   ipcMain.handle('dispatch:generate', async (e, input: Parameters<typeof runGenerate>[0]) => {
     const emit = (ev: DispatchEvent): void => {
       if (!e.sender.isDestroyed()) e.sender.send('job:event', ev)
@@ -363,6 +377,7 @@ app.whenReady().then(() => {
       return { ok: false, error: e instanceof Error ? e.message : String(e) }
     }
   })
+  initAutoUpdater(sendUpdaterStatus)
   initProviders()
   initCookieRenew()
   createWindow()

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,0 +1,85 @@
+import { app } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+export type UpdaterState =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'downloaded'
+  | 'not-available'
+  | 'error'
+
+export interface UpdaterStatus {
+  state: UpdaterState
+  version?: string
+  progress?: number
+  error?: string
+}
+
+let lastStatus: UpdaterStatus = { state: 'idle' }
+let initialized = false
+
+function setStatus(sendStatus: (status: UpdaterStatus) => void, status: UpdaterStatus): void {
+  lastStatus = status
+  sendStatus(status)
+}
+
+export function getUpdaterStatus(): UpdaterStatus {
+  return lastStatus
+}
+
+export function initAutoUpdater(sendStatus: (status: UpdaterStatus) => void): void {
+  if (initialized) return
+  initialized = true
+
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+
+  autoUpdater.on('checking-for-update', () => {
+    setStatus(sendStatus, { state: 'checking' })
+  })
+  autoUpdater.on('update-available', (info) => {
+    setStatus(sendStatus, { state: 'available', version: info.version })
+  })
+  autoUpdater.on('update-not-available', (info) => {
+    setStatus(sendStatus, { state: 'not-available', version: info.version })
+  })
+  autoUpdater.on('download-progress', (progress) => {
+    setStatus(sendStatus, { state: 'downloading', progress: progress.percent })
+  })
+  autoUpdater.on('update-downloaded', (info) => {
+    setStatus(sendStatus, { state: 'downloaded', version: info.version })
+  })
+  autoUpdater.on('error', (err) => {
+    setStatus(sendStatus, {
+      state: 'error',
+      error: err instanceof Error ? err.message : String(err)
+    })
+  })
+
+  if (app.isPackaged) {
+    setTimeout(() => {
+      void checkForUpdatesNow(sendStatus)
+    }, 3000)
+  }
+}
+
+export async function checkForUpdatesNow(sendStatus: (status: UpdaterStatus) => void): Promise<UpdaterStatus> {
+  setStatus(sendStatus, { state: 'checking' })
+  try {
+    await autoUpdater.checkForUpdates()
+    return getUpdaterStatus()
+  } catch (err) {
+    const status: UpdaterStatus = {
+      state: 'error',
+      error: err instanceof Error ? err.message : String(err)
+    }
+    setStatus(sendStatus, status)
+    return status
+  }
+}
+
+export function quitAndInstall(): void {
+  autoUpdater.quitAndInstall()
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -56,6 +56,13 @@ export interface JobEvent {
   data?: unknown
 }
 
+export interface UpdaterStatus {
+  state: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error'
+  version?: string
+  progress?: number
+  error?: string
+}
+
 export interface GenerateRequest {
   supabaseUrl: string
   supabaseAnonKey: string
@@ -114,6 +121,11 @@ export interface DesktopApi {
     configure: (config: CookieRenewConfig) => Promise<{ ok: boolean; error?: string }>
     setEnabled: (enabled: boolean) => Promise<{ ok: boolean; state: CookieRenewState }>
     getState: () => Promise<CookieRenewState>
+  }
+  updater: {
+    check: () => Promise<UpdaterStatus>
+    quitAndInstall: () => Promise<void>
+    onStatus: (callback: (status: UpdaterStatus) => void) => () => void
   }
   dispatch: {
     generate: (input: GenerateRequest) => Promise<{ ok: boolean; jobId?: string; error?: string }>
@@ -193,6 +205,18 @@ const api: DesktopApi = {
     configure: (config) => ipcRenderer.invoke('cookie-renew:configure', config) as Promise<{ ok: boolean; error?: string }>,
     setEnabled: (enabled) => ipcRenderer.invoke('cookie-renew:set-enabled', enabled) as Promise<{ ok: boolean; state: CookieRenewState }>,
     getState: () => ipcRenderer.invoke('cookie-renew:get-state') as Promise<CookieRenewState>
+  },
+  updater: {
+    check: () => ipcRenderer.invoke('updater:check') as Promise<UpdaterStatus>,
+    quitAndInstall: () => ipcRenderer.invoke('updater:quit-and-install') as Promise<void>,
+    onStatus: (callback) => {
+      const listener = (_e: Electron.IpcRendererEvent, status: UpdaterStatus): void =>
+        callback(status)
+      ipcRenderer.on('updater:status', listener)
+      return () => {
+        ipcRenderer.removeListener('updater:status', listener)
+      }
+    }
   },
   dispatch: {
     generate: (input) => ipcRenderer.invoke('dispatch:generate', input) as Promise<{ ok: boolean; jobId?: string; error?: string }>,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import History from './components/History'
 import Team from './components/Team'
 import TitleBar from './components/TitleBar'
 import WelcomeBanner from './components/WelcomeBanner'
+import { NotificationBell } from './components/NotificationBell'
 import { BrandMark } from './components/Brand'
 import AuthScreen from './auth/AuthScreen'
 import { useAuth } from './hooks/useAuth'
@@ -31,6 +32,13 @@ interface TabDef {
   id: TabId
   label: string
   icon: ComponentType<{ size?: number }>
+}
+
+interface UpdaterStatusView {
+  state: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error'
+  version?: string
+  progress?: number
+  error?: string
 }
 
 const TABS: TabDef[] = [
@@ -85,9 +93,15 @@ function MainApp({
     toastTimer.current = window.setTimeout(() => setToast(null), 2200)
   }, [])
 
+  const [updater, setUpdater] = useState<UpdaterStatusView>({ state: 'idle' })
+
   useEffect(() => {
     applyTheme(getInitialTheme())
     applyFontSize(getInitialFontSize())
+  }, [])
+
+  useEffect(() => {
+    return window.api.updater.onStatus(setUpdater)
   }, [])
 
   // Cookie 自动续命：配置主进程调度器（携带最新会话 token）+ 轮询状态更新状态栏
@@ -170,6 +184,7 @@ function MainApp({
             <IconUsers size={10} />
             {team ? '团队 · ' + team.id.slice(0, 8) : fresh ? '新用户 · 未绑定' : '个人模式'}
           </div>
+          <NotificationBell userId={user.id} />
           <div className="avatar-wrap">
             <div className="avatar">{user.displayName.slice(0, 1).toUpperCase()}</div>
             <div className="avatar-dropdown">
@@ -244,6 +259,29 @@ function MainApp({
           <div className="status-item">{renewText}</div>
         </div>
         <div className="status-right">
+          {updater.state === 'downloaded' ? (
+            <div className="status-item updater-item">
+              <span>新版本已下载</span>
+              <button className="updater-action" onClick={() => void window.api.updater.quitAndInstall()}>
+                重启安装
+              </button>
+            </div>
+          ) : updater.state === 'available' ? (
+            <div className="status-item updater-item">
+              <span>发现新版本 {updater.version}</span>
+              <button className="updater-action" onClick={() => void window.api.updater.check()}>
+                下载
+              </button>
+            </div>
+          ) : updater.state === 'downloading' ? (
+            <div className="status-item">下载更新 {Math.round(updater.progress ?? 0)}%</div>
+          ) : updater.state === 'checking' ? (
+            <div className="status-item">检查更新...</div>
+          ) : updater.state === 'error' ? (
+            <div className="status-item" title={updater.error ?? ''}>
+              更新检查失败
+            </div>
+          ) : null}
           <div className="status-item">Quota-Flow v0.9.0</div>
         </div>
       </footer>

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -81,7 +81,7 @@ interface ModalProps {
   footer: ReactNode
 }
 
-function Modal({ title, onClose, children, footer }: ModalProps) {
+export function Modal({ title, onClose, children, footer }: ModalProps) {
   return (
     <div
       className="modal-overlay"

--- a/apps/desktop/src/renderer/src/components/NotificationBell.tsx
+++ b/apps/desktop/src/renderer/src/components/NotificationBell.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { IconBell, IconRefresh } from './icons'
+import { Modal } from './Modals'
+import { useAnnouncements } from '../hooks/useAnnouncements'
+import type { DesktopAnnouncement } from '../hooks/useAnnouncements'
+
+function readStorageKey(userId: string): string {
+  return `qf:announcements:read:${userId}`
+}
+
+function loadReadIds(userId: string): string[] {
+  try {
+    const raw = localStorage.getItem(readStorageKey(userId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function saveReadIds(userId: string, ids: string[]): void {
+  try {
+    localStorage.setItem(readStorageKey(userId), JSON.stringify(ids))
+  } catch {
+    // ignore
+  }
+}
+
+function noticeKindLabel(kind: DesktopAnnouncement['kind']): string {
+  return kind === 'update' ? '版本更新' : '公告'
+}
+
+function noticeTime(value: string): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return value
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(d)
+}
+
+export function NotificationBell({ userId }: { userId: string }) {
+  const { items, loading, error, reload } = useAnnouncements(userId)
+  const [open, setOpen] = useState(false)
+  const [detail, setDetail] = useState<DesktopAnnouncement | null>(null)
+  const [readIds, setReadIds] = useState<string[]>(() => loadReadIds(userId))
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    setReadIds(loadReadIds(userId))
+  }, [userId])
+
+  useEffect(() => {
+    if (!open) return
+    reload()
+    const onDocClick = (e: MouseEvent): void => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, reload])
+
+  const unread = useMemo(() => {
+    const read = new Set(readIds)
+    return items.filter((item) => !read.has(item.id)).length
+  }, [items, readIds])
+
+  const markRead = (item: DesktopAnnouncement): void => {
+    setReadIds((prev) => {
+      if (prev.includes(item.id)) return prev
+      const next = [...prev, item.id]
+      saveReadIds(userId, next)
+      return next
+    })
+    setDetail(item)
+  }
+
+  return (
+    <div className="notification-wrap" ref={rootRef}>
+      <button
+        className={'notification-button' + (open ? ' active' : '')}
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v
+            if (next) reload()
+            return next
+          })
+        }}
+        aria-label="通知"
+        aria-expanded={open}
+      >
+        <IconBell size={16} />
+        {unread > 0 ? <span className="notification-badge">{unread > 99 ? '99+' : unread}</span> : null}
+      </button>
+
+      {open ? (
+        <div className="notification-dropdown">
+          <div className="notification-dropdown-header">
+            <span>通知</span>
+            <button className="notification-refresh" onClick={() => reload()} aria-label="刷新通知">
+              <IconRefresh size={13} />
+            </button>
+          </div>
+          {loading ? (
+            <div className="notification-empty">加载中...</div>
+          ) : error ? (
+            <div className="notification-empty">{error}</div>
+          ) : items.length === 0 ? (
+            <div className="notification-empty">暂无通知</div>
+          ) : (
+            <div className="notification-list">
+              {items.map((item) => (
+                <button
+                  key={item.id}
+                  className={'notification-item' + (readIds.includes(item.id) ? ' read' : '')}
+                  onClick={() => markRead(item)}
+                >
+                  <div className="notification-item-main">
+                    <span className={'notification-kind ' + (item.kind === 'update' ? 'update' : 'notice')}>
+                      {noticeKindLabel(item.kind)}
+                    </span>
+                    <strong>{item.title}</strong>
+                  </div>
+                  <div className="notification-item-meta">
+                    <span className="notification-time">{noticeTime(item.created_at)}</span>
+                    {!readIds.includes(item.id) ? <span className="notification-item-dot" aria-hidden="true" /> : null}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {detail ? (
+        <Modal
+          title={detail.kind === 'update' ? '版本更新说明' : '通知详情'}
+          onClose={() => setDetail(null)}
+          footer={
+            <button className="btn-sm" onClick={() => setDetail(null)}>
+              关闭
+            </button>
+          }
+        >
+          <div className="notification-detail">
+            <div className="notification-detail-meta">
+              <span className={'notification-kind ' + (detail.kind === 'update' ? 'update' : 'notice')}>
+                {noticeKindLabel(detail.kind)}
+              </span>
+              <span>{noticeTime(detail.created_at)}</span>
+            </div>
+            <h3>{detail.title}</h3>
+            <div className="notification-detail-content">{detail.content}</div>
+          </div>
+        </Modal>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/icons.tsx
@@ -149,6 +149,13 @@ export const IconLogout = (p: IconProps) => (
   </Svg>
 )
 
+export const IconBell = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+  </Svg>
+)
+
 // 厂商图标（官方品牌 logo，来源：LobeHub @lobehub/icons-static-svg v1.94.0，https://lobehub.com/icons）
 export const IconDoubao = (p: IconProps) => (
   <svg width={p.size ?? 16} height={p.size ?? 16} viewBox="0 0 24 24" aria-hidden="true">

--- a/apps/desktop/src/renderer/src/hooks/useAnnouncements.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAnnouncements.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getAuthService } from '../auth/service'
+import { ensureFreshSession } from '../auth/session'
+import { errMsg } from '../utils/error'
+
+export type DesktopAnnouncementKind = 'notice' | 'update'
+
+export interface DesktopAnnouncement {
+  id: string
+  title: string
+  content: string
+  kind: DesktopAnnouncementKind
+  target: 'all' | 'team'
+  published: boolean
+  created_at: string
+  updated_at: string | null
+  deleted_at: string | null
+}
+
+export interface AnnouncementsResult {
+  loading: boolean
+  error: string | null
+  items: DesktopAnnouncement[]
+  reload: () => void
+}
+
+export function useAnnouncements(userId?: string): AnnouncementsResult {
+  const [items, setItems] = useState<DesktopAnnouncement[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => {
+    setReloadKey((k) => k + 1)
+  }, [])
+
+  const load = useCallback(async () => {
+    if (!userId) {
+      setItems([])
+      return
+    }
+    const auth = getAuthService()
+    if (!auth) {
+      setError('通知服务未配置')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const guard = await ensureFreshSession()
+      if (!guard.ok) {
+        setError('登录已过期，请重新登录')
+        return
+      }
+      const { data, error: queryError } = await auth
+        .getClient()
+        .from('announcements')
+        .select('id,title,content,kind,target,published,created_at,updated_at,deleted_at')
+        .eq('target', 'all')
+        .eq('published', true)
+        .is('deleted_at', null)
+        .order('created_at', { ascending: false })
+        .limit(50)
+      if (queryError) throw queryError
+      setItems((data ?? []) as DesktopAnnouncement[])
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    void load()
+  }, [load, reloadKey])
+
+  useEffect(() => {
+    if (!userId) return
+    const auth = getAuthService()
+    if (!auth) return
+    const client = auth.getClient()
+    const channel = client
+      .channel(`announcements-changes-${userId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'announcements' },
+        () => {
+          void load()
+        }
+      )
+      .subscribe()
+
+    return () => {
+      void client.removeChannel(channel)
+    }
+  }, [userId, load])
+
+  return { loading, error, items, reload }
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -474,6 +474,200 @@ body {
   margin: 4px 0;
 }
 
+/* ===== 通知铃铛 ===== */
+.notification-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  z-index: 60;
+}
+.notification-button {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-base);
+  color: var(--fg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.notification-button:hover,
+.notification-button.active {
+  border-color: var(--accent);
+  color: var(--fg-primary);
+}
+.notification-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border-radius: 999px;
+  background: var(--error, #e5484d);
+  color: #fff;
+  font-size: 0.68em;
+  font-weight: 700;
+  line-height: 15px;
+  text-align: center;
+}
+.notification-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 330px;
+  max-width: 78vw;
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  padding: 4px;
+  z-index: 120;
+  overflow: hidden;
+}
+.notification-dropdown::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  right: 8px;
+  width: 10px;
+  height: 10px;
+  background: var(--bg-card);
+  border-left: 1px solid var(--border-light);
+  border-top: 1px solid var(--border-light);
+  transform: rotate(45deg);
+}
+.notification-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px 6px;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--fg-primary);
+}
+.notification-refresh {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.notification-refresh:hover {
+  background: var(--bg-hover);
+  color: var(--fg-primary);
+}
+.notification-list {
+  max-height: 320px;
+  overflow-y: auto;
+  display: grid;
+}
+.notification-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-bottom: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--fg-primary);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+}
+.notification-item:last-child {
+  border-bottom: none;
+}
+.notification-item:hover {
+  background: var(--bg-hover);
+}
+.notification-item.read {
+  opacity: 0.62;
+}
+.notification-item-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--error, #e5484d);
+  flex-shrink: 0;
+  margin-top: 0;
+}
+.notification-item-main {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
+}
+.notification-item-main strong {
+  max-width: 220px;
+  font-size: 0.95em;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.notification-kind {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 0.72em;
+  line-height: 1.5;
+  background: var(--bg-hover);
+  color: var(--fg-secondary);
+}
+.notification-kind.update {
+  background: rgba(99, 54, 231, 0.16);
+  color: #a78bfa;
+}
+.notification-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+.notification-time {
+  font-size: 0.72em;
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+.notification-empty {
+  padding: 18px 12px;
+  font-size: 0.9em;
+  color: var(--fg-muted);
+  text-align: center;
+}
+.notification-detail h3 {
+  margin: 10px 0;
+  font-size: 1.15em;
+  color: var(--fg-primary);
+}
+.notification-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-muted);
+  font-size: 0.85em;
+}
+.notification-detail-content {
+  color: var(--fg-secondary);
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
 /* ===== 主体内容区（一屏显示） ===== */
 .main-content {
   flex: 1;
@@ -1861,6 +2055,23 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+.status-bar .updater-item {
+  gap: 6px;
+}
+.status-bar .updater-action {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  border-radius: var(--radius-sm);
+  padding: 1px 8px;
+  font-size: 0.82em;
+  line-height: 1.7;
+  cursor: pointer;
+}
+.status-bar .updater-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 /* ===== 弹窗 ===== */

--- a/docs/develop/admin-notifications-app-update.md
+++ b/docs/develop/admin-notifications-app-update.md
@@ -1,0 +1,59 @@
+# 公共通知模块 + App 更新方案
+
+> 更新时间：2026-08-13
+
+## Summary
+
+- 后台公告页从静态原型改为真实管理页：发布、编辑、下架/恢复、删除（软删除），并写 `audit_logs`。
+- 桌面端右上角用户区新增铃铛：点开显示通知下拉，点击条目打开详情弹窗；未读角标用本地存储记录。
+- App 更新不在公告里做安装逻辑；公告只作为“版本更新说明”。实际更新走 `electron-updater` + GitHub Releases，桌面端启动/手动检查并下载安装。
+
+## 数据/接口变化
+
+- 新增迁移 `migrations/0011_announcements_notifications.sql`，扩展现有 `announcements`：
+  - `kind text not null default 'notice' check (kind in ('notice','update'))`
+  - `published boolean not null default true`
+  - `created_by uuid null references profiles(id)`
+  - `updated_at timestamptz default now()`
+  - `deleted_at timestamptz null`
+- 调整 RLS：`announcements_select_all` 改为只允许 authenticated 读取 `published = true and deleted_at is null`；admin 保留全量管理。
+- Admin 新增 `apps/admin/src/lib/api/announcements.ts`：`listAnnouncements`、`createAnnouncement`、`updateAnnouncement`、`deleteAnnouncement`、`togglePublished`；操作成功后写 `audit_logs`。
+- 桌面端新增 `useAnnouncements` hook 和 `NotificationBell` 组件，读取 `announcements` 的 `target = 'all'` 已发布未删除记录。
+
+## Admin 公告页
+
+- 替换 `apps/admin/src/app/(dashboard)/announcements/page.tsx` 静态 `PrototypePage`。
+- 页面先渲染列表骨架/空态，再异步拉数据；支持搜索标题和按类型筛选（全部/公告/版本更新）。
+- 列表项显示：类型徽标、标题、发布时间、发布状态、内容摘要；操作按钮为编辑、发布/下架、删除。
+- 发布/编辑弹窗字段：类型、标题、内容、是否立即发布；MVP 只发送给全部用户，不展示团队选择。
+- 删除使用软删除，列表不显示已删除记录；后台记录 `announcement.delete` 等审计事件。
+
+## 桌面端铃铛与详情
+
+- 在 `apps/desktop/src/renderer/src/App.tsx` 的 `.user-area` 中，`team-badge` 和 `avatar-wrap` 之间插入铃铛按钮；点击展开通知下拉，而不是 hover。
+- 下拉展示最新 50 条通知，最多显示标题、时间、类型；未读数量显示角标；点击条目打开详情 Modal 并标记该条已读。
+- 已读状态按用户保存在 `localStorage`，key 使用 `qf:announcements:read:<userId>`；换设备不共享，符合当前 MVP。
+- 拉取时机：登录/应用进入后拉一次，打开铃铛时重新拉一次；同时订阅 Supabase Realtime，新发布/下架/删除后即时刷新。
+
+## App 更新
+
+- `apps/desktop/package.json` 增加 `electron-updater`。
+- `electron-builder.yml` 增加 `publish` GitHub Releases 配置：owner `Shaun520`，repo `quota-flow`，private `false`。
+- 主进程接入 `autoUpdater`：启动后静默检查、下载；通过 IPC 向渲染进程推送状态（检查中/无更新/可下载/已下载）。
+- 渲染进程暴露更新状态：状态栏或设置中显示“发现新版本”，下载完成后提供“重启安装”；不把安装逻辑放进公告。
+- 公告类型 `kind='update'` 仅用于展示版本说明，实际版本安装由 `electron-updater` 处理。
+
+## Test Plan
+
+- 执行迁移后，admin 发布一条公告：桌面端在线时铃铛即时出现；下架/删除后即时消失。
+- 创建 `kind=update` 的版本公告，桌面端铃铛显示版本更新类型；同时验证 `electron-updater` 能按配置检查到 GitHub Releases 更新。
+- Admin 跑 `pnpm --filter @quota-flow/admin typecheck`；桌面端跑 `pnpm --filter @quota-flow/desktop typecheck`。
+- 验证未读角标：点击详情后该条不再计入未读；重新登录同一用户本地已读仍保留。
+- 验证删除/编辑/发布切换均写入 `audit_logs`，且 RLS 不会让普通用户读到草稿或已删除公告。
+
+## Assumptions
+
+- MVP 桌面端只显示 `target = 'all'` 通知，后台也只发布全部用户通知；团队通知后续再做。
+- 已读状态采用本地存储，不新增 `announcement_reads` 表。
+- 删除采用软删除，避免普通用户读到已删除内容，也便于审计。
+- 自动更新使用 GitHub Releases；当前仓库远程为公开仓库 `Shaun520/quota-flow`。

--- a/migrations/0011_announcements_notifications.sql
+++ b/migrations/0011_announcements_notifications.sql
@@ -1,0 +1,64 @@
+-- ============ 1. announcements 扩展：通知类型 / 发布状态 / 软删除 ============
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'notice'
+    CHECK (kind IN ('notice', 'update'));
+
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS published BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS created_by UUID NULL REFERENCES profiles(id);
+
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ NULL;
+
+-- 已有数据全部视为已发布公告
+UPDATE announcements
+SET published = true
+WHERE published IS NULL OR published = false;
+
+-- ============ 2. RLS：普通用户只读已发布且未删除的公告 ============
+DROP POLICY IF EXISTS "announcements_select_all" ON announcements;
+CREATE POLICY "announcements_select_all" ON announcements
+  FOR SELECT
+  USING (
+    auth.role() = 'authenticated'
+    AND published = true
+    AND deleted_at IS NULL
+  );
+
+-- admin 仍可全量管理，包括草稿、已删除和版本更新公告
+DROP POLICY IF EXISTS "announcements_admin_all" ON announcements;
+CREATE POLICY "announcements_admin_all" ON announcements
+  FOR ALL
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- 索引：桌面端铃铛默认按时间倒序拉取已发布通知
+CREATE INDEX IF NOT EXISTS idx_announcements_public
+  ON announcements (published, deleted_at, created_at DESC);
+
+COMMENT ON TABLE announcements IS '后台公告通知，kind=notice 普通公告，kind=update 版本更新说明';
+
+-- ============ 3. Realtime：桌面端铃铛需要即时看到新发布/下架/删除 ============
+ALTER TABLE announcements REPLICA IDENTITY FULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'supabase_realtime'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'announcements'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.announcements;
+  END IF;
+END $$;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@quota-flow/db-supabase':
         specifier: workspace:^
         version: link:../../packages/db-supabase
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.8.9
     devDependencies:
       '@types/node':
         specifier: ^20.14.0
@@ -1681,6 +1684,9 @@ packages:
   electron-to-chromium@1.5.402:
     resolution: {integrity: sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2076,6 +2082,13 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -2594,6 +2607,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -4018,6 +4034,19 @@ snapshots:
 
   electron-to-chromium@1.5.402: {}
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@5.0.0(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.11)):
     dependencies:
       '@babel/core': 7.29.7
@@ -4285,7 +4314,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -4477,6 +4506,10 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash@4.18.1: {}
 
   lowercase-keys@2.0.0: {}
@@ -4586,11 +4619,11 @@ snapshots:
 
   node-abi@4.33.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-gyp@12.4.0:
     dependencies:
@@ -4599,7 +4632,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 6.28.0
@@ -5012,6 +5045,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinyexec@0.3.2: {}
 


### PR DESCRIPTION
Closes #7

## 提交信息
feat: 公告通知与桌面端应用自动更新

- admin: 公告管理页（列表/发布/停用/删除），公告类型支持系统/维护/功能/紧急
- desktop: 通知铃铛 + 公告弹窗，按公告类型展示、未读红点、标记已读
- desktop: 应用自动更新（electron-updater，下载进度/安装提示），升级通道配置
- db: 0011_announcements_notifications.sql（announcements + user_notifications 表及 RLS）
- docs: admin-notifications-app-update.md 设计文档