### PR TITLE
feat: 智能调度时长能力（厂商时长分级 + 调度按能力匹配）

### DIFF
--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -6,6 +6,7 @@ import { copyFileSync, createWriteStream, mkdirSync, renameSync } from 'node:fs'
 import { get as httpsGet } from 'node:https'
 import { join } from 'node:path'
 import { createSupabaseClient, JobService, ProviderService, todayKey } from '@quota-flow/db-supabase'
+import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
 import { runDoubaoGeneration } from './webview-engine'
 import type { ProviderCookie, OriginStorage } from './webview-engine'
 
@@ -71,8 +72,28 @@ export interface DispatchEvent {
   data?: unknown
 }
 
+export interface QuotaUpdatedPayload {
+  userId: string
+  ledger: QuotaLedgerRow
+}
+
 const UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
+
+const DEFAULT_SUPPORTED_DURATIONS = [5, 10]
+
+function resolveDispatchProvider(providerId: string): string {
+  return providerId === 'auto' ? 'doubao' : providerId
+}
+
+function parseSupportedDurations(meta: { capabilities?: Record<string, unknown> | null } | undefined): number[] {
+  const raw = meta?.capabilities?.supported_durations
+  if (!Array.isArray(raw)) return [...DEFAULT_SUPPORTED_DURATIONS]
+  const durations = raw
+    .map((n) => Number(n))
+    .filter((n) => Number.isFinite(n) && n > 0)
+  return durations.length > 0 ? durations : [...DEFAULT_SUPPORTED_DURATIONS]
+}
 
 function doubaoCost(durationSec: number): number {
   if (durationSec <= 5) return 1
@@ -149,7 +170,8 @@ function downloadVideo(url: string, jobId: string, redirects = 0): Promise<strin
 export async function runGenerate(
   input: GenerateInput,
   emit: (event: DispatchEvent) => void,
-  onJobCreated?: (jobId: string, state: { aborted: boolean; submitted: boolean }) => void
+  onJobCreated?: (jobId: string, state: { aborted: boolean; submitted: boolean }) => void,
+  onQuotaUpdated?: (payload: QuotaUpdatedPayload) => void
 ): Promise<{ ok: boolean; jobId?: string; error?: string }> {
   if (!input.supabaseUrl || !input.supabaseAnonKey) {
     return { ok: false, error: 'Supabase 未配置' }
@@ -166,6 +188,18 @@ export async function runGenerate(
   }
   const jobSvc = new JobService(client)
   const providerSvc = new ProviderService(client)
+
+  const resolvedProviderId = resolveDispatchProvider(input.providerId)
+  try {
+    const providers = await providerSvc.listAllProviders()
+    const meta = providers.find((p) => p.id === resolvedProviderId)
+    const supportedDurations = parseSupportedDurations(meta)
+    if (!supportedDurations.includes(input.durationSec)) {
+      return { ok: false, error: `当前厂商不支持 ${input.durationSec} 秒` }
+    }
+  } catch (e) {
+    return { ok: false, error: '校验厂商时长失败: ' + (e instanceof Error ? e.message : String(e)) }
+  }
   // 取消/已提交状态：由主进程注册表持有引用，IPC 侧可标记 aborted，引擎提交后置 submitted
   const runCancelState: { aborted: boolean; submitted: boolean } = { aborted: false, submitted: false }
 
@@ -421,6 +455,7 @@ export async function runGenerate(
     if (selectedKey?.id && consumed) {
       await providerSvc.insertQuotaOperation(job.id, consumed.id, 'finalize', cost)
     }
+    onQuotaUpdated?.({ userId: input.userId, ledger: consumed })
   } catch (e) {
     const errMsg = '额度扣减失败: ' + (e instanceof Error ? e.message : String(e))
     await jobSvc.updateJob(input.userId, job.id, {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,7 +13,7 @@ import {
   quitAndInstall as quitAndInstallUpdater
 } from './updater'
 import { runGenerate } from './dispatch'
-import type { DispatchEvent } from './dispatch'
+import type { DispatchEvent, QuotaUpdatedPayload } from './dispatch'
 import type { UpdaterStatus } from './updater'
 
 /** 活跃生成任务注册表：jobId → 取消/已提交状态（用于「终止生成」与「关闭确认」） */
@@ -43,6 +43,14 @@ function sendUpdaterStatus(status: UpdaterStatus): void {
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.webContents.isDestroyed()) {
       win.webContents.send('updater:status', status)
+    }
+  }
+}
+
+function sendQuotaUpdated(payload: QuotaUpdatedPayload): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) {
+      win.webContents.send('quota:updated', payload)
     }
   }
 }
@@ -272,6 +280,9 @@ app.whenReady().then(() => {
     const emit = (ev: DispatchEvent): void => {
       if (!e.sender.isDestroyed()) e.sender.send('job:event', ev)
     }
+    const onQuotaUpdated = (payload: QuotaUpdatedPayload): void => {
+      sendQuotaUpdated(payload)
+    }
     let registeredJobId: string | null = null
     isGenerating = true
     pendingCancel = false
@@ -282,7 +293,7 @@ app.whenReady().then(() => {
         // 准备窗口用户已点停止 → 任务一注册立即标记取消
         if (pendingCancel) state.aborted = true
         pendingCancel = false
-      })
+      }, onQuotaUpdated)
     } catch (err) {
       // 主进程抛出任意值（如 Supabase PostgrestError 对象）时规范化为可读信息，
       // 避免 Electron 序列化成 [object Object] 导致 UI 看不到真实原因

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
+import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
 
 export type ProviderId = 'yuanbao' | 'qwenwan'
 
@@ -54,6 +55,11 @@ export interface JobEvent {
   stage?: string
   message?: string
   data?: unknown
+}
+
+export interface QuotaUpdatedPayload {
+  userId: string
+  ledger: QuotaLedgerRow
 }
 
 export interface UpdaterStatus {
@@ -133,6 +139,7 @@ export interface DesktopApi {
     reconcile: (params: { supabaseUrl: string; supabaseAnonKey: string; accessToken: string; refreshToken: string; userId: string }) => Promise<{ ok: boolean; recovered?: boolean; error?: string }>
     cancel: (jobId?: string) => Promise<{ ok: boolean; reason?: string; submitted?: boolean }>
     onEvent: (callback: (event: JobEvent) => void) => () => void
+    onQuotaUpdated: (callback: (payload: QuotaUpdatedPayload) => void) => () => void
   }
   files: {
     getPath: (file: File) => string
@@ -229,6 +236,13 @@ const api: DesktopApi = {
       ipcRenderer.on('job:event', listener)
       return () => {
         ipcRenderer.removeListener('job:event', listener)
+      }
+    },
+    onQuotaUpdated: (callback) => {
+      const listener = (_e: Electron.IpcRendererEvent, payload: QuotaUpdatedPayload): void => callback(payload)
+      ipcRenderer.on('quota:updated', listener)
+      return () => {
+        ipcRenderer.removeListener('quota:updated', listener)
       }
     }
   },

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
 import {
+  DEFAULT_SUPPORTED_DURATIONS,
   MODELS,
   computeCost,
   durationOptions,
+  intersectDurations,
   resolutionOptions,
   uploadHint
 } from '../spec'
@@ -91,9 +93,22 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
   const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const durations = durationOptions(provider, model, mode, VIP)
+  const activeBoundAggs = useMemo(
+    () => provAggs.filter((a) => a.enabled && a.boundCount > 0),
+    [provAggs]
+  )
+  const providerDurations = useMemo(() => {
+    return new Map(provAggs.map((a) => [a.providerId, a.durations]))
+  }, [provAggs])
+  const selectedDurations = useMemo(() => {
+    if (provider === 'auto') {
+      return intersectDurations(activeBoundAggs.map((a) => a.durations))
+    }
+    return providerDurations.get(provider) ?? DEFAULT_SUPPORTED_DURATIONS
+  }, [provider, activeBoundAggs, providerDurations])
+  const durations = durationOptions(provider, model, mode, VIP, selectedDurations)
   const resolutions = resolutionOptions(provider)
-  const cost = computeCost(provider, model, duration, resolution)
+  const cost = computeCost(provider === 'auto' ? 'doubao' : provider, model, duration, resolution)
   const upload = uploadHint(provider, mode)
 
   // 调度台状态面板不展示后台已停用的厂商，避免出现置灰/停用态干扰调度信息。
@@ -101,12 +116,12 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
 
   // 厂商选项只取「已启用且已绑定」的厂商；智能调度仅在至少绑定一家时提供
   const providerOptions = useMemo(() => {
-    const bound = provAggs
-      .filter((a) => a.enabled && a.boundCount > 0)
-      .map((a) => ({ value: a.providerId, label: a.name }))
-    if (bound.length === 0) return []
-    return [{ value: 'auto', label: '智能调度（推荐）' }, ...bound]
-  }, [provAggs])
+    if (activeBoundAggs.length === 0) return []
+    return [
+      { value: 'auto', label: '智能调度（推荐）' },
+      ...activeBoundAggs.map((a) => ({ value: a.providerId, label: a.name }))
+    ]
+  }, [activeBoundAggs])
 
   // 当前选择不在可用列表时（例如厂商被解绑），回退到智能调度或第一个可用厂商
   useEffect(() => {
@@ -249,6 +264,10 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
       setGenError('图生视频需要先上传图片')
       return
     }
+    if (!durations.some((d) => d.value === duration)) {
+      setGenError('当前厂商不支持该时长')
+      return
+    }
     if (providerOptions.length === 0) {
       setGenError('尚未绑定厂商账号，请先到厂商页绑定后再生成')
       onGoProviders()
@@ -292,7 +311,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
         resolution,
         audio,
         ratio,
-        images: imageFiles.map((f) => window.api.files.getPath(f)).filter(Boolean),
+        images: mode === 't2v' ? [] : imageFiles.map((f) => window.api.files.getPath(f)).filter(Boolean),
         showWebview: getInitialShowWebview()
       })
       activeJobIdRef.current = res.jobId ?? null
