### PR TITLE
feat: 团队模块 MVP（桌面端团队管理 + admin 团队页 + RPC）

### DIFF
--- a/apps/admin/src/app/(dashboard)/teams/page.tsx
+++ b/apps/admin/src/app/(dashboard)/teams/page.tsx
@@ -1,6 +1,135 @@
-import { PrototypePage } from "@/components/prototype-page";
-import { PROTOTYPE_PAGE_HTML } from "@/lib/prototype-pages";
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { listTeams, type AdminTeam, type TeamStatusFilter } from "@/lib/api/teams";
+import { TeamFilters } from "@/components/teams/team-filters";
+import { TeamTable } from "@/components/teams/team-table";
+import { TeamDetailModal } from "@/components/teams/team-detail-modal";
+import { Pagination } from "@/components/users/pagination";
+
+const PAGE_SIZE = 20;
 
 export default function TeamsPage() {
-  return <PrototypePage html={PROTOTYPE_PAGE_HTML["teams"]} />;
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [status, setStatus] = useState<TeamStatusFilter>("");
+  const [page, setPage] = useState(1);
+
+  const [result, setResult] = useState<{ total: number; items: AdminTeam[] }>({
+    total: 0,
+    items: []
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [detailTeam, setDetailTeam] = useState<AdminTeam | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        setPage(1);
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listTeams({
+        search: debouncedSearch,
+        status,
+        page,
+        pageSize: PAGE_SIZE
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch, status, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  function handleSaved(team: AdminTeam) {
+    setResult((prev) => ({
+      total: prev.total,
+      items: prev.items.map((it) => (it.id === team.id ? team : it))
+    }));
+    setDetailTeam(team);
+    setToast(`已更新 ${team.name}`);
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">团队管理</h1>
+          <p className="page-subtitle">查看团队、成员、订阅与用量，维护团队状态</p>
+        </div>
+      </div>
+
+      <TeamFilters
+        value={{ search, status }}
+        onChange={(v) => {
+          if (v.search !== search) setSearch(v.search);
+          if (v.status !== status) {
+            setStatus(v.status);
+            setPage(1);
+          }
+        }}
+      />
+
+      <TeamTable
+        teams={result.items}
+        loading={loading}
+        error={error}
+        onDetail={setDetailTeam}
+      />
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <Pagination
+          page={page}
+          total={result.total}
+          pageSize={PAGE_SIZE}
+          onPageChange={setPage}
+        />
+      </div>
+
+      <TeamDetailModal
+        team={detailTeam}
+        onClose={() => setDetailTeam(null)}
+        onSaved={handleSaved}
+      />
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/admin/src/components/teams/team-detail-modal.tsx
+++ b/apps/admin/src/components/teams/team-detail-modal.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AdminTeam, AdminTeamMember, TeamStatus } from "@/lib/api/teams";
+import {
+  listTeamMembers,
+  planLabel,
+  statusLabel,
+  subscriptionLabel,
+  updateTeamSettings
+} from "@/lib/api/teams";
+import { formatCount, formatDate, formatDateTime } from "@/lib/utils/format";
+
+export function TeamDetailModal({
+  team,
+  onClose,
+  onSaved
+}: {
+  team: AdminTeam | null;
+  onClose: () => void;
+  onSaved: (team: AdminTeam) => void;
+}) {
+  const [members, setMembers] = useState<AdminTeamMember[]>([]);
+  const [loadingMembers, setLoadingMembers] = useState(false);
+  const [membersError, setMembersError] = useState<string | null>(null);
+
+  const [plan, setPlan] = useState("free");
+  const [seats, setSeats] = useState("3");
+  const [status, setStatus] = useState<TeamStatus>("active");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!team) return;
+
+    setPlan(team.plan || "free");
+    setSeats(String(team.seats_limit || 3));
+    setStatus(team.status);
+    setSaveError(null);
+
+    let cancelled = false;
+    setLoadingMembers(true);
+    setMembersError(null);
+    listTeamMembers(team.id)
+      .then((rows) => {
+        if (!cancelled) setMembers(rows);
+      })
+      .catch((e) => {
+        if (!cancelled) setMembersError(e instanceof Error ? e.message : "加载成员失败");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingMembers(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [team]);
+
+  if (!team) return null;
+
+  const currentTeam = team;
+
+  async function handleSave() {
+    const seatsNumber = Number(seats);
+    if (!Number.isInteger(seatsNumber) || seatsNumber < 1) {
+      setSaveError("席位必须是大于 0 的整数");
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await updateTeamSettings(currentTeam.id, {
+        plan,
+        seats_limit: seatsNumber,
+        status
+      });
+      onSaved({
+        ...currentTeam,
+        plan,
+        seats_limit: seatsNumber,
+        status
+      });
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "保存失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay show" onClick={onClose}>
+      <div className="modal" style={{ maxWidth: 760 }} onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-title">团队详情</div>
+          <button className="modal-close" onClick={onClose} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <div style={{ marginBottom: 20 }}>
+            <div style={{ fontSize: 16, fontWeight: 600, color: "var(--color-foreground)" }}>
+              {team.name}
+            </div>
+            <div style={{ fontSize: 13, color: "#64748B", marginTop: 2 }}>
+              负责人：{team.owner_name ?? team.owner_email ?? "未知"} · 创建于 {formatDate(team.created_at)}
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">套餐</label>
+              <select
+                className="form-select"
+                value={plan}
+                onChange={(e) => setPlan(e.target.value)}
+              >
+                <option value="free">Free</option>
+                <option value="pro">Pro</option>
+                <option value="business">Business</option>
+                <option value="team">Team</option>
+              </select>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">席位上限</label>
+              <input
+                type="number"
+                min={1}
+                value={seats}
+                onChange={(e) => setSeats(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">团队状态</label>
+              <select
+                className="form-select"
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TeamStatus)}
+              >
+                <option value="active">正常</option>
+                <option value="banned">已封禁</option>
+                <option value="exhausted">额度耗尽</option>
+                <option value="expired">已过期</option>
+              </select>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">成员 / 席位</label>
+              <div style={{ fontSize: 14, paddingTop: 9 }}>{team.active_member_count}/{team.seats_limit} 可用</div>
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">本月用量</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>{formatCount(team.month_usage)}</div>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">累计用量</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>{formatCount(team.total_usage)}</div>
+            </div>
+          </div>
+
+          <div className="form-group" style={{ marginBottom: 20 }}>
+            <label className="form-label">订阅信息</label>
+            {team.subscription ? (
+              <div className="table-container">
+                <table className="table">
+                  <tbody>
+                    <tr>
+                      <td>套餐</td>
+                      <td>{planLabel(team.subscription.plan)}</td>
+                      <td>状态</td>
+                      <td>{subscriptionLabel(team.subscription.status)}</td>
+                      <td>订阅席位</td>
+                      <td>{team.subscription.seats ?? "-"}</td>
+                    </tr>
+                    <tr>
+                      <td>周期开始</td>
+                      <td>{formatDateTime(team.subscription.current_period_start)}</td>
+                      <td>周期结束</td>
+                      <td>{formatDateTime(team.subscription.current_period_end)}</td>
+                      <td>绑定账号</td>
+                      <td>{team.key_count}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div style={{ fontSize: 13, color: "#94A3B8" }}>无订阅记录</div>
+            )}
+          </div>
+
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">成员</label>
+            {loadingMembers ? (
+              <div style={{ fontSize: 13, color: "#94A3B8", padding: "12px 0" }}>加载中...</div>
+            ) : membersError ? (
+              <div style={{ fontSize: 13, color: "var(--color-destructive)", padding: "12px 0" }}>
+                {membersError}
+              </div>
+            ) : members.length === 0 ? (
+              <div style={{ fontSize: 13, color: "#94A3B8", padding: "12px 0" }}>暂无成员</div>
+            ) : (
+              <div className="table-container" style={{ maxHeight: 260, overflowY: "auto" }}>
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>成员</th>
+                      <th>角色</th>
+                      <th>状态</th>
+                      <th>今日用量</th>
+                      <th>本月用量</th>
+                      <th>日限额</th>
+                      <th>加入时间</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {members.map((member) => (
+                      <tr key={member.user_id}>
+                        <td>
+                          <div className="cell-primary">{member.display_name ?? member.email ?? "未命名"}</div>
+                          {member.email ? <div style={{ fontSize: 11, color: "#94A3B8" }}>{member.email}</div> : null}
+                        </td>
+                        <td>{member.role === "admin" ? "Admin" : "Member"}</td>
+                        <td>{member.status ? statusLabel(member.status) : "-"}</td>
+                        <td className="cell-mono">{formatCount(member.today_usage)}</td>
+                        <td className="cell-mono">{formatCount(member.month_usage)}</td>
+                        <td className="cell-mono">
+                          {member.daily_quota_limit_equivalent == null ? "不限" : formatCount(member.daily_quota_limit_equivalent)}
+                        </td>
+                        <td>{formatDate(member.joined_at)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {saveError ? (
+            <div style={{ marginTop: 12, fontSize: 13, color: "var(--color-destructive)" }}>
+              {saveError}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            关闭
+          </button>
+          <button className="btn btn-primary" disabled={saving} onClick={() => void handleSave()}>
+            {saving ? "保存中..." : "保存设置"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/teams/team-filters.tsx
+++ b/apps/admin/src/components/teams/team-filters.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { TeamStatusFilter } from "@/lib/api/teams";
+
+export interface TeamFiltersValue {
+  search: string;
+  status: TeamStatusFilter;
+}
+
+export function TeamFilters({
+  value,
+  onChange
+}: {
+  value: TeamFiltersValue;
+  onChange: (value: TeamFiltersValue) => void;
+}) {
+  return (
+    <div className="filter-bar">
+      <div className="filter-group">
+        <span className="filter-label">状态</span>
+        <select
+          className="form-select"
+          style={{ width: 120 }}
+          value={value.status}
+          onChange={(e) => onChange({ ...value, status: e.target.value as TeamStatusFilter })}
+        >
+          <option value="">全部</option>
+          <option value="active">正常</option>
+          <option value="banned">已封禁</option>
+          <option value="exhausted">额度耗尽</option>
+          <option value="expired">已过期</option>
+        </select>
+      </div>
+
+      <div className="filter-group" style={{ marginLeft: "auto" }}>
+        <input
+          type="text"
+          placeholder="搜索团队或负责人..."
+          style={{ width: 240 }}
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/teams/team-table.tsx
+++ b/apps/admin/src/components/teams/team-table.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { AdminTeam } from "@/lib/api/teams";
+import { planLabel, statusLabel, subscriptionLabel } from "@/lib/api/teams";
+import { formatCount, formatDate } from "@/lib/utils/format";
+
+function statusTone(status: AdminTeam["status"]): "success" | "danger" | "warning" | "muted" {
+  if (status === "banned") return "danger";
+  if (status === "exhausted" || status === "expired") return "warning";
+  return "success";
+}
+
+function planClass(plan: string): string {
+  const normalized = (plan || "free").toLowerCase();
+  if (normalized === "pro") return "plan-pro";
+  if (normalized === "business") return "plan-business";
+  return "plan-free";
+}
+
+export function TeamTable({
+  teams,
+  loading,
+  error,
+  onDetail
+}: {
+  teams: AdminTeam[];
+  loading: boolean;
+  error: string | null;
+  onDetail: (team: AdminTeam) => void;
+}) {
+  return (
+    <div className="card">
+      <div className="table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>团队</th>
+              <th>负责人</th>
+              <th>席位</th>
+              <th>套餐</th>
+              <th>订阅</th>
+              <th>本月用量</th>
+              <th>累计用量</th>
+              <th>绑定账号</th>
+              <th>状态</th>
+              <th style={{ textAlign: "right" }}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && teams.length === 0 ? (
+              <tr>
+                <td colSpan={10} className="empty-state" style={{ textAlign: "center" }}>
+                  加载中...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={10} className="empty-state" style={{ textAlign: "center", color: "var(--color-destructive)" }}>
+                  {error}
+                </td>
+              </tr>
+            ) : teams.length === 0 ? (
+              <tr>
+                <td colSpan={10} className="empty-state" style={{ textAlign: "center" }}>
+                  暂无匹配的团队
+                </td>
+              </tr>
+            ) : (
+              teams.map((team) => (
+                <tr key={team.id}>
+                  <td>
+                    <div className="cell-primary">{team.name}</div>
+                    <div style={{ fontSize: 11, color: "#94A3B8" }}>{team.id.slice(0, 8)}</div>
+                  </td>
+                  <td>
+                    <div>{team.owner_name ?? team.owner_email ?? "未知"}</div>
+                    {team.owner_email ? (
+                      <div style={{ fontSize: 11, color: "#94A3B8" }}>{team.owner_email}</div>
+                    ) : null}
+                  </td>
+                  <td className="cell-mono">
+                    {team.active_member_count}/{team.seats_limit}
+                  </td>
+                  <td>
+                    <span className={`plan-badge ${planClass(team.plan)}`}>{planLabel(team.plan)}</span>
+                  </td>
+                  <td>
+                    {team.subscription ? (
+                      <>
+                        <div>{planLabel(team.subscription.plan)}</div>
+                        <div style={{ fontSize: 11, color: "#94A3B8" }}>
+                          {subscriptionLabel(team.subscription.status)}
+                        </div>
+                      </>
+                    ) : (
+                      <div>无订阅</div>
+                    )}
+                  </td>
+                  <td className="cell-mono">{formatCount(team.month_usage)}</td>
+                  <td className="cell-mono">{formatCount(team.total_usage)}</td>
+                  <td className="cell-mono">{team.key_count}</td>
+                  <td>
+                    <span className={`badge badge-${statusTone(team.status)}`}>
+                      <span className="badge-dot" />
+                      {statusLabel(team.status)}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="cell-actions">
+                      <button className="btn btn-secondary btn-sm" onClick={() => onDetail(team)}>
+                        详情
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/api/teams.ts
+++ b/apps/admin/src/lib/api/teams.ts
@@ -1,0 +1,202 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+
+export type TeamStatus = "active" | "banned" | "exhausted" | "expired";
+export type TeamStatusFilter = "" | TeamStatus;
+export type TeamRole = "admin" | "member";
+
+export interface AdminTeamSubscription {
+  plan: string | null;
+  status: string | null;
+  seats: number | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+}
+
+export interface AdminTeam {
+  id: string;
+  name: string;
+  owner_id: string;
+  owner_email: string | null;
+  owner_name: string | null;
+  owner_status: string | null;
+  plan: string;
+  seats_limit: number;
+  status: TeamStatus;
+  created_at: string;
+  member_count: number;
+  active_member_count: number;
+  subscription: AdminTeamSubscription | null;
+  month_usage: number;
+  total_usage: number;
+  key_count: number;
+}
+
+export interface AdminTeamMember {
+  team_id: string;
+  user_id: string;
+  email: string | null;
+  display_name: string | null;
+  status: string | null;
+  role: TeamRole;
+  daily_quota_limit_equivalent: number | null;
+  joined_at: string;
+  today_usage: number;
+  month_usage: number;
+  total_usage: number;
+}
+
+export interface TeamListResult {
+  total: number;
+  items: AdminTeam[];
+}
+
+export interface TeamListParams {
+  search?: string;
+  status?: TeamStatusFilter;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface TeamSettingsInput {
+  plan?: string;
+  seats_limit?: number;
+  status?: TeamStatus;
+}
+
+export async function listTeams(params: TeamListParams = {}): Promise<TeamListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+
+  const { data, error } = await supabase.rpc("admin_list_teams", {
+    p_search: params.search?.trim() || null,
+    p_status: params.status || null,
+    p_limit: pageSize,
+    p_offset: (page - 1) * pageSize
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { total: 0, items: [] }) as { total: number; items: unknown[] };
+  return {
+    total: Number(raw.total ?? 0),
+    items: (raw.items ?? []).map((it) => normalizeTeam(it as Record<string, unknown>))
+  };
+}
+
+export async function listTeamMembers(teamId: string): Promise<AdminTeamMember[]> {
+  const supabase = createAdminBrowserClient();
+  const { data, error } = await supabase.rpc("admin_list_team_members", {
+    p_team_id: teamId
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { items: [] }) as { items: unknown[] };
+  return (raw.items ?? []).map((it) => normalizeTeamMember(it as Record<string, unknown>));
+}
+
+export async function updateTeamSettings(teamId: string, input: TeamSettingsInput): Promise<void> {
+  const supabase = createAdminBrowserClient();
+
+  const payload: Record<string, unknown> = {};
+  if (input.plan !== undefined) payload.plan = input.plan;
+  if (input.seats_limit !== undefined) payload.seats_limit = input.seats_limit;
+  if (input.status !== undefined) payload.status = input.status;
+
+  if (Object.keys(payload).length === 0) return;
+
+  const { error } = await supabase
+    .from("teams")
+    .update(payload)
+    .eq("id", teamId);
+  if (error) throw error;
+
+  try {
+    const { data: authData } = await supabase.auth.getUser();
+    if (authData.user?.id) {
+      await supabase.from("audit_logs").insert({
+        admin_user_id: authData.user.id,
+        team_id: teamId,
+        action: "team.update",
+        target: teamId,
+        metadata: payload
+      });
+    }
+  } catch {
+    // 审计日志失败不阻断主操作。
+  }
+}
+
+export function statusLabel(status: TeamStatus | string): string {
+  if (status === "banned") return "已封禁";
+  if (status === "exhausted") return "额度耗尽";
+  if (status === "expired") return "已过期";
+  return "正常";
+}
+
+export function planLabel(plan: string | null | undefined): string {
+  const value = plan || "free";
+  const map: Record<string, string> = {
+    free: "Free",
+    pro: "Pro",
+    business: "Business",
+    team: "Team"
+  };
+  return map[value] ?? value;
+}
+
+export function subscriptionLabel(status: string | null | undefined): string {
+  if (status === "active") return "生效中";
+  if (status === "expired") return "已过期";
+  if (status === "cancelled") return "已取消";
+  return status ?? "无订阅";
+}
+
+function normalizeTeam(it: Record<string, unknown>): AdminTeam {
+  return {
+    id: String(it.id ?? ""),
+    name: String(it.name ?? ""),
+    owner_id: String(it.owner_id ?? ""),
+    owner_email: (it.owner_email as string) ?? null,
+    owner_name: (it.owner_name as string) ?? null,
+    owner_status: (it.owner_status as string) ?? null,
+    plan: String(it.plan ?? "free"),
+    seats_limit: Number(it.seats_limit ?? 0),
+    status: (it.status as TeamStatus) ?? "active",
+    created_at: String(it.created_at ?? ""),
+    member_count: Number(it.member_count ?? 0),
+    active_member_count: Number(it.active_member_count ?? 0),
+    subscription: normalizeSubscription(it.subscription as Record<string, unknown> | null),
+    month_usage: Number(it.month_usage ?? 0),
+    total_usage: Number(it.total_usage ?? 0),
+    key_count: Number(it.key_count ?? 0)
+  };
+}
+
+function normalizeSubscription(it: Record<string, unknown> | null | undefined): AdminTeamSubscription | null {
+  if (!it) return null;
+  return {
+    plan: (it.plan as string) ?? null,
+    status: (it.status as string) ?? null,
+    seats: it.seats == null ? null : Number(it.seats),
+    current_period_start: (it.current_period_start as string) ?? null,
+    current_period_end: (it.current_period_end as string) ?? null
+  };
+}
+
+function normalizeTeamMember(it: Record<string, unknown>): AdminTeamMember {
+  return {
+    team_id: String(it.team_id ?? ""),
+    user_id: String(it.user_id ?? ""),
+    email: (it.email as string) ?? null,
+    display_name: (it.display_name as string) ?? null,
+    status: (it.status as string) ?? null,
+    role: (it.role as TeamRole) ?? "member",
+    daily_quota_limit_equivalent: it.daily_quota_limit_equivalent == null
+      ? null
+      : Number(it.daily_quota_limit_equivalent),
+    joined_at: String(it.joined_at ?? ""),
+    today_usage: Number(it.today_usage ?? 0),
+    month_usage: Number(it.month_usage ?? 0),
+    total_usage: Number(it.total_usage ?? 0)
+  };
+}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -85,6 +85,7 @@ interface MainAppProps {
   updater: UpdaterStatusView
   onOpenModal: (m: 'profile' | 'settings') => void
   onSignOut: () => Promise<void>
+  onRefreshTeam: () => Promise<void>
 }
 
 function MainApp({
@@ -92,7 +93,8 @@ function MainApp({
   team,
   updater,
   onOpenModal,
-  onSignOut
+  onSignOut,
+  onRefreshTeam
 }: MainAppProps) {
   // 厂商 / 任务数据提升到 MainApp 层：随 user 挂载/卸载，账号切换时整棵数据树重建，避免残留上一账号数据
   const providers = useProviders()
@@ -125,7 +127,7 @@ function MainApp({
   const [tab, setTab] = useState<TabId>(() => {
     const hit = location.hash.match(/#tab=(.+)/)
     const t = hit ? hit[1] : 'dispatch'
-    return (['dispatch', 'providers', 'history'] as TabId[]).includes(t as TabId)
+    return (['dispatch', 'providers', 'history', 'team'] as TabId[]).includes(t as TabId)
       ? (t as TabId)
       : 'dispatch'
   })
@@ -218,10 +220,6 @@ function MainApp({
               key={t.id}
               className={'nav-tab' + (tab === t.id ? ' active' : '')}
               onClick={() => {
-                if (t.id === 'team') {
-                  showToast('系统暂未实现')
-                  return
-                }
                 setTab(t.id)
                 location.hash = 'tab=' + t.id
               }}
@@ -295,7 +293,12 @@ function MainApp({
             <History jobs={jobs} />
           </div>
           <div className="tab-pane" style={{ display: tab === 'team' ? 'flex' : 'none' }}>
-            <Team fresh={fresh} />
+            <Team
+              fresh={fresh}
+              userId={user.id}
+              team={team}
+              onTeamChanged={onRefreshTeam}
+            />
           </div>
         </div>
       </main>
@@ -439,7 +442,7 @@ function ConfigWarning() {
 }
 
 export default function App() {
-  const { configured, loading, user, team, error, notice, signIn, signUp, sendOtp, verifyOtp, signOut, forgotPassword, updateProfile } =
+  const { configured, loading, user, team, error, notice, signIn, signUp, sendOtp, verifyOtp, signOut, forgotPassword, updateProfile, refreshTeam } =
     useAuth()
   const modalApiRef = useRef<{ open: (m: ModalKind) => void } | null>(null)
   const [updater, setUpdater] = useState<UpdaterStatusView>({ state: 'idle' })
@@ -512,6 +515,7 @@ export default function App() {
         updater={updater}
         onOpenModal={openModal}
         onSignOut={signOut}
+        onRefreshTeam={refreshTeam}
       />
       <AppModals
         modalApiRef={modalApiRef}

--- a/apps/desktop/src/renderer/src/auth/service.ts
+++ b/apps/desktop/src/renderer/src/auth/service.ts
@@ -1,6 +1,6 @@
 import { createAuthService } from '@quota-flow/auth'
 import type { AuthService, AuthTokens } from '@quota-flow/auth'
-import { JobService, ProviderService } from '@quota-flow/db-supabase'
+import { JobService, ProviderService, TeamService } from '@quota-flow/db-supabase'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -8,6 +8,7 @@ const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 let service: AuthService | null = null
 let providerService: ProviderService | null = null
 let jobService: JobService | null = null
+let teamService: TeamService | null = null
 
 export interface PlainSession {
   access_token: string
@@ -50,6 +51,15 @@ export function getJobService(): JobService | null {
     jobService = new JobService(auth.getClient())
   }
   return jobService
+}
+
+export function getTeamService(): TeamService | null {
+  const auth = getAuthService()
+  if (!auth) return null
+  if (!teamService) {
+    teamService = new TeamService(auth.getClient())
+  }
+  return teamService
 }
 
 export function toTokens(session: PlainSession): AuthTokens {

--- a/apps/desktop/src/renderer/src/components/Team.tsx
+++ b/apps/desktop/src/renderer/src/components/Team.tsx
@@ -1,37 +1,272 @@
-import { TEAM } from '../data'
+import { useCallback, useEffect, useState } from 'react'
+import type { TeamContext, TeamDetail, TeamInvitation, TeamMemberView } from '@quota-flow/db-supabase'
+import { getTeamService } from '../auth/service'
 import { IconUsers } from './icons'
 import { EmptyState } from './EmptyState'
 
 interface TeamProps {
   fresh: boolean
+  userId: string
+  team: TeamContext | null
+  onTeamChanged: () => Promise<void>
 }
 
-export default function Team({ fresh }: TeamProps) {
-  if (fresh) {
+function formatDate(iso: string | null): string {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatCount(n: number | null | undefined): string {
+  const value = Number(n ?? 0)
+  return `${Math.round(value).toLocaleString('zh-CN')} 次`
+}
+
+function memberName(member: TeamMemberView): string {
+  return member.display_name || member.email || '成员'
+}
+
+function statusLabel(status: string | null): string {
+  if (status === 'active') return '正常'
+  if (status === 'banned') return '已封禁'
+  if (status === 'exhausted') return '额度耗尽'
+  if (status === 'expired') return '已过期'
+  return status ?? '-'
+}
+
+function statusTone(status: string | null): string {
+  if (status === 'active') return 'badge badge-success'
+  if (status === 'banned') return 'badge badge-danger'
+  if (status === 'exhausted' || status === 'expired') return 'badge badge-warning'
+  return 'badge badge-muted'
+}
+
+export default function Team({ userId, team, onTeamChanged }: TeamProps) {
+  const [detail, setDetail] = useState<TeamDetail | null>(null)
+  const [members, setMembers] = useState<TeamMemberView[]>([])
+  const [invitations, setInvitations] = useState<TeamInvitation[]>([])
+  const [inviteCode, setInviteCode] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [teamName, setTeamName] = useState('')
+  const [joinToken, setJoinToken] = useState('')
+  const [limitDrafts, setLimitDrafts] = useState<Record<string, string>>({})
+
+  const isOwner = team?.role === 'admin'
+
+  const load = useCallback(async () => {
+    if (!team) {
+      setDetail(null)
+      setMembers([])
+      setInvitations([])
+      return
+    }
+
+    const service = getTeamService()
+    if (!service) {
+      setError('Supabase 未配置')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const owner = team.role === 'admin'
+      const [nextDetail, nextMembers, nextInvitations] = await Promise.all([
+        service.getTeamDetail(team.id),
+        service.listMembers(team.id),
+        owner ? service.listInvitations(team.id) : Promise.resolve([])
+      ])
+      setDetail(nextDetail)
+      setMembers(nextMembers)
+      setInvitations(nextInvitations)
+      setInviteCode((prev) => prev || nextInvitations[0]?.token || '')
+      setLimitDrafts((prev) => {
+        const next = { ...prev }
+        for (const member of nextMembers) {
+          if (next[member.user_id] === undefined) {
+            next[member.user_id] = member.daily_quota_limit_equivalent == null
+              ? ''
+              : String(member.daily_quota_limit_equivalent)
+          }
+        }
+        return next
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '加载失败')
+    } finally {
+      setLoading(false)
+    }
+  }, [team])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => {
+    if (!notice) return
+    const timer = window.setTimeout(() => setNotice(null), 2400)
+    return () => window.clearTimeout(timer)
+  }, [notice])
+
+  async function handleCreate(): Promise<void> {
+    if (!teamName.trim()) {
+      setError('请输入团队名称')
+      return
+    }
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.createTeam(teamName.trim())
+      setTeamName('')
+      await onTeamChanged()
+      setNotice('团队创建成功')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '创建失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleJoin(): Promise<void> {
+    if (!joinToken.trim()) {
+      setError('请输入邀请码')
+      return
+    }
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.joinTeam(joinToken.trim().toUpperCase())
+      setJoinToken('')
+      await onTeamChanged()
+      setNotice('已加入团队')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '加入失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleGenerateInvite(): Promise<void> {
+    if (!team) return
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      const invite = await service.createInvite(team.id)
+      setInviteCode(invite.token)
+      await load()
+      setNotice('邀请码已生成')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '生成失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleCopyInvite(): Promise<void> {
+    if (!inviteCode) return
+    try {
+      await navigator.clipboard?.writeText(inviteCode)
+      setNotice('邀请码已复制')
+    } catch {
+      setNotice('复制失败，请手动复制')
+    }
+  }
+
+  async function handleRemoveMember(member: TeamMemberView): Promise<void> {
+    if (!team || member.user_id === userId) return
+    if (!window.confirm(`确定移除 ${memberName(member)} 吗？`)) return
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.removeMember(team.id, member.user_id)
+      await load()
+      setNotice('成员已移除')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '移除失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleSaveLimit(member: TeamMemberView): Promise<void> {
+    if (!team) return
+    const raw = limitDrafts[member.user_id] ?? ''
+    const next = raw.trim() === '' ? null : Number(raw)
+    if (next != null && (Number.isNaN(next) || next < 0)) {
+      setError('日限额必须是非负数字')
+      return
+    }
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.updateMemberLimit(team.id, member.user_id, next)
+      await load()
+      setNotice('成员日限额已更新')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '更新失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!team) {
     return (
-      <>
+      <div className="tab-wrap">
         <div className="page-header">
           <div className="title-group">
             <div>
-              <h1>团队额度池</h1>
+              <h1>团队</h1>
               <div className="divider" />
             </div>
-            <p>创建团队 · 分享额度 · 集中管理</p>
+            <p>创建团队或通过邀请码加入</p>
           </div>
         </div>
         <EmptyState
           className="team-empty"
           icon={<IconUsers size={20} />}
           title="你还没有加入任何团队"
-          description="创建团队后可与队友共享额度池，统一管理成员消耗上限与公共账号"
+          description="创建团队后可以集中管理成员与邀请码；共享额度池不在本轮范围。"
           action={
             <div className="team-empty-actions">
-              <button className="btn-sm primary">+ 创建团队</button>
-              <button className="btn-sm">输入邀请码加入</button>
+              <input
+                className="team-input"
+                type="text"
+                placeholder="团队名称"
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+              />
+              <button className="btn-sm primary" disabled={busy} onClick={() => void handleCreate()}>
+                创建团队
+              </button>
+              <input
+                className="team-input"
+                type="text"
+                placeholder="邀请码"
+                value={joinToken}
+                onChange={(e) => setJoinToken(e.target.value.toUpperCase())}
+              />
+              <button className="btn-sm" disabled={busy} onClick={() => void handleJoin()}>
+                加入团队
+              </button>
             </div>
           }
         />
-      </>
+        {error && <div className="team-message team-message-error">{error}</div>}
+      </div>
     )
   }
 
@@ -40,18 +275,22 @@ export default function Team({ fresh }: TeamProps) {
       <div className="page-header">
         <div className="title-group">
           <div>
-            <h1>团队额度池</h1>
+            <h1>团队</h1>
             <div className="divider" />
           </div>
-          <p>{TEAM.header}</p>
+          <p>{detail?.name ?? '团队管理'}</p>
         </div>
       </div>
+
+      {error && <div className="team-message team-message-error">{error}</div>}
 
       <div className="team-grid">
         <div className="team-panel">
           <div className="panel-header">
             <h2>成员列表</h2>
-            <span className="panel-meta">{TEAM.seats}</span>
+            <span className="panel-meta">
+              {members.length}/{detail?.seats_limit ?? '-'} 席位
+            </span>
           </div>
           <div className="history-table-wrap" style={{ flex: 1, minHeight: 0 }}>
             <div className="table-scroll">
@@ -60,29 +299,68 @@ export default function Team({ fresh }: TeamProps) {
                   <tr>
                     <th>成员</th>
                     <th>角色</th>
-                    <th>今日消耗</th>
-                    <th>日上限</th>
-                    <th>自带额度</th>
                     <th>状态</th>
+                    <th>今日用量</th>
+                    <th>日限额</th>
+                    <th>加入时间</th>
+                    {isOwner ? <th style={{ textAlign: 'right' }}>操作</th> : null}
                   </tr>
                 </thead>
                 <tbody>
-                  {TEAM.members.map((m) => (
-                    <tr key={m.name}>
-                      <td>
-                        <strong>{m.name}</strong>
-                      </td>
-                      <td>{m.role}</td>
-                      <td>{m.used}</td>
-                      <td>{m.limit}</td>
-                      <td>{m.own}</td>
-                      <td>
-                        <span className={m.state === '正常' ? 'badge badge-success' : 'badge badge-pending'}>
-                          {m.state}
-                        </span>
+                  {loading && members.length === 0 ? (
+                    <tr>
+                      <td colSpan={isOwner ? 7 : 6} style={{ textAlign: 'center', color: 'var(--fg-muted)' }}>
+                        加载中...
                       </td>
                     </tr>
-                  ))}
+                  ) : members.length === 0 ? (
+                    <tr>
+                      <td colSpan={isOwner ? 7 : 6} style={{ textAlign: 'center', color: 'var(--fg-muted)' }}>
+                        暂无成员
+                      </td>
+                    </tr>
+                  ) : (
+                    members.map((member) => (
+                      <tr key={member.user_id}>
+                        <td>
+                          <strong>{memberName(member)}</strong>
+                          {member.user_id === userId ? <span style={{ marginLeft: 6, color: 'var(--fg-muted)' }}>我</span> : null}
+                          <div style={{ fontSize: 11, color: 'var(--fg-muted)' }}>{member.email ?? ''}</div>
+                        </td>
+                        <td>{member.role === 'admin' ? '管理员' : '成员'}</td>
+                        <td>
+                          <span className={statusTone(member.status)}>{statusLabel(member.status)}</span>
+                        </td>
+                        <td className="cell-mono">{formatCount(member.today_usage)}</td>
+                        <td className="cell-mono">{member.daily_quota_limit_equivalent == null ? '不限' : formatCount(member.daily_quota_limit_equivalent)}</td>
+                        <td>{formatDate(member.joined_at)}</td>
+                        {isOwner ? (
+                          <td>
+                            <div className="team-row-actions">
+                              <input
+                                className="team-limit-input"
+                                type="number"
+                                min={0}
+                                value={limitDrafts[member.user_id] ?? ''}
+                                placeholder="不限"
+                                onChange={(e) =>
+                                  setLimitDrafts((prev) => ({ ...prev, [member.user_id]: e.target.value }))
+                                }
+                              />
+                              <button className="btn-sm" disabled={busy} onClick={() => void handleSaveLimit(member)}>
+                                保存
+                              </button>
+                              {member.user_id !== userId ? (
+                                <button className="btn-sm danger" disabled={busy} onClick={() => void handleRemoveMember(member)}>
+                                  移除
+                                </button>
+                              ) : null}
+                            </div>
+                          </td>
+                        ) : null}
+                      </tr>
+                    ))
+                  )}
                 </tbody>
               </table>
             </div>
@@ -94,23 +372,72 @@ export default function Team({ fresh }: TeamProps) {
             <h2>团队配置</h2>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {TEAM.config.map((c) => (
-              <div className="config-card" key={c.label}>
-                <div className="config-label">{c.label}</div>
-                <div className="config-val">{c.value}</div>
-              </div>
-            ))}
-            <div style={{ marginTop: 'auto', display: 'flex', gap: 6 }}>
-              <button className="btn-sm" style={{ flex: 1 }}>
-                邀请成员
-              </button>
-              <button className="btn-sm primary" style={{ flex: 1 }}>
-                升级套餐
-              </button>
+            <div className="config-card">
+              <div className="config-label">团队名称</div>
+              <div className="config-val">{detail?.name ?? '-'}</div>
             </div>
+            <div className="config-card">
+              <div className="config-label">当前套餐</div>
+              <div className="config-val">{detail?.plan ?? '-'}</div>
+            </div>
+            <div className="config-card">
+              <div className="config-label">席位上限</div>
+              <div className="config-val">{detail?.seats_limit ?? '-'} 人</div>
+            </div>
+            <div className="config-card">
+              <div className="config-label">状态</div>
+              <div className="config-val">{detail ? statusLabel(detail.status) : '-'}</div>
+            </div>
+            <div className="config-card">
+              <div className="config-label">本月用量</div>
+              <div className="config-val">{detail ? formatCount(detail.month_usage) : '-'}</div>
+            </div>
+            <div className="config-card">
+              <div className="config-label">累计用量</div>
+              <div className="config-val">{detail ? formatCount(detail.total_usage) : '-'}</div>
+            </div>
+          </div>
+
+          {isOwner ? (
+            <div className="team-invite-box">
+              <div className="config-label">邀请码</div>
+              <input
+                className="team-input"
+                type="text"
+                readOnly
+                value={inviteCode}
+                placeholder="点击生成"
+              />
+              <div style={{ display: 'flex', gap: 6 }}>
+                <button className="btn-sm" style={{ flex: 1 }} disabled={busy || !inviteCode} onClick={() => void handleCopyInvite()}>
+                  复制
+                </button>
+                <button className="btn-sm primary" style={{ flex: 1 }} disabled={busy} onClick={() => void handleGenerateInvite()}>
+                  生成邀请码
+                </button>
+              </div>
+              {invitations.length > 0 ? (
+                <div className="team-invite-list">
+                  {invitations.map((invite) => (
+                    <div key={invite.id} className="team-invite-item">
+                      <span>{invite.token}</span>
+                      <span>{invite.email ?? '不限邮箱'}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div style={{ marginTop: 'auto', display: 'flex', gap: 6 }}>
+            <button className="btn-sm" style={{ flex: 1 }} disabled={loading} onClick={() => void load()}>
+              刷新
+            </button>
           </div>
         </div>
       </div>
+
+      {notice && <div className="app-toast">{notice}</div>}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/hooks/useAuth.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAuth.ts
@@ -56,6 +56,7 @@ export interface AuthResult {
   signOut: () => Promise<void>
   forgotPassword: (email: string) => Promise<void>
   updateProfile: (displayName: string) => Promise<string | null>
+  refreshTeam: () => Promise<void>
 }
 
 function toAuthUser(raw: RawUser | null): AuthUser | null {
@@ -306,5 +307,20 @@ export function useAuth(): AuthResult {
     return null
   }, [])
 
-  return { configured, loading, user, team, error, notice, signIn, signUp, sendOtp, verifyOtp, signOut, forgotPassword, updateProfile }
+  const refreshTeam = useCallback(async () => {
+    const auth = getAuthService()
+    if (!auth) {
+      setTeam(null)
+      return
+    }
+    const session = await auth.getSession()
+    if (!session?.user) {
+      setTeam(null)
+      return
+    }
+    const t = await auth.getTeam(session.user.id)
+    setTeam(t)
+  }, [])
+
+  return { configured, loading, user, team, error, notice, signIn, signUp, sendOtp, verifyOtp, signOut, forgotPassword, updateProfile, refreshTeam }
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2969,4 +2969,88 @@ textarea::-webkit-scrollbar {
 .team-empty-actions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.team-input {
+  height: 28px;
+  min-width: 160px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  font-family: var(--font-body);
+  font-size: 0.9em;
+  box-shadow: var(--shadow-inset);
+}
+.team-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.team-input:read-only {
+  opacity: 0.85;
+}
+
+.team-message {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 0.88em;
+  line-height: 1.5;
+}
+.team-message-error {
+  background: rgba(196, 77, 77, 0.1);
+  color: var(--error);
+}
+
+.team-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.team-limit-input {
+  width: 78px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  font-family: var(--font-body);
+  font-size: 0.82em;
+}
+.team-limit-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.team-invite-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+}
+.team-invite-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.team-invite-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--fg-secondary);
+  font-size: 0.84em;
 }

--- a/docs/team-module-mvp.md
+++ b/docs/team-module-mvp.md
@@ -1,0 +1,55 @@
+# 团队模块 MVP 实施计划
+
+日期：2026-08-14
+
+## 摘要与现状
+
+当前 Admin 端团队页还是静态 HTML 原型，只展示假数据，详情、封禁、重置额度等按钮没有真实逻辑；桌面端团队 Tab 在导航里被直接拦截，提示“系统暂未实现”，页面组件也只用 `TEAM` 静态数据。数据库已经有 `teams`、`team_members`、`team_invitations`、`subscriptions`、`member_usage` 等基础表和 Admin RLS 策略，但缺少团队列表 RPC、桌面端创建/加入/邀请服务、以及真实 UI 数据流。
+
+本次范围：Admin 团队管理 + 桌面端基础团队功能一起做，不包含共享额度池。
+
+## 关键改动
+
+- 新增 `migrations/0013_team_rpc.sql`：
+  - `admin_list_teams(p_search, p_status, p_limit, p_offset) returns json`：Admin 专用，聚合团队名称、owner、成员数、席位、套餐、状态、最近订阅、本月/累计用量、绑定账号数。
+  - `admin_list_team_members(p_team_id) returns json`：Admin 专用，返回成员资料、角色、日限额、加入时间、用量统计。
+  - `create_team(p_name)`：事务化创建团队并插入 owner 成员记录，返回 `TeamContext`。
+  - `join_team_by_invite(p_token)`：校验邀请码、过期时间、席位上限，插入成员并消费邀请码，返回 `TeamContext`。
+  - `get_team_detail(p_team_id)`：桌面端成员读取团队信息、订阅摘要、成员数与用量。
+  - `get_team_members(p_team_id)`：桌面端成员读取团队成员的资料、日限额、加入时间与用量统计。
+  - `create_team_invite(p_team_id, p_email, p_role, p_expires_at)`：owner 生成单次邀请码，默认 7 天有效。
+  - 所有 RPC 都 `SECURITY DEFINER` 并显式校验权限，`GRANT EXECUTE` 给 `authenticated`。
+- Admin 端替换团队页：
+  - 新增 `apps/admin/src/lib/api/teams.ts`，类型为 `AdminTeam`、`AdminTeamMember`、状态筛选等。
+  - 新增团队表格、筛选、分页、详情弹窗组件，沿用现有用户管理页的模式。
+  - 详情弹窗展示团队成员、订阅信息、用量；支持修改 `plan`、`seats_limit`、`status` 并写 `audit_logs`。
+  - 不实现“重置额度”或“成员封禁”的额度/封禁业务，保留为后续独立项。
+- 桌面端加入真实团队服务：
+  - 在 `@quota-flow/db-supabase` 增加 `TeamService`，并在桌面 renderer 的 `auth/service.ts` 增加 `getTeamService()` 单例。
+  - 方法包括：创建团队、邀请码加入、成员列表、生成邀请码、移除成员、更新成员日限额、读取团队信息。
+  - `useAuth` 增加 `refreshTeam()`，创建/加入成功后刷新顶部团队徽标和 Profile 弹窗。
+  - `App.tsx` 移除团队 Tab 的拦截，并把 `team` 纳入可恢复的 hash tab。
+- 重写桌面端 `Team.tsx`：
+  - 无团队时显示真实空状态，支持“创建团队”和“输入邀请码加入”。
+  - 有团队时展示成员表格、团队信息、邀请码生成/复制；owner 可移除成员、设置成员日限额。
+  - 移除对静态 `TEAM` 数据的依赖；“升级套餐”按钮隐藏或禁用，因为计费/套餐购买不在本轮范围。
+
+## 公共 API / 类型变化
+
+- 新增 RPC：`admin_list_teams`、`admin_list_team_members`、`create_team`、`join_team_by_invite`、`get_team_detail`、`get_team_members`、`create_team_invite`。
+- 新增 TS 类型：`AdminTeam`、`AdminTeamMember`、`TeamDetail`、`TeamMemberView`、`TeamInvitation`。
+- 新增导出：`@quota-flow/db-supabase` 的 `TeamService`，桌面端 `auth/service.ts` 的 `getTeamService()`，`useAuth` 的 `refreshTeam()`。
+
+## 测试计划
+
+- SQL：在 Supabase 本地或远程环境幂等执行迁移，验证非 admin 调用 Admin RPC 被拒绝；验证 `create_team` 后 owner 能读团队、`join_team_by_invite` 对无效/过期/满员/重复加入返回合理错误。
+- Admin：运行 `pnpm --filter @quota-flow/admin typecheck` 和 `pnpm --filter @quota-flow/admin build`；人工验证团队列表、筛选、分页、详情成员、状态/套餐编辑、审计日志写入。
+- 桌面端：运行 `pnpm --filter @quota-flow/db-supabase typecheck`、`pnpm --filter @quota-flow/desktop typecheck` 和 `pnpm --filter @quota-flow/desktop build`；人工验证创建团队、邀请码加入、成员列表、生成邀请码、owner 操作、团队徽标刷新。
+- 根目录跑一次 `pnpm typecheck`，确认共享包和两端类型兼容。
+
+## 假设
+
+- 本轮不实现共享额度池、计费支付、公共账号绑定/额度扣减改造。
+- 邀请码采用 8 位大写 token，默认 7 天有效，单次使用后消费；暂不使用邀请邮箱匹配。
+- Admin 团队操作以 `teams` 表字段为主，订阅周期只读展示，不新增订阅账务流程。
+- 保留现有 `prototype-pages.ts` 和其他原型页不动，仅团队页切到真实数据。

--- a/migrations/0013_team_rpc.sql
+++ b/migrations/0013_team_rpc.sql
@@ -1,0 +1,559 @@
+-- 0013_team_rpc.sql
+-- Team module RPCs for admin management and desktop create/join flows.
+-- Idempotent: uses CREATE OR REPLACE FUNCTION and explicit GRANTs.
+
+-- ============ 1. admin_list_teams ============
+CREATE OR REPLACE FUNCTION public.admin_list_teams(
+  p_search TEXT DEFAULT NULL,
+  p_status TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM teams t
+  LEFT JOIN profiles owner ON owner.id = t.owner_id
+  WHERE
+    (p_search IS NULL OR p_search = '' OR t.name ILIKE '%' || p_search || '%' OR owner.email ILIKE '%' || p_search || '%' OR owner.display_name ILIKE '%' || p_search || '%')
+    AND (p_status IS NULL OR p_status = '' OR t.status = p_status);
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      t.id,
+      t.name,
+      t.owner_id,
+      owner.email AS owner_email,
+      owner.display_name AS owner_name,
+      owner.status AS owner_status,
+      t.plan,
+      t.seats_limit,
+      t.status,
+      t.created_at,
+      (
+        SELECT count(*)
+        FROM team_members tm
+        WHERE tm.team_id = t.id
+      ) AS member_count,
+      (
+        SELECT count(*)
+        FROM team_members tm
+        JOIN profiles mp ON mp.id = tm.user_id
+        WHERE tm.team_id = t.id
+          AND mp.status = 'active'
+      ) AS active_member_count,
+      (
+        SELECT json_build_object(
+          'plan', s.plan,
+          'status', s.status,
+          'seats', s.seats,
+          'current_period_start', s.current_period_start,
+          'current_period_end', s.current_period_end
+        )
+        FROM subscriptions s
+        WHERE s.team_id = t.id
+        ORDER BY s.created_at DESC
+        LIMIT 1
+      ) AS subscription,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = t.id
+          AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+      ), 0) AS month_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = t.id
+      ), 0) AS total_usage,
+      (
+        SELECT count(*)
+        FROM provider_keys pk
+        WHERE pk.team_id = t.id
+      ) AS key_count
+    FROM teams t
+    LEFT JOIN profiles owner ON owner.id = t.owner_id
+    WHERE
+      (p_search IS NULL OR p_search = '' OR t.name ILIKE '%' || p_search || '%' OR owner.email ILIKE '%' || p_search || '%' OR owner.display_name ILIKE '%' || p_search || '%')
+      AND (p_status IS NULL OR p_status = '' OR t.status = p_status)
+    ORDER BY t.created_at DESC, t.id
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_teams(text, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_teams(text, text, integer, integer)
+  IS 'Admin team list with owner, members, subscription, usage, and key count. Admin only.';
+
+-- ============ 2. admin_list_team_members ============
+CREATE OR REPLACE FUNCTION public.admin_list_team_members(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      tm.team_id,
+      tm.user_id,
+      p.email,
+      p.display_name,
+      p.status,
+      tm.role,
+      tm.daily_quota_limit_equivalent,
+      tm.joined_at,
+      (
+        SELECT mu.used_equivalent
+        FROM member_usage mu
+        WHERE mu.team_id = tm.team_id
+          AND mu.user_id = tm.user_id
+          AND mu.date = (now() AT TIME ZONE 'Asia/Shanghai')::date
+        LIMIT 1
+      ) AS today_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = tm.team_id
+          AND j.user_id = tm.user_id
+          AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+      ), 0) AS month_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = tm.team_id
+          AND j.user_id = tm.user_id
+      ), 0) AS total_usage
+    FROM team_members tm
+    JOIN profiles p ON p.id = tm.user_id
+    WHERE tm.team_id = p_team_id
+    ORDER BY tm.joined_at, tm.user_id
+  ) item;
+
+  RETURN json_build_object(
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_team_members(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_team_members(uuid)
+  IS 'Admin team member detail list. Admin only.';
+
+-- ============ 3. create_team ============
+CREATE OR REPLACE FUNCTION public.create_team(p_name TEXT)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_team_id UUID;
+  v_member_exists BOOLEAN;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_name IS NULL OR trim(p_name) = '' THEN
+    RAISE EXCEPTION 'team name is required';
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM team_members tm WHERE tm.user_id = v_user_id
+  ) INTO v_member_exists;
+
+  IF v_member_exists THEN
+    RAISE EXCEPTION 'already in a team';
+  END IF;
+
+  INSERT INTO teams (name, owner_id, plan, seats_limit, status)
+  VALUES (trim(p_name), v_user_id, 'free', 3, 'active')
+  RETURNING id INTO v_team_id;
+
+  INSERT INTO team_members (team_id, user_id, role)
+  VALUES (v_team_id, v_user_id, 'admin');
+
+  RETURN json_build_object(
+    'ok', true,
+    'team', json_build_object('id', v_team_id, 'role', 'admin')
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_team(text) TO authenticated;
+
+COMMENT ON FUNCTION public.create_team(text)
+  IS 'Create a team with the signed-in user as owner/admin member.';
+
+-- ============ 4. join_team_by_invite ============
+CREATE OR REPLACE FUNCTION public.join_team_by_invite(p_token TEXT)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_invite_id UUID;
+  v_team_id UUID;
+  v_role TEXT;
+  v_member_count INTEGER;
+  v_seats_limit INTEGER;
+  v_team_status TEXT;
+  v_member_exists BOOLEAN;
+  v_inserted_user UUID;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_token IS NULL OR trim(p_token) = '' THEN
+    RAISE EXCEPTION 'invite token is required';
+  END IF;
+
+  SELECT
+    i.id,
+    i.team_id,
+    COALESCE(NULLIF(i.role, ''), 'member'),
+    t.seats_limit,
+    t.status
+  INTO
+    v_invite_id,
+    v_team_id,
+    v_role,
+    v_seats_limit,
+    v_team_status
+  FROM team_invitations i
+  JOIN teams t ON t.id = i.team_id
+  WHERE i.token = upper(trim(p_token))
+  LIMIT 1
+  FOR UPDATE OF i;
+
+  IF v_invite_id IS NULL THEN
+    RAISE EXCEPTION 'invalid invite';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM team_invitations i
+    WHERE i.id = v_invite_id
+      AND i.expires_at > now()
+  ) THEN
+    RAISE EXCEPTION 'invite expired';
+  END IF;
+
+  IF v_team_status IS DISTINCT FROM 'active' THEN
+    RAISE EXCEPTION 'team not active';
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM team_members tm WHERE tm.user_id = v_user_id
+  ) INTO v_member_exists;
+
+  IF v_member_exists THEN
+    RAISE EXCEPTION 'already in a team';
+  END IF;
+
+  SELECT count(*)
+  INTO v_member_count
+  FROM team_members tm
+  WHERE tm.team_id = v_team_id;
+
+  IF v_member_count >= v_seats_limit THEN
+    RAISE EXCEPTION 'team seats full';
+  END IF;
+
+  INSERT INTO team_members (team_id, user_id, role)
+  VALUES (v_team_id, v_user_id, v_role)
+  ON CONFLICT (team_id, user_id) DO NOTHING
+  RETURNING user_id INTO v_inserted_user;
+
+  IF v_inserted_user IS NULL THEN
+    RAISE EXCEPTION 'already in team';
+  END IF;
+
+  DELETE FROM team_invitations WHERE id = v_invite_id;
+
+  RETURN json_build_object(
+    'ok', true,
+    'team', json_build_object('id', v_team_id, 'role', v_role)
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.join_team_by_invite(text) TO authenticated;
+
+COMMENT ON FUNCTION public.join_team_by_invite(text)
+  IS 'Join a team by a one-time 8-character invite token. Consumes the invitation.';
+
+-- ============ 5. get_team_detail ============
+CREATE OR REPLACE FUNCTION public.get_team_detail(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_row JSON;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM team_members tm
+    WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT json_build_object(
+    'id', t.id,
+    'name', t.name,
+    'owner_id', t.owner_id,
+    'owner_email', owner.email,
+    'owner_name', owner.display_name,
+    'owner_status', owner.status,
+    'plan', t.plan,
+    'seats_limit', t.seats_limit,
+    'status', t.status,
+    'created_at', t.created_at,
+    'member_count', (
+      SELECT count(*) FROM team_members tm
+      WHERE tm.team_id = t.id
+    ),
+    'active_member_count', (
+      SELECT count(*) FROM team_members tm
+      JOIN profiles mp ON mp.id = tm.user_id
+      WHERE tm.team_id = t.id AND mp.status = 'active'
+    ),
+    'subscription', CASE
+      WHEN EXISTS (SELECT 1 FROM subscriptions s WHERE s.team_id = t.id)
+      THEN (
+        SELECT json_build_object(
+          'plan', s.plan,
+          'status', s.status,
+          'seats', s.seats,
+          'current_period_start', s.current_period_start,
+          'current_period_end', s.current_period_end
+        )
+        FROM subscriptions s
+        WHERE s.team_id = t.id
+        ORDER BY s.created_at DESC
+        LIMIT 1
+      )
+      ELSE NULL
+    END,
+    'month_usage', COALESCE((
+      SELECT SUM(COALESCE(j.equivalent_count, 0))
+      FROM jobs j
+      WHERE j.team_id = t.id
+        AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+    ), 0),
+    'total_usage', COALESCE((
+      SELECT SUM(COALESCE(j.equivalent_count, 0))
+      FROM jobs j
+      WHERE j.team_id = t.id
+    ), 0),
+    'key_count', (
+      SELECT count(*) FROM provider_keys pk
+      WHERE pk.team_id = t.id
+    ),
+    'current_user_role', (
+      SELECT tm.role FROM team_members tm
+      WHERE tm.team_id = t.id AND tm.user_id = v_user_id
+    )
+  )
+  INTO v_row
+  FROM teams t
+  LEFT JOIN profiles owner ON owner.id = t.owner_id
+  WHERE t.id = p_team_id;
+
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'team not found';
+  END IF;
+
+  RETURN json_build_object('team', v_row);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_team_detail(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_team_detail(uuid)
+  IS 'Team detail for the signed-in member, including owner profile and usage summary.';
+
+-- ============ 6. get_team_members ============
+CREATE OR REPLACE FUNCTION public.get_team_members(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_items JSON;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM team_members tm
+    WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      tm.team_id,
+      tm.user_id,
+      p.email,
+      p.display_name,
+      p.status,
+      tm.role,
+      tm.daily_quota_limit_equivalent,
+      tm.joined_at,
+      (
+        SELECT mu.used_equivalent
+        FROM member_usage mu
+        WHERE mu.team_id = tm.team_id
+          AND mu.user_id = tm.user_id
+          AND mu.date = (now() AT TIME ZONE 'Asia/Shanghai')::date
+        LIMIT 1
+      ) AS today_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = tm.team_id
+          AND j.user_id = tm.user_id
+          AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+      ), 0) AS month_usage,
+      COALESCE((
+        SELECT SUM(COALESCE(j.equivalent_count, 0))
+        FROM jobs j
+        WHERE j.team_id = tm.team_id
+          AND j.user_id = tm.user_id
+      ), 0) AS total_usage
+    FROM team_members tm
+    JOIN profiles p ON p.id = tm.user_id
+    WHERE tm.team_id = p_team_id
+    ORDER BY tm.joined_at, tm.user_id
+  ) item;
+
+  RETURN json_build_object('items', v_items);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_team_members(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_team_members(uuid)
+  IS 'Team member list for the signed-in member, including profile and usage stats.';
+
+-- ============ 7. create_team_invite ============
+CREATE OR REPLACE FUNCTION public.create_team_invite(
+  p_team_id UUID,
+  p_email TEXT DEFAULT NULL,
+  p_role TEXT DEFAULT 'member',
+  p_expires_at TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_token TEXT;
+  v_invite_id UUID;
+  v_expires_at TIMESTAMPTZ;
+  v_member_count INTEGER;
+  v_seats_limit INTEGER;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM teams t WHERE t.id = p_team_id AND t.owner_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: only team owner can create invites' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_role IS NULL OR p_role NOT IN ('member', 'admin') THEN
+    RAISE EXCEPTION 'invalid invite role';
+  END IF;
+
+  SELECT t.seats_limit INTO v_seats_limit
+  FROM teams t WHERE t.id = p_team_id;
+
+  SELECT count(*) INTO v_member_count
+  FROM team_members tm WHERE tm.team_id = p_team_id;
+
+  IF v_member_count >= v_seats_limit THEN
+    RAISE EXCEPTION 'team seats full';
+  END IF;
+
+  v_token := upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 8));
+  v_expires_at := COALESCE(p_expires_at, now() + interval '7 days');
+
+  IF v_expires_at <= now() THEN
+    RAISE EXCEPTION 'invite expires_at must be in the future';
+  END IF;
+
+  INSERT INTO team_invitations (team_id, email, role, token, expires_at)
+  VALUES (p_team_id, NULLIF(trim(p_email), ''), p_role, v_token, v_expires_at)
+  RETURNING id INTO v_invite_id;
+
+  RETURN json_build_object(
+    'invite', json_build_object(
+      'id', v_invite_id,
+      'team_id', p_team_id,
+      'email', NULLIF(trim(p_email), ''),
+      'role', p_role,
+      'token', v_token,
+      'expires_at', v_expires_at,
+      'created_at', now()
+    )
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_team_invite(uuid, text, text, timestamptz) TO authenticated;
+
+COMMENT ON FUNCTION public.create_team_invite(uuid, text, text, timestamptz)
+  IS 'Create a one-time 7-day invite token for a team owner.';

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -49,6 +49,210 @@ export async function getTeamContext(
   return { id: data.team_id as string, role: data.role as TeamRole }
 }
 
+export interface TeamDetail {
+  id: string
+  name: string
+  owner_id: string
+  owner_email: string | null
+  owner_name: string | null
+  owner_status: string | null
+  plan: string
+  seats_limit: number
+  status: string
+  created_at: string
+  member_count: number
+  active_member_count: number
+  subscription: {
+    plan: string | null
+    status: string | null
+    seats: number | null
+    current_period_start: string | null
+    current_period_end: string | null
+  } | null
+  month_usage: number
+  total_usage: number
+  key_count: number
+  current_user_role: TeamRole
+}
+
+export interface TeamMemberView {
+  team_id: string
+  user_id: string
+  email: string | null
+  display_name: string | null
+  status: string | null
+  role: TeamRole
+  daily_quota_limit_equivalent: number | null
+  joined_at: string
+  today_usage: number
+  month_usage: number
+  total_usage: number
+}
+
+export interface TeamInvitation {
+  id: string
+  team_id: string
+  email: string | null
+  role: TeamRole | string
+  token: string
+  expires_at: string
+  created_at: string
+}
+
+export interface CreateTeamInviteOptions {
+  email?: string | null
+  role?: TeamRole | string
+  expiresAt?: string
+}
+
+export class TeamService {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async createTeam(name: string): Promise<TeamContext> {
+    const { data, error } = await this.client.rpc('create_team', { p_name: name })
+    if (error) throw error
+    const raw = data as { ok?: boolean; team?: { id?: string; role?: string } } | null
+    if (!raw?.team?.id) throw new Error('create_team RPC returned no team')
+    return {
+      id: raw.team.id,
+      role: (raw.team.role === 'admin' ? 'admin' : 'member') as TeamRole
+    }
+  }
+
+  async joinTeam(token: string): Promise<TeamContext> {
+    const { data, error } = await this.client.rpc('join_team_by_invite', { p_token: token })
+    if (error) throw error
+    const raw = data as { ok?: boolean; team?: { id?: string; role?: string } } | null
+    if (!raw?.team?.id) throw new Error('join_team_by_invite RPC returned no team')
+    return {
+      id: raw.team.id,
+      role: (raw.team.role === 'admin' ? 'admin' : 'member') as TeamRole
+    }
+  }
+
+  async getTeamDetail(teamId: string): Promise<TeamDetail | null> {
+    const { data, error } = await this.client.rpc('get_team_detail', { p_team_id: teamId })
+    if (error) throw error
+    const raw = data as { team?: Record<string, unknown> } | null
+    if (!raw?.team) return null
+    return normalizeTeamDetail(raw.team)
+  }
+
+  async listMembers(teamId: string): Promise<TeamMemberView[]> {
+    const { data, error } = await this.client.rpc('get_team_members', { p_team_id: teamId })
+    if (error) throw error
+    const raw = data as { items?: Array<Record<string, unknown>> } | null
+    return (raw?.items ?? []).map((it) => normalizeTeamMember(it))
+  }
+
+  async createInvite(teamId: string, opts: CreateTeamInviteOptions = {}): Promise<TeamInvitation> {
+    const { data, error } = await this.client.rpc('create_team_invite', {
+      p_team_id: teamId,
+      p_email: opts.email ?? null,
+      p_role: opts.role ?? 'member',
+      p_expires_at: opts.expiresAt ?? null
+    })
+    if (error) throw error
+    const raw = data as { invite?: Record<string, unknown> } | null
+    if (!raw?.invite) throw new Error('create_team_invite RPC returned no invite')
+    return normalizeInvitation(raw.invite)
+  }
+
+  async listInvitations(teamId: string): Promise<TeamInvitation[]> {
+    const { data, error } = await this.client
+      .from('team_invitations')
+      .select('id, team_id, email, role, token, expires_at, created_at')
+      .eq('team_id', teamId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return (data ?? []).map((it) => normalizeInvitation(it as Record<string, unknown>))
+  }
+
+  async removeMember(teamId: string, targetUserId: string): Promise<boolean> {
+    const { error, count } = await this.client
+      .from('team_members')
+      .delete({ count: 'exact' })
+      .eq('team_id', teamId)
+      .eq('user_id', targetUserId)
+    if (error) throw error
+    return (count ?? 0) > 0
+  }
+
+  async updateMemberLimit(teamId: string, targetUserId: string, limit: number | null): Promise<void> {
+    const { error } = await this.client
+      .from('team_members')
+      .update({ daily_quota_limit_equivalent: limit })
+      .eq('team_id', teamId)
+      .eq('user_id', targetUserId)
+    if (error) throw error
+  }
+}
+
+function normalizeTeamDetail(it: Record<string, unknown>): TeamDetail {
+  return {
+    id: String(it.id ?? ''),
+    name: String(it.name ?? ''),
+    owner_id: String(it.owner_id ?? ''),
+    owner_email: (it.owner_email as string | null) ?? null,
+    owner_name: (it.owner_name as string | null) ?? null,
+    owner_status: (it.owner_status as string | null) ?? null,
+    plan: String(it.plan ?? ''),
+    seats_limit: Number(it.seats_limit ?? 0),
+    status: String(it.status ?? ''),
+    created_at: String(it.created_at ?? ''),
+    member_count: Number(it.member_count ?? 0),
+    active_member_count: Number(it.active_member_count ?? 0),
+    subscription: normalizeSubscription(it.subscription as Record<string, unknown> | null),
+    month_usage: Number(it.month_usage ?? 0),
+    total_usage: Number(it.total_usage ?? 0),
+    key_count: Number(it.key_count ?? 0),
+    current_user_role: (it.current_user_role === 'admin' ? 'admin' : 'member') as TeamRole
+  }
+}
+
+function normalizeSubscription(
+  it: Record<string, unknown> | null | undefined
+): TeamDetail['subscription'] {
+  if (!it) return null
+  return {
+    plan: (it.plan as string | null) ?? null,
+    status: (it.status as string | null) ?? null,
+    seats: it.seats == null ? null : Number(it.seats),
+    current_period_start: (it.current_period_start as string | null) ?? null,
+    current_period_end: (it.current_period_end as string | null) ?? null
+  }
+}
+
+function normalizeTeamMember(it: Record<string, unknown>): TeamMemberView {
+  return {
+    team_id: String(it.team_id ?? ''),
+    user_id: String(it.user_id ?? ''),
+    email: (it.email as string | null) ?? null,
+    display_name: (it.display_name as string | null) ?? null,
+    status: (it.status as string | null) ?? null,
+    role: (it.role === 'admin' ? 'admin' : 'member') as TeamRole,
+    daily_quota_limit_equivalent: it.daily_quota_limit_equivalent == null
+      ? null
+      : Number(it.daily_quota_limit_equivalent),
+    joined_at: String(it.joined_at ?? ''),
+    today_usage: Number(it.today_usage ?? 0),
+    month_usage: Number(it.month_usage ?? 0),
+    total_usage: Number(it.total_usage ?? 0)
+  }
+}
+
+function normalizeInvitation(it: Record<string, unknown>): TeamInvitation {
+  return {
+    id: String(it.id ?? ''),
+    team_id: String(it.team_id ?? ''),
+    email: (it.email as string | null) ?? null,
+    role: String(it.role ?? 'member'),
+    token: String(it.token ?? ''),
+    expires_at: String(it.expires_at ?? ''),
+    created_at: String(it.created_at ?? '')
+  }
+}
+
 /* ================= 数据一致性：错误码 + Quota Operation ================= */
 
 export type LedgerErrorCode =


### PR DESCRIPTION
Closes #15

## 提交信息
feat: 团队模块 MVP（桌面端团队管理 + admin 团队页 + RPC）

- desktop: 团队页（创建/加入/成员管理/切换团队），团队额度共享看板
- desktop: useAuth 增加团队上下文（teamId 切换后数据树重建）
- admin: 团队管理页（列表/成员查看/解散）
- db: 0013_team_rpc.sql（团队 CRUD RPC + 邀请码），index.ts 对应 API
- docs: team-module-mvp.md 设计文档