@@ -312,7 +331,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, duration, resolution, audio, ratio, imageFiles, user, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, duration, durations, resolution, audio, ratio, imageFiles, user, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -348,6 +367,14 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
   const onProviderChange = (value: string): void => {
     setProvider(value)
     setModel(MODELS[value]?.[0] ?? MODELS.auto[0])
+  }
+
+  const onModeChange = (value: string): void => {
+    setMode(value)
+    if (value === 't2v') {
+      setImages([])
+      setImageFiles([])
+    }
   }
 
   const onPickFiles = useCallback(() => {
@@ -424,7 +451,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
               <Select
                 id="mode"
                 value={mode}
-                onChange={setMode}
+                onChange={onModeChange}
                 options={[
                   { value: 't2v', label: '文生视频' },
                   { value: 'img', label: '图生视频' },
@@ -485,46 +512,48 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
             </div>
           </div>
 
-          <div
-            className={'upload-zone' + (images.length > 0 ? ' has-images' : '')}
-            onClick={onPickFiles}
-          >
-            {images.length > 0 ? (
-              <div className="thumb-strip">
-                {images.map((src, idx) => (
-                  <div
-                    className="thumb-item"
-                    key={idx}
-                    title="点击预览图片"
-                    style={{ cursor: 'pointer' }}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setImagePreview(src)
-                    }}
-                  >
-                    <img src={src} alt="" />
-                    <button className="remove-thumb" onClick={(e) => { e.stopPropagation(); onRemoveImage(idx) }}>×</button>
-                  </div>
-                ))}
-                {images.length < 4 && (
-                  <div className="thumb-add">+</div>
-                )}
-              </div>
-            ) : (
-              <>
-                <IconUpload size={16} />
-                <span className="upload-text">{upload}</span>
-              </>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: 'none' }}
-              onChange={onFilesSelected}
-            />
-          </div>
+          {mode !== 't2v' && (
+            <div
+              className={'upload-zone' + (images.length > 0 ? ' has-images' : '')}
+              onClick={onPickFiles}
+            >
+              {images.length > 0 ? (
+                <div className="thumb-strip">
+                  {images.map((src, idx) => (
+                    <div
+                      className="thumb-item"
+                      key={idx}
+                      title="点击预览图片"
+                      style={{ cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setImagePreview(src)
+                      }}
+                    >
+                      <img src={src} alt="" />
+                      <button className="remove-thumb" onClick={(e) => { e.stopPropagation(); onRemoveImage(idx) }}>×</button>
+                    </div>
+                  ))}
+                  {images.length < 4 && (
+                    <div className="thumb-add">+</div>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <IconUpload size={16} />
+                  <span className="upload-text">{upload}</span>
+                </>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                style={{ display: 'none' }}
+                onChange={onFilesSelected}
+              />
+            </div>
+          )}
 
           <div className="generate-actions">
             {genError && (
@@ -682,7 +711,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
             />
           ) : (
             <div className="job-list">
-              {jobItems.slice(0, 6).map((j) => {
+              {jobItems.slice(0, 10).map((j) => {
                 const r = j.record
                 const badgeCls = r.status === '成功' ? 'success' : r.status === '失败' ? 'error' : 'pending'
                 return (

--- a/apps/desktop/src/renderer/src/components/History.tsx
+++ b/apps/desktop/src/renderer/src/components/History.tsx
@@ -148,7 +148,10 @@ export default function History({ jobs }: { jobs: JobsResult }) {
     if (confirm.kind === 'one') {
       setDeletingId(confirm.item.id)
       try {
-        await remove(confirm.item.id)
+        const ok = await remove(confirm.item.id)
+        if (!ok) {
+          setNotice('删除失败：只能删除当前账号下的历史记录，请确认这条记录归属后重试。')
+        }
       } finally {
         setDeletingId(null)
       }
@@ -156,7 +159,14 @@ export default function History({ jobs }: { jobs: JobsResult }) {
       setBatchDeleting(true)
       try {
         const n = await removeMany(confirm.ids)
-        if (n > 0) clearSelection()
+        if (n === confirm.ids.length) {
+          clearSelection()
+        } else if (n > 0) {
+          clearSelection()
+          setNotice(`已删除 ${n} 条，剩余 ${confirm.ids.length - n} 条不是当前账号记录，未删除。`)
+        } else {
+          setNotice('删除失败：只能删除当前账号下的历史记录，请确认这些记录归属后重试。')
+        }
       } finally {
         setBatchDeleting(false)
       }

--- a/apps/desktop/src/renderer/src/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TitleBar.tsx
@@ -10,7 +10,7 @@ export default function TitleBar() {
 
   return (
     <div className="title-bar">
-      <div className="title-bar-text">Quota-Flow · Unified LLM Router</div>
+      <div className="title-bar-text">Quota-Flow · Video Generation Router</div>
       <div className="window-controls">
         <button
           title="最小化"

--- a/apps/desktop/src/renderer/src/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/src/hooks/useJobs.ts
@@ -114,7 +114,7 @@ export function useJobs(): JobsResult {
     if (!loadedRef.current) setLoading(true)
     setError(null)
     svc
-      .listJobs()
+      .listJobs(user.id)
       .then((rows) => {
         if (!cancelled) {
           loadedRef.current = true

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -4,6 +4,7 @@ import { ensureFreshSession, isAuthError } from '../auth/session'
 import { useAuth } from './useAuth'
 import { errMsg } from '../utils/error'
 import { getHealthCheckIntervalMs } from '../components/Modals'
+import { DEFAULT_SUPPORTED_DURATIONS } from '../spec'
 import type {
   ProviderKey,
   ProviderMeta,
@@ -33,6 +34,7 @@ export interface ProviderAgg {
   enabled: boolean
   unitName: string
   defaultDailyQuota: number
+  durations: number[]
   boundCount: number
   enabledCount: number
   health: 'online' | 'degraded' | 'offline' | 'unbound'
@@ -56,6 +58,15 @@ function todayShanghai(): string {
   }).formatToParts(new Date())
   const get = (t: string): string => parts.find((p) => p.type === t)?.value ?? ''
   return `${get('year')}-${get('month')}-${get('day')}`
+}
+
+function supportedDurations(meta: ProviderMeta): number[] {
+  const raw = meta.capabilities?.supported_durations
+  if (!Array.isArray(raw)) return [...DEFAULT_SUPPORTED_DURATIONS]
+  const durations = raw
+    .map((n) => Number(n))
+    .filter((n) => Number.isFinite(n) && n > 0)
+  return durations.length > 0 ? durations : [...DEFAULT_SUPPORTED_DURATIONS]
 }
 
 function bindHealth(bindings: BindingView[]): ProviderAgg['health'] {
@@ -274,6 +285,23 @@ export function useProviders(): ProvidersResult {
     }
   }, [user?.id])
 
+  useEffect(() => {
+    if (!user) return
+    return window.api.dispatch.onQuotaUpdated((payload) => {
+      if (payload.userId !== user.id) return
+      const ledger = payload.ledger
+      setLedgers((prev) => {
+        const idx = prev.findIndex((l) => l.id === ledger.id)
+        if (idx >= 0) {
+          const next = [...prev]
+          next[idx] = ledger
+          return next
+        }
+        return [ledger, ...prev]
+      })
+    })
+  }, [user?.id])
+
   // 健康检查：与数据加载解耦，keys 就绪后独立运行（节流 + 并发限制，见 runHealthChecks）
   useEffect(() => {
     if (!user || keys.length === 0) return
@@ -326,6 +354,7 @@ export function useProviders(): ProvidersResult {
         enabled: p.enabled !== false,
         unitName: p.unit_name ?? '',
         defaultDailyQuota: Number(p.default_daily_quota ?? 0),
+        durations: supportedDurations(p),
         boundCount: bindings.length,
         enabledCount: bindings.filter((b) => b.enabled).length,
         health,

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -28,33 +28,54 @@ export interface DurationOption {
   disabled?: boolean
 }
 
+export const DEFAULT_SUPPORTED_DURATIONS = [5, 10]
+
+const DURATION_ORDER = [5, 10, 15] as const
+
+export function intersectDurations(lists: number[][]): number[] {
+  if (lists.length === 0) return [...DEFAULT_SUPPORTED_DURATIONS]
+  const counts = new Map<number, number>()
+  for (const list of lists) {
+    const unique = Array.from(new Set(list.map(Number).filter((n) => Number.isFinite(n) && n > 0)))
+    for (const duration of unique) {
+      counts.set(duration, (counts.get(duration) ?? 0) + 1)
+    }
+  }
+  return DURATION_ORDER.filter((duration) => counts.get(duration) === lists.length)
+}
+
 export function durationOptions(
   provider: string,
   model: string,
   mode: string,
-  vip: boolean
+  vip: boolean,
+  supportedDurations: number[] = DEFAULT_SUPPORTED_DURATIONS
 ): DurationOption[] {
-  const durations: DurationOption[] = [
-    { value: 5, label: '5 秒' },
-    { value: 10, label: '10 秒' },
-    { value: 15, label: '15 秒' }
-  ]
+  const allowed = new Set(supportedDurations)
+  const durations: DurationOption[] = DURATION_ORDER.filter((d) => allowed.has(d)).map((d) => ({
+    value: d,
+    label: `${d} 秒`
+  }))
+  if (durations.length === 0) {
+    durations.push({ value: 5, label: '5 秒' })
+  }
   if (provider === 'yuanbao') {
     durations.length = 1
-    durations[0].label = '5 秒（固定）'
+    durations[0] = { value: 5, label: '5 秒（固定）' }
   }
-  if (provider === 'doubao' && !vip) {
-    durations[2].label = '15 秒（仅 VIP）'
-    durations[2].disabled = true
+  const d15 = durations.find((d) => d.value === 15)
+  if (provider === 'doubao' && d15 && !vip) {
+    d15.label = '15 秒（仅 VIP）'
+    d15.disabled = true
   }
-  if (provider === 'qwen') {
+  if (provider === 'qwen' && d15) {
     if (model === '万相 2.6' && mode === 'multi_ref') {
-      durations[2].label = '15 秒（多参考不支持）'
-      durations[2].disabled = true
+      d15.label = '15 秒（多参考不支持）'
+      d15.disabled = true
     }
     if (model === 'HappyHorse 1.0 Beta') {
-      durations[2].label = '15 秒（该模型不支持）'
-      durations[2].disabled = true
+      d15.label = '15 秒（该模型不支持）'
+      d15.disabled = true
     }
   }
   return durations

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -74,10 +74,6 @@
 [data-theme="dark"] .main-content::after {
   opacity: 0.015;
 }
-[data-theme="dark"] .title-bar {
-  background: var(--bg-base);
-  border-bottom-color: #222;
-}
 [data-theme="dark"] .generate-panel,
 [data-theme="dark"] .provider-status-panel,
 [data-theme="dark"] .job-card,
@@ -240,8 +236,8 @@ body {
   align-items: center;
   height: 30px;
   padding: 0 8px;
-  background: #1a1a1a;
-  border-bottom: 1px solid #2a2a2a;
+  background: var(--bg-base);
+  border-bottom: 1px solid var(--border-light);
   -webkit-app-region: drag;
   user-select: none;
   flex-shrink: 0;
@@ -250,7 +246,7 @@ body {
   flex: 1;
   text-align: center;
   font-size: 0.92em;
-  color: #e0e0e0;
+  color: var(--fg-secondary);
   font-weight: 400;
   letter-spacing: 0.3px;
   white-space: nowrap;
@@ -270,7 +266,7 @@ body {
   border: none;
   border-radius: 0;
   background: transparent;
-  color: #b0b0b0;
+  color: var(--fg-muted);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -278,8 +274,8 @@ body {
   transition: background 0.1s ease, color 0.1s ease;
 }
 .title-bar .window-controls button:hover {
-  background: #333;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--fg-primary);
 }
 .title-bar .window-controls .btn-close:hover {
   background: #e81123;

--- a/docs/develop/smart-dispatch-duration-plan.md
+++ b/docs/develop/smart-dispatch-duration-plan.md
@@ -1,0 +1,46 @@
+# 智能调度时长优化方案
+
+## Summary
+
+- 问题根因：桌面端 `durationOptions()` 对 `provider === 'auto'` 没有做时长收敛，当前默认仍返回 `5s / 10s / 15s`，而实际执行链路只支持豆包，豆包只支持 `5s / 10s`。
+- 方案：把“厂商支持时长”做成数据库驱动的能力字段，桌面端智能调度只展示所有“已绑定且启用”厂商都支持的时长交集。
+- 当前只绑定豆包时，智能调度只显示 `5s` 和 `10s`，不再出现 `15s`。
+
+## Key Changes
+
+### 数据
+
+- 新增迁移 `migrations/0012_provider_duration_capabilities.sql`，给 `providers.capabilities` 写入 `supported_durations`。
+- 豆包固定为 `[5, 10]`；其他厂商默认也按当前实际支持范围保守配置，未确认支持 `15s` 的一律不配置 `15`。
+- 如果后续厂商支持 `15s`，由 admin 修改对应 `providers.capabilities.supported_durations`，桌面端刷新后自动生效。
+
+### 桌面端能力读取
+
+- `useProviders` 的 `ProviderAgg` 增加 `durations: number[]`，从 `ProviderMeta.capabilities.supported_durations` 解析；字段缺失时默认 `[5, 10]`，避免旧数据又漏出 15s。
+- `Dashboard.tsx` 根据已绑定且启用厂商的 `durations` 计算“智能调度可选时长交集”。
+
+### 调度台 UI
+
+- `durationOptions()` 增加可选 `supportedDurations` 入参；显式选择某个厂商时用该厂商能力，`auto` 时用已绑定且启用厂商的交集。
+- 时长选择后如果当前值不在候选列表里，自动回退到最后一个合法值，例如从 15s 回退到 10s。
+- 智能调度当前实际仍走豆包执行，所以 `auto` 的预计额度按豆包规则展示：5s = 1 点，10s = 2 点，不再显示成默认“1 次”。
+
+### 主进程兜底
+
+- 在 `dispatch.ts` 创建任务前校验 `durationSec` 是否在目标厂商 `capabilities.supported_durations` 内；不支持时直接返回明确错误，避免绕过 UI 后仍提交 15s。
+- 本次不新增多厂商真实调度，`auto` 仍解析为豆包执行；只把时长能力收紧到正确范围。
+
+## Test Plan
+
+- 执行迁移后，确认 `doubao` 的 `capabilities.supported_durations = [5, 10]`。
+- 桌面端 `auto` 模式只显示 `5s / 10s`，没有 `15s`；显式选择豆包同样只显示 `5s / 10s`。
+- 用开发工具或 IPC 强制提交 `durationSec: 15`，主进程应报“当前厂商不支持 15 秒”，任务不会进入生成阶段。
+- 验证智能调度 5s、10s 正常生成并扣 1 点 / 2 点。
+- 如果后续绑定第二个厂商且只支持 5s，则 `auto` 只显示 5s，确保交集逻辑生效。
+- 运行 `pnpm --filter @quota-flow/desktop typecheck`。
+
+## Assumptions
+
+- 智能调度当前只执行豆包，不在此次方案里扩展为真正多厂商自动选择。
+- “支持时长”以 `providers.capabilities.supported_durations` 为准，不再靠前端硬编码 `[5, 10, 15]`。
+- 已有 `provider_cost_tables` 继续负责扣费规则，不改成时长选项数据源；本次只加能力字段用于 UI 和提交校验。

--- a/migrations/0012_provider_duration_capabilities.sql
+++ b/migrations/0012_provider_duration_capabilities.sql
@@ -1,0 +1,11 @@
+-- 0012_provider_duration_capabilities.sql
+-- 厂商时长能力以 providers.capabilities.supported_durations 为准。
+-- 当前实际执行链路只确认豆包支持 5s / 10s；未确认支持 15s 的一律不配置 15。
+
+UPDATE providers
+SET capabilities = COALESCE(capabilities, '{}'::jsonb) || '{"supported_durations":[5,10]}'::jsonb
+WHERE id IN ('doubao', 'jimeng', 'qwen', 'qwenwan', 'hailuo', 'mathmind');
+
+UPDATE providers
+SET capabilities = COALESCE(capabilities, '{}'::jsonb) || '{"supported_durations":[5]}'::jsonb
+WHERE id IN ('yuanbao', 'kling');

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -550,11 +550,12 @@ export interface UpdateJobInput {
 export class JobService {
   constructor(private readonly client: SupabaseClient) {}
 
-  /** 列出当前用户可见的任务（RLS 已按本人/团队隔离，无需显式过滤），最新在前 */
-  async listJobs(): Promise<JobRow[]> {
+  /** 列出当前用户的任务（明确按账号过滤，避免团队/其他记录混入时区），最新在前 */
+  async listJobs(userId: string): Promise<JobRow[]> {
     const { data, error } = await this.client
       .from('jobs')
       .select('*')
+      .eq('user_id', userId)
       .order('created_at', { ascending: false })
     if (error) throw error
     return (data ?? []) as unknown as JobRow[]


### PR DESCRIPTION
Closes #11

## 提交信息
feat: 智能调度时长能力（厂商时长分级 + 调度按能力匹配 + Dashboard 重排）

- desktop: dispatch 按厂商时长能力（provider_duration_capabilities）匹配可用档位，超时档自动降级
- desktop: Dashboard 作业面板重排（时长档位展示/当前档位/能力不足提示）
- desktop: History 显示作业实际时长档位
- db: 0012_provider_duration_capabilities.sql（时长能力表 + RPC）
- docs: smart-dispatch-duration-plan.md 设计文档