### PR TITLE
feat: 团队额度与账号作用域（额度池共享 + 成员账号授权 + 刷新频率配置）

### DIFF
--- a/apps/admin/src/components/teams/team-detail-modal.tsx
+++ b/apps/admin/src/components/teams/team-detail-modal.tsx
@@ -5,6 +5,7 @@ import type { AdminTeam, AdminTeamMember, TeamStatus } from "@/lib/api/teams";
 import {
   listTeamMembers,
   planLabel,
+  resetTeamQuota,
   statusLabel,
   subscriptionLabel,
   updateTeamSettings
@@ -29,6 +30,8 @@ export function TeamDetailModal({
   const [status, setStatus] = useState<TeamStatus>("active");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [resettingQuota, setResettingQuota] = useState(false);
+  const [resetNotice, setResetNotice] = useState<string | null>(null);
 
   useEffect(() => {
     if (!team) return;
@@ -37,6 +40,7 @@ export function TeamDetailModal({
     setSeats(String(team.seats_limit || 3));
     setStatus(team.status);
     setSaveError(null);
+    setResetNotice(null);
 
     let cancelled = false;
     setLoadingMembers(true);
@@ -86,6 +90,30 @@ export function TeamDetailModal({
       setSaveError(e instanceof Error ? e.message : "保存失败");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleResetQuota() {
+    if (!currentTeam) return;
+    setResettingQuota(true);
+    setSaveError(null);
+    setResetNotice(null);
+    try {
+      await resetTeamQuota(currentTeam.id);
+      const quota = currentTeam.quota
+        ? { ...currentTeam.quota, used: 0, remaining: currentTeam.quota.daily_total }
+        : currentTeam.quota;
+      const next = {
+        ...currentTeam,
+        quota,
+        status: currentTeam.status === "exhausted" ? "active" : currentTeam.status
+      };
+      onSaved(next);
+      setResetNotice("今日额度已重置");
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "重置额度失败");
+    } finally {
+      setResettingQuota(false);
     }
   }
 
@@ -153,7 +181,21 @@ export function TeamDetailModal({
             </div>
             <div className="form-group" style={{ marginBottom: 0 }}>
               <label className="form-label">成员 / 席位</label>
-              <div style={{ fontSize: 14, paddingTop: 9 }}>{team.active_member_count}/{team.seats_limit} 可用</div>
+              <div style={{ fontSize: 14, paddingTop: 9 }}>{team.active_member_count}/{team.seats_limit}</div>
+            </div>
+          </div>
+
+          <div className="form-row" style={{ marginBottom: 20 }}>
+            <div className="form-group" style={{ marginBottom: 0 }}>
+              <label className="form-label">共享额度</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>
+                {team.quota ? `${Math.round(team.quota.used)}/${Math.round(team.quota.daily_total)}` : "-"}
+              </div>
+            </div>
+            <div className="form-group" style={{ marginBottom: 0, display: "flex", alignItems: "flex-end" }}>
+              <button className="btn btn-secondary btn-sm" disabled={resettingQuota} onClick={() => void handleResetQuota()}>
+                {resettingQuota ? "重置中..." : "重置今日额度"}
+              </button>
             </div>
           </div>
 
@@ -248,6 +290,11 @@ export function TeamDetailModal({
           {saveError ? (
             <div style={{ marginTop: 12, fontSize: 13, color: "var(--color-destructive)" }}>
               {saveError}
+            </div>
+          ) : null}
+          {resetNotice ? (
+            <div style={{ marginTop: 12, fontSize: 13, color: "var(--color-success)" }}>
+              {resetNotice}
             </div>
           ) : null}
         </div>

--- a/apps/admin/src/lib/api/teams.ts
+++ b/apps/admin/src/lib/api/teams.ts
@@ -12,6 +12,14 @@ export interface AdminTeamSubscription {
   current_period_end: string | null;
 }
 
+export interface AdminTeamQuota {
+  provider_id: string;
+  daily_total: number;
+  used: number;
+  remaining: number;
+  reserved: number;
+}
+
 export interface AdminTeam {
   id: string;
   name: string;
@@ -26,6 +34,7 @@ export interface AdminTeam {
   member_count: number;
   active_member_count: number;
   subscription: AdminTeamSubscription | null;
+  quota: AdminTeamQuota | null;
   month_usage: number;
   total_usage: number;
   key_count: number;
@@ -126,6 +135,17 @@ export async function updateTeamSettings(teamId: string, input: TeamSettingsInpu
   }
 }
 
+export async function resetTeamQuota(teamId: string): Promise<void> {
+  const supabase = createAdminBrowserClient();
+  const { data, error } = await supabase.rpc("admin_reset_team_quota", {
+    p_team_id: teamId
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { ok: false }) as { ok?: boolean };
+  if (!raw.ok) throw new Error("重置团队额度失败");
+}
+
 export function statusLabel(status: TeamStatus | string): string {
   if (status === "banned") return "已封禁";
   if (status === "exhausted") return "额度耗尽";
@@ -166,9 +186,21 @@ function normalizeTeam(it: Record<string, unknown>): AdminTeam {
     member_count: Number(it.member_count ?? 0),
     active_member_count: Number(it.active_member_count ?? 0),
     subscription: normalizeSubscription(it.subscription as Record<string, unknown> | null),
+    quota: normalizeQuota(it.quota as Record<string, unknown> | null),
     month_usage: Number(it.month_usage ?? 0),
     total_usage: Number(it.total_usage ?? 0),
     key_count: Number(it.key_count ?? 0)
+  };
+}
+
+function normalizeQuota(it: Record<string, unknown> | null | undefined): AdminTeamQuota | null {
+  if (!it) return null;
+  return {
+    provider_id: String(it.provider_id ?? ""),
+    daily_total: Number(it.daily_total ?? 0),
+    used: Number(it.used ?? 0),
+    remaining: Number(it.remaining ?? 0),
+    reserved: Number(it.reserved ?? 0)
   };
 }
 

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -17,6 +17,7 @@ export interface GenerateInput {
   accessToken: string
   refreshToken: string
   userId: string
+  teamId?: string | null
   prompt: string
   providerId: string
   durationSec: number
@@ -209,6 +210,7 @@ export async function runGenerate(
   let job
   try {
     job = await jobSvc.insertJob(input.userId, {
+      teamId: input.teamId,
       mode: input.mode === 'img2video' ? 'img2video' : 'text2video',
       prompt: input.prompt,
       status: 'pending',
@@ -251,7 +253,9 @@ export async function runGenerate(
     watermarkEnabled: input.watermarkEnabled !== false
   }
   if (jobImages.length > 0) jobOptions.images = jobImages
-  const keys = await providerSvc.listProviderKeys(input.userId)
+  const keys = input.teamId
+    ? await providerSvc.listTeamProviderKeys(input.teamId)
+    : (await providerSvc.listProviderKeys(input.userId)).filter((k) => !k.team_id)
   const doubaoKeys = keys.filter((k) => k.provider_id === 'doubao' && k.enabled !== false)
 
   let selectedKey: { id: string; accountName: string | null } | null = null
@@ -270,27 +274,12 @@ export async function runGenerate(
     return { ok: false, jobId: job.id, error: err }
   } else {
     try {
-      const providers = await providerSvc.listProviders()
-      const doubaoMeta = providers.find((p) => p.id === 'doubao')
-      const dailyTotal = Number(doubaoMeta?.default_daily_quota ?? 10)
-      const unitName = doubaoMeta?.unit_name ?? '点'
       const today = todayKey()
-      const ledgers = await providerSvc.listLedger(input.userId)
-
-      // 确保每个账号今日 ledger 行存在（每日 0 点重置）
-      for (const k of doubaoKeys) {
-        const hasToday = ledgers.some((l) => l.account_key_id === k.id && l.date === today)
-        if (!hasToday) {
-          await providerSvc.getOrInitLedger({
-            userId: input.userId,
-            providerId: 'doubao',
-            unitName,
-            dailyTotal,
-            keyId: k.id
-          })
-        }
-      }
-      const freshLedgers = await providerSvc.listLedger(input.userId)
+      // 批量确保今日 ledger 行存在，避免逐账号请求拖慢生成前的额度排序。
+      await providerSvc.ensureProviderLedgerRows(input.userId, input.teamId ?? null, doubaoKeys.map((k) => k.id))
+      const freshLedgers = input.teamId
+        ? await providerSvc.listTeamTodayLedger(input.teamId)
+        : await providerSvc.listTodayLedger(input.userId)
       const remainingOf = (keyId: string): number => {
         const row = freshLedgers.find((l) => l.account_key_id === keyId && l.date === today)
         // 用 daily_total - used - reserved 而非 remaining，与 RPC 原子扣减条件一致
@@ -450,16 +439,31 @@ export async function runGenerate(
 
   // 先扣额度（原子 RPC），成功后再写 job success；
   // 失败则 job 标记 failed，通过 reconciliation 兜底追记
-  let consumed: Awaited<ReturnType<typeof providerSvc.consumeLedger>> | null = null
+  let consumed: QuotaLedgerRow | null = null
   try {
-    consumed = await providerSvc.consumeLedger(input.userId, 'doubao', cost, {
-      unitName: '点',
-      keyId: selectedKey?.id ?? undefined
-    })
-    if (selectedKey?.id && consumed) {
-      await providerSvc.insertQuotaOperation(job.id, consumed.id, 'finalize', cost)
+    if (input.teamId) {
+      const teamResult = await providerSvc.consumeTeamQuotaAndFinalize({
+        teamId: input.teamId,
+        userId: input.userId,
+        providerId: 'doubao',
+        amount: cost,
+        keyId: selectedKey?.id ?? null,
+        jobId: job.id
+      })
+      if (!teamResult.ok) {
+        throw new Error(`[${teamResult.code || 'UNKNOWN'}] ${teamResult.message || '额度扣减失败'}`)
+      }
+      consumed = teamResult.row ?? null
+    } else {
+      consumed = await providerSvc.consumeLedger(input.userId, 'doubao', cost, {
+        unitName: '点',
+        keyId: selectedKey?.id ?? undefined
+      })
+      if (selectedKey?.id && consumed) {
+        await providerSvc.insertQuotaOperation(job.id, consumed.id, 'finalize', cost)
+      }
     }
-    onQuotaUpdated?.({ userId: input.userId, ledger: consumed })
+    if (consumed) onQuotaUpdated?.({ userId: input.userId, ledger: consumed })
   } catch (e) {
     const errMsg = '额度扣减失败: ' + (e instanceof Error ? e.message : String(e))
     await jobSvc.updateJob(input.userId, job.id, {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -437,14 +437,26 @@ app.whenReady().then(() => {
       const unfinalized = await providerSvc.findUnfinalizedJobs(params.userId)
       for (const u of unfinalized) {
         try {
-          const { data, error } = await client.rpc('reconcile_consume_and_finalize', {
-            p_user_id: params.userId,
-            p_provider_id: 'doubao',
-            p_amount: u.costAmount,
-            p_key_id: u.keyId,
-            p_date: todayKey(),
-            p_job_id: u.jobId
-          })
+          const rpcName = u.teamId ? 'team_consume_quota_and_finalize' : 'reconcile_consume_and_finalize'
+          const rpcArgs = u.teamId
+            ? {
+                p_team_id: u.teamId,
+                p_user_id: params.userId,
+                p_provider_id: 'doubao',
+                p_amount: u.costAmount,
+                p_account_key_id: u.keyId,
+                p_date: todayKey(),
+                p_job_id: u.jobId
+              }
+            : {
+                p_user_id: params.userId,
+                p_provider_id: 'doubao',
+                p_amount: u.costAmount,
+                p_key_id: u.keyId,
+                p_date: todayKey(),
+                p_job_id: u.jobId
+              }
+          const { data, error } = await client.rpc(rpcName, rpcArgs)
           if (error) throw error
           const result = data as unknown as { ok: boolean; code?: string }
           if (result.ok && result.code !== 'ALREADY_FINALIZED') {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -118,6 +118,7 @@ export interface GenerateRequest {
   accessToken: string
   refreshToken: string
   userId: string
+  teamId?: string | null
   prompt: string
   providerId: string
   durationSec: number

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,7 +13,7 @@ import { useAuth } from './hooks/useAuth'
 import type { AuthUser } from './hooks/useAuth'
 import { useProviders } from './hooks/useProviders'
 import { useJobs } from './hooks/useJobs'
-import type { TeamContext } from '@quota-flow/db-supabase'
+import type { TeamContext, UsageScope, ViewScope } from '@quota-flow/db-supabase'
 import {
   Modal,
   ProfileModal,
@@ -26,6 +26,7 @@ import {
 import { getSupabaseConfig, getAuthService } from './auth/service'
 import {
   IconClock,
+  IconChevron,
   IconGear,
   IconGrid,
   IconLogout,
@@ -36,6 +37,16 @@ import {
 import desktopPackage from '../../../package.json'
 
 type TabId = 'dispatch' | 'providers' | 'history' | 'team'
+
+function readStoredViewScope(hasTeam: boolean): ViewScope {
+  const stored = localStorage.getItem('qf-view-scope')
+  if (hasTeam && (stored === 'team' || stored === 'global')) return stored
+  return hasTeam ? 'global' : 'personal'
+}
+
+function readStoredUsageScope(): UsageScope {
+  return localStorage.getItem('qf-usage-scope') === 'team' ? 'team' : 'personal'
+}
 
 interface TabDef {
   id: TabId
@@ -96,8 +107,10 @@ function MainApp({
   onSignOut,
   onRefreshTeam
 }: MainAppProps) {
+  const [viewScope, setViewScope] = useState<ViewScope>(() => readStoredViewScope(!!team))
+  const [usageScope, setUsageScope] = useState<UsageScope>(readStoredUsageScope)
   // 厂商 / 任务数据提升到 MainApp 层：随 user 挂载/卸载，账号切换时整棵数据树重建，避免残留上一账号数据
-  const providers = useProviders()
+  const providers = useProviders(viewScope)
   const jobs = useJobs()
   const [bannerDismissed, setBannerDismissed] = useState(() => readWelcomeDismissed(user.id))
   const onboardStep = useMemo<1 | 2 | 3>(() => {
@@ -131,16 +144,78 @@ function MainApp({
       ? (t as TabId)
       : 'dispatch'
   })
+  const providersTabActiveRef = useRef(tab === 'providers')
   const [toast, setToast] = useState<string | null>(null)
   const toastTimer = useRef<number | undefined>(undefined)
+  const [scopeOpen, setScopeOpen] = useState(false)
+  const scopeWrapRef = useRef<HTMLDivElement | null>(null)
   const [renewText, setRenewText] = useState('自动续命：—')
   const [updatePromptVisible, setUpdatePromptVisible] = useState(false)
+
+  useEffect(() => {
+    const wasActive = providersTabActiveRef.current
+    providersTabActiveRef.current = tab === 'providers'
+    if (!wasActive && tab === 'providers') providers.reload()
+  }, [tab, providers.reload])
+
+  const scopeLabel = useMemo(() => {
+    if (viewScope === 'team') return '团队模式'
+    if (viewScope === 'global') return '全局模式'
+    return '个人模式'
+  }, [viewScope])
 
   const showToast = useCallback((msg: string) => {
     setToast(msg)
     window.clearTimeout(toastTimer.current)
     toastTimer.current = window.setTimeout(() => setToast(null), 2200)
   }, [])
+
+  const switchViewScope = useCallback((scope: ViewScope) => {
+    if (scope === 'team' && !team) {
+      showToast('请先加入团队')
+      return
+    }
+    setViewScope(scope)
+    localStorage.setItem('qf-view-scope', scope)
+    if (scope === 'personal') {
+      setUsageScope('personal')
+      localStorage.setItem('qf-usage-scope', 'personal')
+    } else if (scope === 'team') {
+      setUsageScope('team')
+      localStorage.setItem('qf-usage-scope', 'team')
+    }
+  }, [team, showToast])
+
+  const switchUsageScope = useCallback((scope: UsageScope) => {
+    setUsageScope(scope)
+    localStorage.setItem('qf-usage-scope', scope)
+  }, [])
+
+  useEffect(() => {
+    if (!scopeOpen) return
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (!scopeWrapRef.current?.contains(event.target as Node)) {
+        setScopeOpen(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setScopeOpen(false)
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [scopeOpen])
+
+  useEffect(() => {
+    if (!team && (viewScope === 'team' || viewScope === 'global')) {
+      switchViewScope('personal')
+    }
+  }, [team, viewScope, switchViewScope])
 
   useEffect(() => {
     applyTheme(getInitialTheme())
@@ -231,9 +306,69 @@ function MainApp({
         })}
 
         <div className="user-area">
-          <div className="team-badge">
-            <IconUsers size={10} />
-            {team ? '团队 · ' + team.id.slice(0, 8) : providers.totalBound > 0 || !fresh ? '个人模式' : '新用户 · 未绑定'}
+          <div
+            className={'scope-switcher' + (scopeOpen ? ' open' : '')}
+            ref={scopeWrapRef}
+            aria-label="账号显示模式"
+          >
+            <button
+              className="scope-trigger"
+              type="button"
+              aria-haspopup="listbox"
+              aria-expanded={scopeOpen}
+              onClick={() => setScopeOpen((open) => !open)}
+              title="点击切换账号显示模式"
+            >
+              <IconUsers size={12} />
+              <span>{scopeLabel}</span>
+              <IconChevron size={11} className="scope-chevron" />
+            </button>
+            <div className="scope-menu" role="listbox" aria-label="账号显示模式">
+              <button
+                className={'scope-option' + (viewScope === 'personal' ? ' active' : '')}
+                type="button"
+                role="option"
+                aria-selected={viewScope === 'personal'}
+                onClick={() => {
+                  switchViewScope('personal')
+                  setScopeOpen(false)
+                }}
+                title="只显示个人账号，使用个人额度"
+              >
+                <span>个人模式</span>
+                {viewScope === 'personal' && <span className="scope-option-check">✓</span>}
+              </button>
+              <button
+                className={'scope-option' + (viewScope === 'team' ? ' active' : '')}
+                type="button"
+                role="option"
+                aria-selected={viewScope === 'team'}
+                disabled={!team}
+                onClick={() => {
+                  switchViewScope('team')
+                  setScopeOpen(false)
+                }}
+                title={team ? '只显示团队账号，使用团队额度' : '加入团队后可切换'}
+              >
+                <span>团队模式</span>
+                {viewScope === 'team' && <span className="scope-option-check">✓</span>}
+              </button>
+              <button
+                className={'scope-option' + (viewScope === 'global' ? ' active' : '')}
+                type="button"
+                role="option"
+                aria-selected={viewScope === 'global'}
+                disabled={!team}
+                onClick={() => {
+                  switchViewScope('global')
+                  setScopeOpen(false)
+                }}
+                title={team ? '同时显示个人账号和团队账号，可在生成时选择额度' : '加入团队后可切换'}
+              >
+                <span>全局模式</span>
+                {viewScope === 'global' && <span className="scope-option-check">✓</span>}
+              </button>
+            </div>
           </div>
           <NotificationBell userId={user.id} />
           <div className="avatar-wrap">
@@ -280,6 +415,9 @@ function MainApp({
               fresh={fresh}
               banner={bannerVisible}
               step={onboardStep}
+              viewScope={viewScope}
+              usageScope={usageScope}
+              onUsageScopeChange={switchUsageScope}
               onGoHistory={() => setTab('history')}
               onGoProviders={() => setTab('providers')}
               providers={providers}
@@ -287,13 +425,14 @@ function MainApp({
             />
           </div>
           <div className="tab-pane" style={{ display: tab === 'providers' ? 'flex' : 'none' }}>
-            <Providers fresh={fresh} providers={providers} />
+            <Providers fresh={fresh} viewScope={viewScope} usageScope={usageScope} providers={providers} />
           </div>
           <div className="tab-pane" style={{ display: tab === 'history' ? 'flex' : 'none' }}>
             <History jobs={jobs} />
           </div>
           <div className="tab-pane" style={{ display: tab === 'team' ? 'flex' : 'none' }}>
             <Team
+              active={tab === 'team'}
               fresh={fresh}
               userId={user.id}
               team={team}

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -15,6 +15,7 @@ import type { JobItem } from '../hooks/useJobs'
 import { useAuth } from '../hooks/useAuth'
 import type { ProvidersResult } from '../hooks/useProviders'
 import type { JobsResult } from '../hooks/useJobs'
+import type { UsageScope, ViewScope } from '@quota-flow/db-supabase'
 import { getAuthService, getSupabaseConfig } from '../auth/service'
 import { ensureFreshSession } from '../auth/session'
 import { VideoThumb } from './VideoThumb'
@@ -60,6 +61,9 @@ interface DashboardProps {
   fresh: boolean
   banner: boolean
   step: 1 | 2 | 3
+  viewScope: ViewScope
+  usageScope: UsageScope
+  onUsageScopeChange: (scope: UsageScope) => void
   onGenerate?: () => void
   onGoHistory: () => void
   onGoProviders: () => void
@@ -67,9 +71,21 @@ interface DashboardProps {
   jobs: JobsResult
 }
 
-export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory, onGoProviders, providers, jobs }: DashboardProps) {
+export default function Dashboard({
+  fresh,
+  banner,
+  step,
+  viewScope,
+  usageScope,
+  onUsageScopeChange,
+  onGenerate,
+  onGoHistory,
+  onGoProviders,
+  providers,
+  jobs
+}: DashboardProps) {
   const { aggs: provAggs } = providers
-  const { user } = useAuth()
+  const { user, team } = useAuth()
   const { items: jobItems, reload: reloadJobs } = jobs
   const [provider, setProvider] = useState('auto')
   const [model, setModel] = useState(MODELS.auto[0])
@@ -307,6 +323,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
         accessToken: session.access_token,
         refreshToken: session.refresh_token,
         userId: user.id,
+        teamId: usageScope === 'team' ? team?.id ?? null : null,
         prompt: prompt.trim(),
         providerId: provider === 'auto' ? 'doubao' : provider,
         durationSec: duration,
@@ -335,7 +352,7 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, duration, durations, resolution, audio, ratio, watermark, imageFiles, user, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, duration, durations, resolution, audio, ratio, watermark, imageFiles, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -511,6 +528,20 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
                 ]}
               />
             </div>
+            {viewScope === 'global' && team ? (
+              <div className="param-field">
+                <label htmlFor="usage-scope">生成额度</label>
+                <Select
+                  id="usage-scope"
+                  value={usageScope}
+                  onChange={(v) => onUsageScopeChange(v as UsageScope)}
+                  options={[
+                    { value: 'personal', label: '个人额度' },
+                    { value: 'team', label: '团队额度' }
+                  ]}
+                />
+              </div>
+            ) : null}
             <div className="param-field">
               <label htmlFor="watermark">去水印</label>
               <label className="switch watermark-switch">
@@ -526,9 +557,11 @@ export default function Dashboard({ fresh, banner, step, onGenerate, onGoHistory
                 <span className="switch-label">{watermark ? '开' : '关'}</span>
               </label>
             </div>
-            <div className="param-field">
-              <span className="field-hint">配音 / 比例不影响额度</span>
-            </div>
+            {!(viewScope === 'global' && team) ? (
+              <div className="param-field">
+                <span className="field-hint">配音 / 比例不影响额度</span>
+              </div>
+            ) : null}
           </div>
 
           {mode !== 't2v' && (

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -455,13 +455,17 @@ function ProviderSelect({
 export function AddProviderModal({
   providers,
   userId,
+  team,
   initialProviderId,
+  defaultScope = 'personal',
   onClose,
   onDone
 }: {
   providers: ProviderOption[]
   userId: string
+  team?: TeamContext | null
   initialProviderId?: string
+  defaultScope?: 'personal' | 'team'
   onClose: () => void
   onDone?: () => void
 }) {
@@ -469,6 +473,9 @@ export function AddProviderModal({
     initialProviderId && providers.some((p) => p.providerId === initialProviderId && p.enabled !== false)
       ? initialProviderId
       : (firstEnabledProvider(providers)?.providerId ?? '')
+  )
+  const [accountScope, setAccountScope] = useState<'personal' | 'team'>(
+    defaultScope === 'team' && !!team ? 'team' : 'personal'
   )
   const [status, setStatus] = useState<'idle' | 'logging' | 'pick-account' | 'login-ok' | 'login-fail' | 'apikey-ok'>('idle')
   const [apiKey, setApiKey] = useState('')
@@ -535,6 +542,10 @@ export function AddProviderModal({
     try {
       const svc = getProviderService()
       if (!svc) throw new Error('数据库服务未配置')
+      const targetTeamId = accountScope === 'team' && team ? team.id : null
+      const scopeKeys = accountScope === 'team' && team
+        ? await svc.listTeamProviderKeys(team.id)
+        : (await svc.listProviderKeys(userId)).filter((k) => !k.team_id)
 
       // 用户明确选择「刷新已有账号」：直接更新该 key 的 cookie（保留 keyId 与额度归属）
       if (refreshKeyId) {
@@ -558,8 +569,14 @@ export function AddProviderModal({
 
       // P2 去重：同一账号指纹已存在则拦截（指纹为 null 时跳过）
       if (accountFingerprint) {
-        const dup = await svc.findDuplicateFingerprint(userId, providerId, accountFingerprint)
+        const dup =
+          scopeKeys.find(
+            (k) => k.provider_id === providerId && k.account_fingerprint === accountFingerprint
+          ) ?? null
         if (dup) {
+          if (accountScope === 'team' && team && dup.owner_user_id !== userId) {
+            throw new Error('该账号已由其他成员绑定，请由绑定成员刷新')
+          }
           // 同一账号重新登录：刷新 cookie，保留 keyId 与额度归属
           await svc.refreshProviderKey(userId, dup.id, {
             encryptedKey: encrypted,
@@ -579,7 +596,7 @@ export function AddProviderModal({
       }
 
       // 备注为空时兜底自动命名：<厂商名> 账号 N（按该厂商第 N 个绑定递增）
-      const allKeys = await svc.listProviderKeys(userId)
+      const allKeys = scopeKeys
       const sameProvider = allKeys.filter((k) => k.provider_id === providerId)
       const seq = sameProvider.length + 1
       const name = accountName.trim() || `${selected?.name ?? providerId} 账号 ${seq}`
@@ -588,6 +605,7 @@ export function AddProviderModal({
       const saved = await svc.addProviderKey({
         providerId,
         ownerUserId: userId,
+        teamId: targetTeamId,
         encryptedKey: encrypted,
         accountName: name,
         authType,
@@ -606,7 +624,8 @@ export function AddProviderModal({
           providerId,
           unitName: p?.unit_name ?? '',
           dailyTotal: Number(p?.default_daily_quota ?? 0),
-          keyId: saved.id
+          keyId: saved.id,
+          teamId: targetTeamId
         })
       }
     } catch (e) {
@@ -655,9 +674,12 @@ export function AddProviderModal({
       let existing: Array<{ id: string; accountName: string }> = []
       if (svc) {
         try {
-          const keys = await svc.listProviderKeys(userId)
+          const keys = accountScope === 'team' && team
+            ? await svc.listTeamProviderKeys(team.id)
+            : (await svc.listProviderKeys(userId)).filter((k) => !k.team_id)
           existing = keys
             .filter((k) => k.provider_id === selected.providerId)
+            .filter((k) => accountScope !== 'team' || k.owner_user_id === userId)
             .map((k) => ({ id: k.id, accountName: k.account_name ?? '未命名账号' }))
         } catch {}
       }
@@ -665,8 +687,19 @@ export function AddProviderModal({
       // 指纹去重优先：匹配到已有账号 → 直接刷新（不弹选择）；指纹能识别且无重复 → 暂存待「完成」时保存
       if (res.accountFingerprint && svc) {
         try {
-          const dup = await svc.findDuplicateFingerprint(userId, selected.providerId, res.accountFingerprint)
+          const scopeKeys = accountScope === 'team' && team
+            ? await svc.listTeamProviderKeys(team.id)
+            : (await svc.listProviderKeys(userId)).filter((k) => !k.team_id)
+          const dup =
+            scopeKeys.find(
+              (k) => k.provider_id === selected.providerId && k.account_fingerprint === res.accountFingerprint
+            ) ?? null
           if (dup) {
+            if (accountScope === 'team' && team && dup.owner_user_id !== userId) {
+              setError('该账号已由其他成员绑定，请由绑定成员刷新')
+              setStatus('login-fail')
+              return
+            }
             await svc.refreshProviderKey(userId, dup.id, {
               encryptedKey: res.encrypted,
               expiresAt: res.expiresAt ? new Date(res.expiresAt).toISOString() : null,
@@ -756,6 +789,22 @@ export function AddProviderModal({
           </p>
         )}
       </div>
+      {team ? (
+        <div className="form-group">
+          <label>账号归属</label>
+          <Select
+            value={accountScope}
+            onChange={(v) => setAccountScope(v as 'personal' | 'team')}
+            options={[
+              { value: 'personal', label: '个人账号（使用个人额度）' },
+              { value: 'team', label: '团队账号（共享给团队，使用团队额度）' }
+            ]}
+          />
+          <p style={{ margin: '6px 0 0', fontSize: '12px', color: 'var(--fg-muted)' }}>
+            团队账号会显示给团队内成员，并进入团队额度调度。
+          </p>
+        </div>
+      ) : null}
       <div className="form-group">
         <label>账号备注</label>
         <input

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from './EmptyState'
 import Select from './Select'
 import type { ProviderAgg, ProvidersResult } from '../hooks/useProviders'
 import { useAuth } from '../hooks/useAuth'
+import type { UsageScope, ViewScope } from '@quota-flow/db-supabase'
 
 const PAGE_SIZE = 10
 
@@ -19,13 +20,15 @@ function statusBadge(p: ProviderAgg): { cls: string; label: string } {
 
 interface ProvidersProps {
   fresh: boolean
+  viewScope: ViewScope
+  usageScope: UsageScope
   onBound?: () => void
   providers: ProvidersResult
 }
 
-export default function Providers({ fresh, onBound, providers }: ProvidersProps) {
-  const { user } = useAuth()
-  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, unbind } = providers
+export default function Providers({ fresh, viewScope, usageScope, onBound, providers }: ProvidersProps) {
+  const { user, team } = useAuth()
+  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind } = providers
   const [text, setText] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -111,6 +114,9 @@ export default function Providers({ fresh, onBound, providers }: ProvidersProps)
         )}
 
       <div className="provider-table-wrap">
+        {(loading || refreshing) && (
+          <div className="table-refresh-overlay">{loading ? '加载中...' : '刷新中...'}</div>
+        )}
         <div className="table-scroll">
           <table className="provider-table">
             <thead>
@@ -154,6 +160,7 @@ export default function Providers({ fresh, onBound, providers }: ProvidersProps)
                       <ProviderRow
                         key={p.providerId}
                         agg={p}
+                        viewScope={viewScope}
                         badge={badge}
                         expanded={isExpanded}
                         onToggle={() => setExpanded((prev) => ({ ...prev, [p.providerId]: !prev[p.providerId] }))}
@@ -174,6 +181,11 @@ export default function Providers({ fresh, onBound, providers }: ProvidersProps)
                         onToggleEnabled={async (keyId, enabled) => {
                           await setEnabled(keyId, enabled)
                         }}
+                        onSetScope={async (keyId, teamId) => {
+                          await setProviderKeyScope(keyId, teamId)
+                        }}
+                        currentUserId={user?.id ?? ''}
+                        team={team}
                       />
                     )
                   })}
@@ -200,7 +212,9 @@ export default function Providers({ fresh, onBound, providers }: ProvidersProps)
         <AddProviderModal
           providers={aggs.map((a) => ({ providerId: a.providerId, name: a.name, authType: a.authType, enabled: a.enabled, boundCount: a.boundCount }))}
           userId={user.id}
+          team={team}
           initialProviderId={addTarget}
+          defaultScope={viewScope === 'team' && team ? 'team' : 'personal'}
           onClose={() => setShowAddModal(false)}
           onDone={() => {
             setShowAddModal(false)
@@ -215,6 +229,7 @@ export default function Providers({ fresh, onBound, providers }: ProvidersProps)
 
 function ProviderRow({
   agg,
+  viewScope,
   badge,
   expanded,
   onToggle,
@@ -223,9 +238,13 @@ function ProviderRow({
   onRename,
   onSetDefault,
   onToggleEnabled,
-  onUnbind
+  onUnbind,
+  onSetScope,
+  currentUserId,
+  team
 }: {
   agg: ProviderAgg
+  viewScope: ViewScope
   badge: { cls: string; label: string }
   expanded: boolean
   onToggle: () => void
@@ -235,6 +254,9 @@ function ProviderRow({
   onSetDefault: (keyId: string) => Promise<void>
   onToggleEnabled: (keyId: string, enabled: boolean) => Promise<void>
   onUnbind: (keyId: string) => Promise<void>
+  onSetScope: (keyId: string, teamId: string | null) => Promise<void>
+  currentUserId: string
+  team: { id: string } | null
 }) {
   const IconComp = PROVIDER_ICONS[agg.providerId]
   const activeBindings = agg.bindings.filter((b) => b.enabled)
@@ -324,34 +346,29 @@ function ProviderRow({
                             </button>
                           </span>
                         ) : (
-                          <span style={{ display: 'inline-flex', gap: '6px', alignItems: 'center' }}>
-                            <strong>{acc.accountName}</strong>
-                            {acc.isDefault && (
-                              <span
-                                style={{
-                                  fontSize: 11,
-                                  color: '#e07a3e',
-                                  border: '1px solid currentColor',
-                                  borderRadius: 4,
-                                  padding: '0 5px'
-                                }}
-                              >
-                                默认
-                              </span>
-                            )}
-                            {!acc.enabled && (
-                              <span className="badge badge-muted" style={{ fontSize: 11, padding: '1px 6px' }}>
-                                已停用
-                              </span>
-                            )}
-                            <button
-                              className="link-btn"
-                              disabled={!acc.enabled}
-                              title={acc.enabled ? undefined : '账号已停用，请先启用'}
-                              onClick={() => { setEditKeyId(acc.keyId); setEditName(acc.accountName) }}
-                            >
-                              改名
-                            </button>
+                          <span className="account-name-cell">
+                            <span className="account-name-line">
+                              <strong>{acc.accountName}</strong>
+                              {viewScope === 'global' ? (
+                                <span className="account-scope-suffix">
+                                  {acc.teamId ? '（团队）' : '（个人）'}
+                                </span>
+                              ) : null}
+                              {acc.isDefault && <span className="account-flag account-flag-default">默认</span>}
+                              {!acc.enabled && (
+                                <span className="badge badge-muted account-flag">已停用</span>
+                              )}
+                              {acc.ownerUserId === currentUserId ? (
+                                <button
+                                  className="link-btn"
+                                  disabled={!acc.enabled}
+                                  title={acc.enabled ? undefined : '账号已停用，请先启用'}
+                                  onClick={() => { setEditKeyId(acc.keyId); setEditName(acc.accountName) }}
+                                >
+                                  改名
+                                </button>
+                              ) : null}
+                            </span>
                           </span>
                         )}
                       </td>
@@ -362,59 +379,86 @@ function ProviderRow({
                           : acc.health === 'healthy' ? '正常' : acc.health === 'expiring' ? '将过期' : acc.health === 'expired' ? '已失效' : '未知'}
                       </td>
                       <td>
-                        <label
-                          className="switch"
-                          title={acc.enabled ? '停用后智能调度将跳过该账号' : '启用后该账号可被智能调度使用'}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={acc.enabled}
-                            onChange={(e) => void onToggleEnabled(acc.keyId, e.target.checked)}
-                          />
-                          <span className="switch-track">
-                            <span className="switch-thumb" />
-                          </span>
-                          <span className="switch-label">{acc.enabled ? '启用' : '停用'}</span>
-                        </label>
+                        {acc.ownerUserId === currentUserId ? (
+                          <label
+                            className="switch"
+                            title={acc.enabled ? '停用后智能调度将跳过该账号' : '启用后该账号可被智能调度使用'}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={acc.enabled}
+                              onChange={(e) => void onToggleEnabled(acc.keyId, e.target.checked)}
+                            />
+                            <span className="switch-track">
+                              <span className="switch-thumb" />
+                            </span>
+                            <span className="switch-label">{acc.enabled ? '启用' : '停用'}</span>
+                          </label>
+                        ) : (
+                          <span className="account-readonly-note">只读</span>
+                        )}
                       </td>
                       <td>
-                        <button
-                          className="btn-sm"
-                          disabled={acc.isDefault || !acc.enabled}
-                          onClick={() => void onSetDefault(acc.keyId)}
-                          title={
-                            !acc.enabled
-                              ? '账号已停用，请先启用'
-                              : acc.isDefault
-                                ? '已是默认账号'
-                                : '设为默认：优先扣减该账号额度'
-                          }
-                        >
-                          设为默认
-                        </button>{' '}
-                        <button
-                          className="btn-sm"
-                          onClick={() => void onTest(acc.keyId)}
-                          disabled={acc.authType !== 'cookie' || !acc.enabled}
-                          title={
-                            !acc.enabled
-                              ? '账号已停用，请先启用'
-                              : acc.authType !== 'cookie'
-                                ? 'API Key 无需健康检查'
-                                : undefined
-                          }
-                        >
-                          测试
-                        </button>{' '}
-                        <button
-                          className="btn-sm"
-                          style={{ color: 'var(--error)' }}
-                          disabled={!acc.enabled}
-                          title={acc.enabled ? undefined : '账号已停用，请先启用'}
-                          onClick={() => void onUnbind(acc.keyId)}
-                        >
-                          解绑
-                        </button>
+                        {acc.ownerUserId === currentUserId ? (
+                          <>
+                            {acc.teamId ? (
+                              <button
+                                className="btn-sm"
+                                onClick={() => void onSetScope(acc.keyId, null)}
+                                title="把该账号取消共享，回到个人账号"
+                              >
+                                取消共享
+                              </button>
+                            ) : team ? (
+                              <button
+                                className="btn-sm"
+                                onClick={() => void onSetScope(acc.keyId, team.id)}
+                                title="把该账号共享给当前团队"
+                              >
+                                共享到团队
+                              </button>
+                            ) : null}{' '}
+                            <button
+                              className="btn-sm"
+                              disabled={acc.isDefault || !acc.enabled}
+                              onClick={() => void onSetDefault(acc.keyId)}
+                              title={
+                                !acc.enabled
+                                  ? '账号已停用，请先启用'
+                                  : acc.isDefault
+                                    ? '已是默认账号'
+                                    : '设为默认：优先扣减该账号额度'
+                              }
+                            >
+                              设为默认
+                            </button>{' '}
+                            <button
+                              className="btn-sm"
+                              onClick={() => void onTest(acc.keyId)}
+                              disabled={acc.authType !== 'cookie' || !acc.enabled}
+                              title={
+                                !acc.enabled
+                                  ? '账号已停用，请先启用'
+                                  : acc.authType !== 'cookie'
+                                    ? 'API Key 无需健康检查'
+                                    : undefined
+                              }
+                            >
+                              测试
+                            </button>{' '}
+                            <button
+                              className="btn-sm"
+                              style={{ color: 'var(--error)' }}
+                              disabled={!acc.enabled}
+                              title={acc.enabled ? undefined : '账号已停用，请先启用'}
+                              onClick={() => void onUnbind(acc.keyId)}
+                            >
+                              解绑
+                            </button>
+                          </>
+                        ) : (
+                          <span className="account-readonly-note">只读</span>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/apps/desktop/src/renderer/src/components/Team.tsx
+++ b/apps/desktop/src/renderer/src/components/Team.tsx
@@ -5,6 +5,7 @@ import { IconUsers } from './icons'
 import { EmptyState } from './EmptyState'
 
 interface TeamProps {
+  active: boolean
   fresh: boolean
   userId: string
   team: TeamContext | null
@@ -42,7 +43,7 @@ function statusTone(status: string | null): string {
   return 'badge badge-muted'
 }
 
-export default function Team({ userId, team, onTeamChanged }: TeamProps) {
+export default function Team({ active, userId, team, onTeamChanged }: TeamProps) {
   const [detail, setDetail] = useState<TeamDetail | null>(null)
   const [members, setMembers] = useState<TeamMemberView[]>([])
   const [invitations, setInvitations] = useState<TeamInvitation[]>([])
@@ -68,6 +69,7 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
     const service = getTeamService()
     if (!service) {
       setError('Supabase 未配置')
+      setLoading(false)
       return
     }
 
@@ -103,8 +105,8 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
   }, [team])
 
   useEffect(() => {
-    void load()
-  }, [load])
+    if (active) void load()
+  }, [active, load])
 
   useEffect(() => {
     if (!notice) return
@@ -223,6 +225,24 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
     }
   }
 
+  async function handleLeave(): Promise<void> {
+    if (!team || isOwner) return
+    if (!window.confirm('退出团队后，你自己共享给该团队的账号会变回个人账号。确定退出吗？')) return
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.leaveTeam(team.id)
+      await onTeamChanged()
+      setNotice('已退出团队')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '退出失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   if (!team) {
     return (
       <div className="tab-wrap">
@@ -239,7 +259,7 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
           className="team-empty"
           icon={<IconUsers size={20} />}
           title="你还没有加入任何团队"
-          description="创建团队后可以集中管理成员与邀请码；共享额度池不在本轮范围。"
+          description="创建团队后可以集中管理成员、邀请码和团队额度。"
           action={
             <div className="team-empty-actions">
               <input
@@ -292,7 +312,8 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
               {members.length}/{detail?.seats_limit ?? '-'} 席位
             </span>
           </div>
-          <div className="history-table-wrap" style={{ flex: 1, minHeight: 0 }}>
+          <div className={'history-table-wrap' + (loading && members.length > 0 ? ' table-wrap-loading' : '')} style={{ flex: 1, minHeight: 0 }}>
+            {loading && members.length > 0 ? <div className="table-refresh-overlay">刷新中...</div> : null}
             <div className="table-scroll">
               <table className="team-table">
                 <thead>
@@ -396,6 +417,12 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
               <div className="config-label">累计用量</div>
               <div className="config-val">{detail ? formatCount(detail.total_usage) : '-'}</div>
             </div>
+            <div className="config-card">
+              <div className="config-label">团队共享额度</div>
+              <div className="config-val">
+                {detail?.quota ? `${Math.round(detail.quota.used)}/${Math.round(detail.quota.daily_total)}` : '-'}
+              </div>
+            </div>
           </div>
 
           {isOwner ? (
@@ -433,6 +460,11 @@ export default function Team({ userId, team, onTeamChanged }: TeamProps) {
             <button className="btn-sm" style={{ flex: 1 }} disabled={loading} onClick={() => void load()}>
               刷新
             </button>
+            {!isOwner ? (
+              <button className="btn-sm danger" style={{ flex: 1 }} disabled={busy} onClick={() => void handleLeave()}>
+                退出团队
+              </button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -9,11 +9,14 @@ import type {
   ProviderKey,
   ProviderMeta,
   ProviderService,
-  QuotaLedgerRow
+  QuotaLedgerRow,
+  ViewScope
 } from '@quota-flow/db-supabase'
 
 export interface BindingView {
   keyId: string
+  teamId: string | null
+  ownerUserId: string
   accountName: string
   authType: string
   health: 'healthy' | 'expiring' | 'expired' | 'unknown'
@@ -154,11 +157,12 @@ export interface ProvidersResult {
   rename: (keyId: string, name: string) => Promise<void>
   setDefault: (providerId: string, keyId: string) => Promise<void>
   setEnabled: (keyId: string, enabled: boolean) => Promise<void>
+  setProviderKeyScope: (keyId: string, teamId: string | null) => Promise<void>
   unbind: (keyId: string) => Promise<void>
 }
 
-export function useProviders(): ProvidersResult {
-  const { user } = useAuth()
+export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult {
+  const { user, team } = useAuth()
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -195,8 +199,46 @@ export function useProviders(): ProvidersResult {
     if (isFirstLoad) setLoading(true)
     else setRefreshing(true)
     setError(null)
-    Promise.all([svc.listAllProviders(), svc.listProviderKeys(user.id), svc.listLedger(user.id)])
-      .then(([p, k, l]) => {
+    const loadScopedData = async (): Promise<{
+      providers: ProviderMeta[]
+      keys: ProviderKey[]
+      ledgers: QuotaLedgerRow[]
+    }> => {
+      const [p] = await Promise.all([svc.listAllProviders()])
+      if (viewScope === 'personal') {
+        const personalKeys = (await svc.listProviderKeys(user.id)).filter((k) => !k.team_id)
+        const personalLedgers = await svc.listTodayLedger(user.id)
+        return { providers: p, keys: personalKeys, ledgers: personalLedgers }
+      }
+      if (viewScope === 'team') {
+        if (!team) return { providers: p, keys: [], ledgers: [] }
+        const teamKeys = await svc.listTeamProviderKeys(team.id)
+        const teamLedgers = await svc.listTeamTodayLedger(team.id)
+        return { providers: p, keys: teamKeys, ledgers: teamLedgers }
+      }
+      const [personalKeys, teamKeys, personalLedgers, teamLedgers] = await Promise.all([
+        svc.listProviderKeys(user.id).then((all) => all.filter((k) => !k.team_id)),
+        team ? svc.listTeamProviderKeys(team.id) : Promise.resolve<ProviderKey[]>([]),
+        svc.listTodayLedger(user.id),
+        team ? svc.listTeamTodayLedger(team.id) : Promise.resolve<QuotaLedgerRow[]>([])
+      ])
+      const seenKeys = new Set<string>()
+      const keys = [...personalKeys, ...teamKeys].filter((k) => {
+        if (seenKeys.has(k.id)) return false
+        seenKeys.add(k.id)
+        return true
+      })
+      const seenLedgers = new Set<string>()
+      const ledgers = [...personalLedgers, ...teamLedgers].filter((l) => {
+        if (seenLedgers.has(l.id)) return false
+        seenLedgers.add(l.id)
+        return true
+      })
+      return { providers: p, keys, ledgers }
+    }
+
+    loadScopedData()
+      .then(async ({ providers: p, keys: k, ledgers: l }) => {
         if (cancelled) return
         setProviders(p)
         setKeys(k)
@@ -207,27 +249,34 @@ export function useProviders(): ProvidersResult {
         // 对已绑定但缺今日 ledger 行的账号自动初始化额度（按账号，每天 0 点重置）
         const today = todayShanghai()
         const existingTodayKeys = new Set(
-          l.filter((row) => row.date === today && row.account_key_id != null).map((row) => row.account_key_id)
+          l
+            .filter((row) => row.date === today && row.account_key_id != null)
+            .map((row) => `${row.account_key_id}:${row.team_id ?? 'personal'}`)
         )
-        const toInit = k.filter((key) => !existingTodayKeys.has(key.id))
+        const toInit = k.filter((key) => !existingTodayKeys.has(`${key.id}:${key.team_id ?? 'personal'}`))
         if (toInit.length > 0) {
-          const providerMap = new Map(p.map((pr) => [pr.id, pr]))
-          Promise.all(
-            toInit.map((key) => {
-              const meta = providerMap.get(key.provider_id)
-              return svc.getOrInitLedger({
-                userId: user.id,
-                providerId: key.provider_id,
-                unitName: meta?.unit_name ?? '',
-                dailyTotal: Number(meta?.default_daily_quota ?? 0),
-                keyId: key.id
-              })
+          const personalToInit = toInit.filter((key) => !key.team_id)
+          const teamToInit = toInit.filter((key) => key.team_id)
+          const initRows: QuotaLedgerRow[] = []
+          if (personalToInit.length > 0) {
+            const rows = await svc.ensureProviderLedgerRows(user.id, null, personalToInit.map((key) => key.id))
+            initRows.push(...rows)
+          }
+          if (teamToInit.length > 0 && team) {
+            const rows = await svc.ensureProviderLedgerRows(user.id, team.id, teamToInit.map((key) => key.id))
+            initRows.push(...rows)
+          }
+          if (cancelled) return
+          const nextLedgers = new Map<string, QuotaLedgerRow>()
+          for (const row of [...l, ...initRows]) nextLedgers.set(row.id, row)
+          setLedgers(
+            [...nextLedgers.values()].sort((a, b) => {
+              const dateDiff = b.date.localeCompare(a.date)
+              if (dateDiff !== 0) return dateDiff
+              return String(a.account_key_id ?? '').localeCompare(String(b.account_key_id ?? ''))
             })
-          ).then(() => {
-            if (!cancelled) setReloadKey((k) => k + 1)
-          })
+          )
         }
-
       })
       .catch(async (e: unknown) => {
         if (cancelled) return
@@ -253,7 +302,7 @@ export function useProviders(): ProvidersResult {
     return () => {
       cancelled = true
     }
-  }, [user?.id, reloadKey])
+  }, [user?.id, team?.id, viewScope, reloadKey])
 
   // 后台停用/启用 providers.enabled 时，通过 Supabase Realtime 拉取最新厂商列表。
   // 桌面端保留全部 admin 配置的厂商；停用厂商在新增厂商弹窗中置灰不可选。
@@ -322,13 +371,19 @@ export function useProviders(): ProvidersResult {
     const map = new Map<string, BindingView[]>()
     for (const k of keys) {
       const list = map.get(k.provider_id) ?? []
-      // 按账号取今日 ledger 行（listLedger 按日期倒序，首条即今天）
-      const ledger = ledgers.find((l) => l.account_key_id === k.id)
+      // 按账号取今日 ledger 行
+      const ledger = ledgers.find(
+        (l) =>
+          l.account_key_id === k.id &&
+          (k.team_id == null ? l.team_id == null : l.team_id === k.team_id)
+      )
       const dailyTotal = Number(ledger?.daily_total ?? 0)
       const used = Number(ledger?.used ?? 0)
       const defaultTotal = dailyTotal || 0
       list.push({
         keyId: k.id,
+        teamId: k.team_id ?? null,
+        ownerUserId: k.owner_user_id,
         accountName: k.account_name ?? '绑定账号',
         authType: k.auth_type,
         health: (healthOverrides[k.id] ?? k.health_status) as BindingView['health'],
@@ -447,5 +502,40 @@ export function useProviders(): ProvidersResult {
     [user]
   )
 
-  return { loading, refreshing, error, aggs, anyBound, totalBound, reload, testHealth, rename, setDefault, setEnabled, unbind }
+  const setProviderKeyScope = useCallback(
+    async (keyId: string, teamId: string | null) => {
+      const svc = getProviderService()
+      if (!svc || !user) return
+      try {
+        await svc.setProviderKeyScope(keyId, teamId)
+        setKeys((prev) => {
+          const next = prev.map((k) => (k.id === keyId ? { ...k, team_id: teamId } : k))
+          if (viewScope === 'personal') return next.filter((k) => !k.team_id)
+          if (viewScope === 'team') return next.filter((k) => k.team_id === team?.id)
+          return next
+        })
+        // 归属变化会影响账号对应的 ledger 行，直接重拉并补初始化目标作用域的今日额度。
+        reload()
+      } catch (e) {
+        setError(errMsg(e))
+      }
+    },
+    [user, viewScope, team?.id, reload]
+  )
+
+  return {
+    loading,
+    refreshing,
+    error,
+    aggs,
+    anyBound,
+    totalBound,
+    reload,
+    testHealth,
+    rename,
+    setDefault,
+    setEnabled,
+    setProviderKeyScope,
+    unbind
+  }
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -377,17 +377,6 @@ body {
   flex-shrink: 0;
   z-index: 50;
 }
-.user-area .team-badge {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-base);
-  border: 1px solid var(--border-light);
-  font-size: 0.85em;
-  color: var(--fg-secondary);
-}
 .avatar-wrap {
   position: relative;
   z-index: 50;
@@ -1437,6 +1426,7 @@ body {
 
 .provider-table-wrap {
   flex: 1;
+  position: relative;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
   border-top-color: rgba(255, 255, 255, 0.6);
@@ -1446,6 +1436,11 @@ body {
   flex-direction: column;
   min-height: 0;
   box-shadow: var(--shadow-card);
+}
+.provider-table-wrap .table-refresh-overlay {
+  background: var(--bg-card);
+  color: var(--fg-secondary);
+  pointer-events: auto;
 }
 .provider-table {
   width: 100%;
@@ -1507,6 +1502,7 @@ body {
   padding: 6px 12px 6px 36px;
   border-bottom: 1px solid var(--border-light);
   color: var(--fg-secondary);
+  vertical-align: middle;
 }
 .account-subtable tr:last-child td {
   border-bottom: none;
@@ -1641,6 +1637,7 @@ body {
 /* ===== 历史 Tab：筛选 + 视频预览 + 操作 ===== */
 .history-table-wrap {
   flex: 1;
+  position: relative;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
   border-top-color: rgba(255, 255, 255, 0.6);
@@ -1650,6 +1647,19 @@ body {
   flex-direction: column;
   min-height: 0;
   box-shadow: var(--shadow-card);
+}
+.table-refresh-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--fg-secondary);
+  font-size: 0.9em;
+  pointer-events: none;
 }
 .history-table {
   width: 100%;
@@ -3053,4 +3063,177 @@ textarea::-webkit-scrollbar {
   background: var(--bg-card);
   color: var(--fg-secondary);
   font-size: 0.84em;
+}
+
+/* ===== 个人/团队/全局模式 ===== */
+.scope-switcher {
+  position: relative;
+  z-index: 70;
+}
+.scope-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg-base);
+  color: var(--fg-secondary);
+  font-family: var(--font-body);
+  font-size: 0.85em;
+  line-height: 1;
+  letter-spacing: 0;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+  white-space: nowrap;
+}
+.scope-trigger:hover,
+.scope-switcher.open .scope-trigger {
+  border-color: var(--accent);
+  color: var(--fg-primary);
+}
+.scope-trigger svg {
+  flex-shrink: 0;
+}
+.scope-trigger .scope-chevron {
+  transition: transform 0.15s ease;
+}
+.scope-switcher.open .scope-trigger .scope-chevron {
+  transform: rotate(180deg);
+}
+.scope-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 168px;
+  max-width: 230px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  padding: 4px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: all 0.2s ease;
+  z-index: 120;
+}
+.scope-switcher.open .scope-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.scope-menu::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  right: 12px;
+  width: 10px;
+  height: 10px;
+  background: var(--bg-card);
+  border-left: 1px solid var(--border-light);
+  border-top: 1px solid var(--border-light);
+  transform: rotate(45deg);
+}
+.scope-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg-secondary);
+  font-family: var(--font-body);
+  font-size: 0.92em;
+  letter-spacing: 0;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+.scope-option:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--fg-primary);
+}
+.scope-option.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-weight: 600;
+}
+.scope-option:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+.scope-option-check {
+  flex-shrink: 0;
+  font-size: 0.9em;
+}
+
+/* ===== 账号归属标签 ===== */
+.account-scope-suffix {
+  color: var(--fg-muted);
+  font-size: 0.9em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.account-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 220px;
+}
+.account-name-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+.account-name-line strong {
+  color: var(--fg-primary);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.account-name-line .link-btn {
+  flex-shrink: 0;
+}
+.account-badge-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.account-badge-line .link-btn {
+  padding: 0;
+  font-size: 0.78em;
+}
+.account-flag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  line-height: 1.5;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.account-flag-default {
+  color: var(--accent);
+  border: 1px solid currentColor;
+}
+.account-readonly-note {
+  color: var(--fg-muted);
+  font-size: 0.82em;
+}
+
+.btn-sm.danger {
+  color: var(--error);
+  border-color: rgba(196, 77, 77, 0.4);
 }

--- a/docs/team-module-mvp.md
+++ b/docs/team-module-mvp.md
@@ -6,7 +6,7 @@
 
 当前 Admin 端团队页还是静态 HTML 原型，只展示假数据，详情、封禁、重置额度等按钮没有真实逻辑；桌面端团队 Tab 在导航里被直接拦截，提示“系统暂未实现”，页面组件也只用 `TEAM` 静态数据。数据库已经有 `teams`、`team_members`、`team_invitations`、`subscriptions`、`member_usage` 等基础表和 Admin RLS 策略，但缺少团队列表 RPC、桌面端创建/加入/邀请服务、以及真实 UI 数据流。
 
-本次范围：Admin 团队管理 + 桌面端基础团队功能一起做，不包含共享额度池。
+本次范围：Admin 团队管理 + 桌面端基础团队功能一起做，并补上团队共享额度池的豆包日额度扣减链路。
 
 ## 关键改动
 
@@ -19,26 +19,33 @@
   - `get_team_members(p_team_id)`：桌面端成员读取团队成员的资料、日限额、加入时间与用量统计。
   - `create_team_invite(p_team_id, p_email, p_role, p_expires_at)`：owner 生成单次邀请码，默认 7 天有效。
   - 所有 RPC 都 `SECURITY DEFINER` 并显式校验权限，`GRANT EXECUTE` 给 `authenticated`。
+- 新增 `migrations/0014_team_quota_rpc.sql`：
+  - `team_quota_snapshot(p_team_id, p_provider_id)`：返回团队共享日额度汇总，按团队豆包账号额度求和，成员或 admin 可读。
+  - `get_team_quota(p_team_id, p_provider_id)`：返回当前成员看到的团队额度 + 个人今日用量/日限额。
+  - `team_consume_quota_and_finalize(...)`：团队任务成功后原子扣团队额度、扣成员日限额、写 `quota_operations`，替代个人 `reconcile_consume_and_finalize` 的团队分支。
+  - `admin_reset_team_quota(p_team_id)`：Admin 重置今天团队池、账号账本和成员用量，并写 `audit_logs`。
+  - 扩展 `admin_list_teams` 和 `get_team_detail`，返回团队共享额度快照。
 - Admin 端替换团队页：
   - 新增 `apps/admin/src/lib/api/teams.ts`，类型为 `AdminTeam`、`AdminTeamMember`、状态筛选等。
   - 新增团队表格、筛选、分页、详情弹窗组件，沿用现有用户管理页的模式。
   - 详情弹窗展示团队成员、订阅信息、用量；支持修改 `plan`、`seats_limit`、`status` 并写 `audit_logs`。
-  - 不实现“重置额度”或“成员封禁”的额度/封禁业务，保留为后续独立项。
+  - 支持“重置今日额度”，写 `audit_logs`；“成员封禁”仍保留为后续独立项。
 - 桌面端加入真实团队服务：
   - 在 `@quota-flow/db-supabase` 增加 `TeamService`，并在桌面 renderer 的 `auth/service.ts` 增加 `getTeamService()` 单例。
   - 方法包括：创建团队、邀请码加入、成员列表、生成邀请码、移除成员、更新成员日限额、读取团队信息。
   - `useAuth` 增加 `refreshTeam()`，创建/加入成功后刷新顶部团队徽标和 Profile 弹窗。
   - `App.tsx` 移除团队 Tab 的拦截，并把 `team` 纳入可恢复的 hash tab。
-- 重写桌面端 `Team.tsx`：
+  - 重写桌面端 `Team.tsx`：
   - 无团队时显示真实空状态，支持“创建团队”和“输入邀请码加入”。
   - 有团队时展示成员表格、团队信息、邀请码生成/复制；owner 可移除成员、设置成员日限额。
   - 移除对静态 `TEAM` 数据的依赖；“升级套餐”按钮隐藏或禁用，因为计费/套餐购买不在本轮范围。
+  - 桌面端生成、厂商列表、额度展示、绑定账号均支持 `teamId`；加入团队后走团队豆包账号和团队额度池。
 
 ## 公共 API / 类型变化
 
-- 新增 RPC：`admin_list_teams`、`admin_list_team_members`、`create_team`、`join_team_by_invite`、`get_team_detail`、`get_team_members`、`create_team_invite`。
-- 新增 TS 类型：`AdminTeam`、`AdminTeamMember`、`TeamDetail`、`TeamMemberView`、`TeamInvitation`。
-- 新增导出：`@quota-flow/db-supabase` 的 `TeamService`，桌面端 `auth/service.ts` 的 `getTeamService()`，`useAuth` 的 `refreshTeam()`。
+- 新增 RPC：`admin_list_teams`、`admin_list_team_members`、`create_team`、`join_team_by_invite`、`get_team_detail`、`get_team_members`、`create_team_invite`、`team_quota_snapshot`、`get_team_quota`、`team_consume_quota_and_finalize`、`admin_reset_team_quota`。
+- 新增 TS 类型：`AdminTeam`、`AdminTeamMember`、`TeamDetail`、`TeamMemberView`、`TeamInvitation`、`TeamQuota`、`TeamQuotaSummary`。
+- 新增导出：`@quota-flow/db-supabase` 的 `TeamService`、`TeamQuota`、`TeamQuotaSummary`、`ProviderService.listTeamProviderKeys`、`ProviderService.listTeamLedger`、`ProviderService.consumeTeamQuotaAndFinalize`；桌面端 `auth/service.ts` 的 `getTeamService()`，`useAuth` 的 `refreshTeam()`。
 
 ## 测试计划
 
@@ -49,7 +56,63 @@
 
 ## 假设
 
-- 本轮不实现共享额度池、计费支付、公共账号绑定/额度扣减改造。
+- 本轮共享额度池只做豆包团队日额度池和团队任务扣减；不实现计费支付、套餐购买、公共账号绑定/额度扣减的完整改造。
 - 邀请码采用 8 位大写 token，默认 7 天有效，单次使用后消费；暂不使用邀请邮箱匹配。
 - Admin 团队操作以 `teams` 表字段为主，订阅周期只读展示，不新增订阅账务流程。
 - 保留现有 `prototype-pages.ts` 和其他原型页不动，仅团队页切到真实数据。
+
+## 账号归属与模式切换补充（0015）
+
+日期：2026-08-14
+
+### 目标
+
+桌面端把“是否在团队”和“生成时用谁的额度”拆开。账号归属仍用 `provider_keys.team_id` 表达：`team_id = NULL` 是个人账号，非 NULL 是团队共享账号。本轮不实现共享额度池扩展、计费、Admin 端改动。
+
+### 关键改动
+
+- 新增 `migrations/0015_team_account_scope_rpc.sql`：
+  - `team_leave(p_team_id)`：仅非 owner 成员可调用；删除团队成员记录，并把该成员自己共享给该团队的 `provider_keys.team_id` 置为 NULL。
+  - `set_provider_key_scope(p_key_id, p_team_id nullable)`：仅账号 owner 可调用；设置个人/团队归属，若目标团队非空则校验当前用户仍是该团队有效成员。
+  - 收紧 `provider_keys` 直接写入策略：INSERT/UPDATE 只能写本人账号，且 `team_id` 非空时必须是当前用户所属团队。
+- 扩展 `@quota-flow/db-supabase`：
+  - `TeamService.leaveTeam(teamId)`。
+  - `ProviderService.setProviderKeyScope(keyId, teamId | null)`。
+  - 新增 `ViewScope = 'personal' | 'team' | 'global'`、`UsageScope = 'personal' | 'team'`。
+- 桌面端状态：
+  - `viewScope` 控制账号展示范围：个人模式只显示个人账号，团队模式只显示团队账号，全局模式同时显示两种。
+  - `usageScope` 控制生成时使用哪个额度：个人/团队模式下固定；全局模式内提供“个人额度 / 团队额度”选择。
+  - `dispatch.generate` 只在 `usageScope === 'team'` 时传 `teamId`；个人额度路径只选个人账号。
+- 账号列表与新增：
+  - 有团队时新增账号可选择“个人账号 / 团队账号”；无团队时默认新增个人账号。
+  - 自己的个人账号可共享到团队；自己的团队账号可取消共享和删除；其他成员的团队账号只读展示。
+  - 个人账号删除、改名、启停、默认、健康检查仍只对本人账号开放。
+- Team 页面：
+  - 非 owner 成员可退出团队；退出前提示自己共享给该团队的账号会变回个人账号。
+  - owner 不显示退出按钮；本轮不做 owner 转让或解散团队。
+
+### 公共 API / 类型变化
+
+- 新增 RPC：`team_leave`、`set_provider_key_scope`。
+- 新增 TS 类型：`ViewScope`、`UsageScope`。
+- 新增导出方法：`TeamService.leaveTeam()`、`ProviderService.setProviderKeyScope()`。
+- 状态流：账号新增/共享/取消共享/删除/退出团队后，刷新 `providers`、`team`、`usage` 相关状态，顶部团队徽标与 Profile 同步更新。
+
+### 测试计划
+
+- 运行 `pnpm --filter @quota-flow/db-supabase typecheck`、`pnpm --filter @quota-flow/desktop typecheck`、`pnpm --filter @quota-flow/desktop build`。
+- 人工验证：
+  - 个人模式只显示个人账号，生成走个人额度。
+  - 团队模式只显示团队账号，生成走团队额度。
+  - 全局模式同时显示个人/团队账号，并可按选择走个人或团队额度。
+  - 有团队时新增账号可选择个人或团队，且新增后归属正确。
+  - 自己的个人账号可共享到团队，自己的团队账号可取消共享回个人，自己的账号可删除。
+  - 其他成员的团队账号可见但不可管理。
+  - 非 owner 退出团队后，自己共享的团队账号变回个人账号；owner 不能退出。
+
+### 假设
+
+- 账号归属继续由 `provider_keys.team_id` 表达，不加新模式字段。
+- 全局模式不自动混合额度，只允许用户显式选择生成时使用个人额度还是团队额度。
+- 退出团队不清理个人账号，只清空自己共享给该团队的账号归属。
+- 本轮不实现共享额度池、计费支付、团队 owner 转让、管理员代管团队账号。

--- a/migrations/0014_team_quota_rpc.sql
+++ b/migrations/0014_team_quota_rpc.sql
@@ -1,0 +1,596 @@
+-- 0014_team_quota_rpc.sql
+-- Team shared quota pool RPCs.
+-- Uses existing quota_ledger rows with team_id NOT NULL, owner_user_id NULL,
+-- account_key_id NULL as the team-level daily pool.
+-- Idempotent: uses CREATE OR REPLACE and explicit GRANTs.
+
+-- ============ 0. Team pool ledger uniqueness ============
+-- quota_ledger UNIQUE (date, team_id, owner_user_id, account_key_id, provider_id)
+-- does not protect team pool rows because both owner_user_id and account_key_id
+-- are NULL. Use a partial unique index for the team-level aggregate row.
+DROP INDEX IF EXISTS idx_quota_ledger_unique_team_pool;
+CREATE UNIQUE INDEX idx_quota_ledger_unique_team_pool
+  ON public.quota_ledger (date, team_id, provider_id)
+  WHERE team_id IS NOT NULL AND owner_user_id IS NULL AND account_key_id IS NULL;
+
+-- ============ 1. team_quota_snapshot ============
+CREATE OR REPLACE FUNCTION public.team_quota_snapshot(
+  p_team_id UUID,
+  p_provider_id TEXT DEFAULT 'doubao'
+)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_daily_total NUMERIC;
+  v_used NUMERIC;
+  v_reserved NUMERIC;
+BEGIN
+  IF NOT public.is_admin()
+     AND NOT EXISTS (
+       SELECT 1 FROM public.team_members tm
+       WHERE tm.team_id = p_team_id AND tm.user_id = auth.uid()
+     ) THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT COALESCE(SUM(COALESCE(pk.daily_quota, p.default_daily_quota, 0)), 0)
+  INTO v_daily_total
+  FROM public.provider_keys pk
+  JOIN public.providers p ON p.id = pk.provider_id
+  WHERE pk.team_id = p_team_id
+    AND pk.provider_id = p_provider_id
+    AND pk.enabled = true;
+
+  SELECT COALESCE(SUM(l.used), 0), COALESCE(SUM(l.reserved), 0)
+  INTO v_used, v_reserved
+  FROM public.quota_ledger l
+  WHERE l.date = (now() AT TIME ZONE 'Asia/Shanghai')::date
+    AND l.team_id = p_team_id
+    AND l.owner_user_id IS NULL
+    AND l.account_key_id IS NULL
+    AND l.provider_id = p_provider_id;
+
+  RETURN json_build_object(
+    'provider_id', p_provider_id,
+    'daily_total', v_daily_total,
+    'used', COALESCE(v_used, 0),
+    'remaining', GREATEST(v_daily_total - COALESCE(v_used, 0) - COALESCE(v_reserved, 0), 0),
+    'reserved', COALESCE(v_reserved, 0)
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.team_quota_snapshot(uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION public.team_quota_snapshot(uuid, text)
+  IS 'Return team daily shared quota summary for a provider. Admin or team member only.';
+
+-- ============ 2. get_team_quota ============
+CREATE OR REPLACE FUNCTION public.get_team_quota(
+  p_team_id UUID,
+  p_provider_id TEXT DEFAULT 'doubao'
+)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_today DATE := (now() AT TIME ZONE 'Asia/Shanghai')::date;
+  v_member_used NUMERIC;
+  v_member_limit NUMERIC;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.team_members tm
+    WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT
+    COALESCE((
+      SELECT mu.used_equivalent
+      FROM public.member_usage mu
+      WHERE mu.team_id = p_team_id
+        AND mu.user_id = v_user_id
+        AND mu.date = v_today
+      LIMIT 1
+    ), 0),
+    tm.daily_quota_limit_equivalent
+  INTO v_member_used, v_member_limit
+  FROM public.team_members tm
+  WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id;
+
+  RETURN json_build_object(
+    'team_id', p_team_id,
+    'quota', public.team_quota_snapshot(p_team_id, p_provider_id),
+    'member_used', v_member_used,
+    'member_limit', v_member_limit
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_team_quota(uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION public.get_team_quota(uuid, text)
+  IS 'Team quota summary for the signed-in team member.';
+
+-- ============ 3. team_consume_quota_and_finalize ============
+CREATE OR REPLACE FUNCTION public.team_consume_quota_and_finalize(
+  p_team_id UUID,
+  p_user_id UUID,
+  p_provider_id TEXT,
+  p_amount NUMERIC,
+  p_account_key_id UUID,
+  p_date DATE,
+  p_job_id UUID
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_today DATE := COALESCE(p_date, (now() AT TIME ZONE 'Asia/Shanghai')::date);
+  v_op_exists BOOLEAN;
+  v_team_status TEXT;
+  v_daily_total NUMERIC;
+  v_pool public.quota_ledger%ROWTYPE;
+  v_account public.quota_ledger%ROWTYPE;
+  v_account_total NUMERIC;
+  v_member_used NUMERIC;
+  v_member_limit NUMERIC;
+  v_pool_id UUID;
+BEGIN
+  IF v_user_id IS NULL OR p_user_id IS DISTINCT FROM v_user_id THEN
+    RETURN jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'message', 'forbidden');
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RETURN jsonb_build_object('ok', false, 'code', 'INVALID_AMOUNT', 'message', 'amount must be greater than 0');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.team_members tm
+    WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'message', 'not a team member');
+  END IF;
+
+  SELECT status INTO v_team_status FROM public.teams WHERE id = p_team_id;
+  IF v_team_status IS DISTINCT FROM 'active' THEN
+    RETURN jsonb_build_object('ok', false, 'code', 'TEAM_NOT_ACTIVE', 'message', 'team not active');
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('team_quota:' || p_team_id::text || ':' || v_today::text, 0));
+
+  IF p_job_id IS NOT NULL THEN
+    SELECT EXISTS(
+      SELECT 1 FROM public.quota_operations
+      WHERE job_id = p_job_id AND operation_type = 'finalize'
+    ) INTO v_op_exists;
+
+    IF v_op_exists THEN
+      RETURN jsonb_build_object(
+        'ok', true,
+        'code', 'ALREADY_FINALIZED',
+        'message', 'job already finalized'
+      );
+    END IF;
+  END IF;
+
+  SELECT COALESCE(SUM(COALESCE(pk.daily_quota, p.default_daily_quota, 0)), 0)
+  INTO v_daily_total
+  FROM public.provider_keys pk
+  JOIN public.providers p ON p.id = pk.provider_id
+  WHERE pk.team_id = p_team_id
+    AND pk.provider_id = p_provider_id
+    AND pk.enabled = true;
+
+  SELECT * INTO v_pool
+  FROM public.quota_ledger
+  WHERE date = v_today
+    AND team_id = p_team_id
+    AND owner_user_id IS NULL
+    AND account_key_id IS NULL
+    AND provider_id = p_provider_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.quota_ledger (
+      date, team_id, owner_user_id, account_key_id, provider_id,
+      unit_name, daily_total, used, remaining, reserved
+    )
+    VALUES (
+      v_today, p_team_id, NULL, NULL, p_provider_id,
+      'points', v_daily_total, 0, v_daily_total, 0
+    )
+    ON CONFLICT (date, team_id, provider_id)
+    WHERE team_id IS NOT NULL AND owner_user_id IS NULL AND account_key_id IS NULL
+    DO UPDATE SET
+      daily_total = EXCLUDED.daily_total,
+      remaining = GREATEST(EXCLUDED.daily_total - quota_ledger.used - quota_ledger.reserved, 0),
+      refreshed_at = now()
+    RETURNING * INTO v_pool;
+  ELSE
+    UPDATE public.quota_ledger
+    SET daily_total = v_daily_total,
+        remaining = GREATEST(v_daily_total - used - reserved, 0),
+        refreshed_at = now()
+    WHERE id = v_pool.id
+    RETURNING * INTO v_pool;
+  END IF;
+
+  IF v_pool.daily_total - COALESCE(v_pool.used, 0) - COALESCE(v_pool.reserved, 0) < p_amount THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'code', 'QUOTA_EXHAUSTED',
+      'message', format('team quota exhausted: need %s, available %s',
+        p_amount,
+        v_pool.daily_total - COALESCE(v_pool.used, 0) - COALESCE(v_pool.reserved, 0)),
+      'row', row_to_json(v_pool)::jsonb
+    );
+  END IF;
+
+  SELECT COALESCE(mu.used_equivalent, 0), tm.daily_quota_limit_equivalent
+  INTO v_member_used, v_member_limit
+  FROM public.team_members tm
+  LEFT JOIN public.member_usage mu
+    ON mu.team_id = tm.team_id
+   AND mu.user_id = tm.user_id
+   AND mu.date = v_today
+  WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  FOR UPDATE OF tm;
+
+  IF v_member_limit IS NOT NULL AND COALESCE(v_member_used, 0) + p_amount > v_member_limit THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'code', 'MEMBER_QUOTA_EXCEEDED',
+      'message', format('member daily limit exceeded: need %s, remaining %s',
+        p_amount,
+        GREATEST(v_member_limit - COALESCE(v_member_used, 0), 0))
+    );
+  END IF;
+
+  IF p_account_key_id IS NOT NULL THEN
+    SELECT COALESCE(pk.daily_quota, p.default_daily_quota, 0)
+    INTO v_account_total
+    FROM public.provider_keys pk
+    JOIN public.providers p ON p.id = pk.provider_id
+    WHERE pk.id = p_account_key_id
+      AND pk.team_id = p_team_id
+      AND pk.provider_id = p_provider_id
+      AND pk.enabled = true;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('ok', false, 'code', 'ACCOUNT_NOT_FOUND', 'message', 'team account not found or disabled');
+    END IF;
+
+    SELECT * INTO v_account
+    FROM public.quota_ledger
+    WHERE date = v_today
+      AND team_id = p_team_id
+      AND account_key_id = p_account_key_id
+      AND provider_id = p_provider_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.quota_ledger (
+        date, team_id, owner_user_id, account_key_id, provider_id,
+        unit_name, daily_total, used, remaining, reserved
+      )
+      SELECT
+        v_today, p_team_id, pk.owner_user_id, pk.id, p_provider_id,
+        COALESCE(pr.unit_name, 'points'), v_account_total, 0, v_account_total, 0
+      FROM public.provider_keys pk
+      JOIN public.providers pr ON pr.id = pk.provider_id
+      WHERE pk.id = p_account_key_id
+      ON CONFLICT (date, team_id, owner_user_id, account_key_id, provider_id)
+      DO UPDATE SET
+        daily_total = EXCLUDED.daily_total,
+        remaining = GREATEST(EXCLUDED.daily_total - quota_ledger.used - quota_ledger.reserved, 0),
+        refreshed_at = now()
+      RETURNING * INTO v_account;
+    ELSE
+      UPDATE public.quota_ledger
+      SET daily_total = v_account_total,
+          remaining = GREATEST(v_account_total - used - reserved, 0),
+          refreshed_at = now()
+      WHERE id = v_account.id
+      RETURNING * INTO v_account;
+    END IF;
+
+    IF v_account.daily_total - COALESCE(v_account.used, 0) - COALESCE(v_account.reserved, 0) < p_amount THEN
+      RETURN jsonb_build_object(
+        'ok', false,
+        'code', 'ACCOUNT_QUOTA_EXHAUSTED',
+        'message', 'team account quota exhausted',
+        'row', row_to_json(v_account)::jsonb
+      );
+    END IF;
+  END IF;
+
+  UPDATE public.quota_ledger
+  SET used = used + p_amount,
+      remaining = GREATEST(daily_total - used - p_amount - reserved, 0),
+      refreshed_at = now()
+  WHERE id = v_pool.id
+  RETURNING * INTO v_pool;
+
+  IF p_account_key_id IS NOT NULL THEN
+    UPDATE public.quota_ledger
+    SET used = used + p_amount,
+        remaining = GREATEST(daily_total - used - p_amount - reserved, 0),
+        refreshed_at = now()
+    WHERE id = v_account.id;
+  END IF;
+
+  INSERT INTO public.member_usage (date, team_id, user_id, used_equivalent)
+  VALUES (v_today, p_team_id, v_user_id, p_amount)
+  ON CONFLICT (date, team_id, user_id)
+  DO UPDATE SET used_equivalent = public.member_usage.used_equivalent + EXCLUDED.used_equivalent;
+
+  v_pool_id := v_pool.id;
+
+  IF p_job_id IS NOT NULL THEN
+    INSERT INTO public.quota_operations (job_id, ledger_id, operation_type, amount)
+    VALUES (p_job_id, v_pool_id, 'finalize', p_amount)
+    ON CONFLICT (job_id, operation_type) DO NOTHING;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'code', 'CONSUMED',
+    'message', 'team shared quota consumed',
+    'row', row_to_json(v_pool)::jsonb,
+    'quota', public.team_quota_snapshot(p_team_id, p_provider_id)
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'code', 'DB_ERROR',
+      'message', SQLERRM
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.team_consume_quota_and_finalize(uuid, uuid, text, numeric, uuid, date, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.team_consume_quota_and_finalize(uuid, uuid, text, numeric, uuid, date, uuid)
+  IS 'Atomic team shared quota consume + member usage + quota_operations finalize. Team member only.';
+
+-- ============ 4. admin_reset_team_quota ============
+CREATE OR REPLACE FUNCTION public.admin_reset_team_quota(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_admin_id UUID := auth.uid();
+  v_today DATE := (now() AT TIME ZONE 'Asia/Shanghai')::date;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('team_quota:' || p_team_id::text || ':' || v_today::text, 0));
+
+  UPDATE public.quota_ledger
+  SET used = 0,
+      remaining = daily_total,
+      reserved = 0,
+      refreshed_at = now()
+  WHERE date = v_today
+    AND team_id = p_team_id;
+
+  UPDATE public.member_usage
+  SET used_equivalent = 0
+  WHERE date = v_today
+    AND team_id = p_team_id;
+
+  UPDATE public.teams
+  SET status = 'active'
+  WHERE id = p_team_id AND status = 'exhausted';
+
+  INSERT INTO public.audit_logs (admin_user_id, team_id, action, target, metadata)
+  VALUES (
+    v_admin_id,
+    p_team_id,
+    'quota.reset',
+    p_team_id::text,
+    json_build_object('date', v_today)
+  );
+
+  RETURN json_build_object(
+    'ok', true,
+    'team_id', p_team_id,
+    'date', v_today
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_reset_team_quota(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_reset_team_quota(uuid)
+  IS 'Reset today team shared quota, account ledgers, and member usage. Admin only.';
+
+-- ============ 5. Extend admin_list_teams with quota ============
+CREATE OR REPLACE FUNCTION public.admin_list_teams(
+  p_search TEXT DEFAULT NULL,
+  p_status TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM teams t
+  LEFT JOIN profiles owner ON owner.id = t.owner_id
+  WHERE
+    (p_search IS NULL OR p_search = '' OR t.name ILIKE '%' || p_search || '%' OR owner.email ILIKE '%' || p_search || '%' OR owner.display_name ILIKE '%' || p_search || '%')
+    AND (p_status IS NULL OR p_status = '' OR t.status = p_status);
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      t.id,
+      t.name,
+      t.owner_id,
+      owner.email AS owner_email,
+      owner.display_name AS owner_name,
+      owner.status AS owner_status,
+      t.plan,
+      t.seats_limit,
+      t.status,
+      t.created_at,
+      (
+        SELECT count(*)
+        FROM team_members tm
+        WHERE tm.team_id = t.id
+      ) AS member_count,
+      (
+        SELECT count(*)
+        FROM team_members tm
+        JOIN profiles mp ON mp.id = tm.user_id
+        WHERE tm.team_id = t.id
+          AND mp.status = 'active'
+      ) AS active_member_count,
+      (
+        SELECT json_build_object(
+          'plan', s.plan,
+          'status', s.status,
+          'seats', s.seats,
+          'current_period_start', s.current_period_start,
+          'current_period_end', s.current_period_end
+        )
+        FROM subscriptions s
+        WHERE s.team_id = t.id
+        ORDER BY s.created_at DESC
+        LIMIT 1
+      ) AS subscription,
+      public.team_quota_snapshot(t.id, 'doubao') AS quota,
+      COALESCE((SELECT SUM(COALESCE(j.equivalent_count, 0)) FROM jobs j WHERE j.team_id = t.id AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'), 0) AS month_usage,
+      COALESCE((SELECT SUM(COALESCE(j.equivalent_count, 0)) FROM jobs j WHERE j.team_id = t.id), 0) AS total_usage,
+      (SELECT count(*) FROM provider_keys pk WHERE pk.team_id = t.id) AS key_count
+    FROM teams t
+    LEFT JOIN profiles owner ON owner.id = t.owner_id
+    WHERE
+      (p_search IS NULL OR p_search = '' OR t.name ILIKE '%' || p_search || '%' OR owner.email ILIKE '%' || p_search || '%' OR owner.display_name ILIKE '%' || p_search || '%')
+      AND (p_status IS NULL OR p_status = '' OR t.status = p_status)
+    ORDER BY t.created_at DESC, t.id
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_teams(text, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_teams(text, text, integer, integer)
+  IS 'Admin team list with owner, members, subscription, shared quota, usage, and key count. Admin only.';
+
+-- ============ 6. Extend get_team_detail with quota ============
+CREATE OR REPLACE FUNCTION public.get_team_detail(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_row JSON;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM team_members tm
+    WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT json_build_object(
+    'id', t.id,
+    'name', t.name,
+    'owner_id', t.owner_id,
+    'owner_email', owner.email,
+    'owner_name', owner.display_name,
+    'owner_status', owner.status,
+    'plan', t.plan,
+    'seats_limit', t.seats_limit,
+    'status', t.status,
+    'created_at', t.created_at,
+    'member_count', (SELECT count(*) FROM team_members tm WHERE tm.team_id = t.id),
+    'active_member_count', (SELECT count(*) FROM team_members tm JOIN profiles mp ON mp.id = tm.user_id WHERE tm.team_id = t.id AND mp.status = 'active'),
+    'subscription', CASE
+      WHEN EXISTS (SELECT 1 FROM subscriptions s WHERE s.team_id = t.id)
+      THEN (
+        SELECT json_build_object(
+          'plan', s.plan,
+          'status', s.status,
+          'seats', s.seats,
+          'current_period_start', s.current_period_start,
+          'current_period_end', s.current_period_end
+        )
+        FROM subscriptions s
+        WHERE s.team_id = t.id
+        ORDER BY s.created_at DESC
+        LIMIT 1
+      )
+      ELSE NULL
+    END,
+    'quota', public.team_quota_snapshot(t.id, 'doubao'),
+    'month_usage', COALESCE((SELECT SUM(COALESCE(j.equivalent_count, 0)) FROM jobs j WHERE j.team_id = t.id AND j.created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'), 0),
+    'total_usage', COALESCE((SELECT SUM(COALESCE(j.equivalent_count, 0)) FROM jobs j WHERE j.team_id = t.id), 0),
+    'key_count', (SELECT count(*) FROM provider_keys pk WHERE pk.team_id = t.id),
+    'current_user_role', (SELECT tm.role FROM team_members tm WHERE tm.team_id = t.id AND tm.user_id = v_user_id)
+  )
+  INTO v_row
+  FROM teams t
+  LEFT JOIN profiles owner ON owner.id = t.owner_id
+  WHERE t.id = p_team_id;
+
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'team not found';
+  END IF;
+
+  RETURN json_build_object('team', v_row);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_team_detail(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_team_detail(uuid)
+  IS 'Team detail for the signed-in member, including owner profile, shared quota, and usage summary.';

--- a/migrations/0015_team_account_scope_rpc.sql
+++ b/migrations/0015_team_account_scope_rpc.sql
@@ -1,0 +1,139 @@
+-- 0015_team_account_scope_rpc.sql
+-- Desktop team/account scope controls:
+--   team_leave             non-owner member leaves team and unshares own team keys
+--   set_provider_key_scope own provider key can be moved between personal/team scope
+-- Idempotent: uses CREATE OR REPLACE FUNCTION and explicit GRANTs.
+
+-- ============ 1. team_leave ============
+CREATE OR REPLACE FUNCTION public.team_leave(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_role TEXT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT tm.role
+  INTO v_role
+  FROM public.team_members tm
+  WHERE tm.team_id = p_team_id
+    AND tm.user_id = v_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    RAISE EXCEPTION 'owner cannot leave team';
+  END IF;
+
+  DELETE FROM public.team_members
+  WHERE team_id = p_team_id AND user_id = v_user_id;
+
+  UPDATE public.provider_keys
+  SET team_id = NULL
+  WHERE owner_user_id = v_user_id
+    AND team_id = p_team_id;
+
+  RETURN json_build_object('ok', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.team_leave(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.team_leave(uuid)
+  IS 'Let a non-owner member leave a team and unshare their own provider keys for that team. Owner cannot leave.';
+
+-- ============ 2. set_provider_key_scope ============
+CREATE OR REPLACE FUNCTION public.set_provider_key_scope(
+  p_key_id UUID,
+  p_team_id UUID DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.provider_keys pk
+    WHERE pk.id = p_key_id AND pk.owner_user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: not the account owner' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_team_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.team_id = p_team_id AND tm.user_id = v_user_id
+    ) THEN
+      RAISE EXCEPTION 'forbidden: not a member of target team' USING ERRCODE = '42501';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM public.teams t
+      WHERE t.id = p_team_id AND t.status = 'active'
+    ) THEN
+      RAISE EXCEPTION 'team not active';
+    END IF;
+  END IF;
+
+  UPDATE public.provider_keys
+  SET team_id = p_team_id
+  WHERE id = p_key_id AND owner_user_id = v_user_id;
+
+  RETURN json_build_object(
+    'ok', true,
+    'key_id', p_key_id,
+    'team_id', p_team_id
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_provider_key_scope(uuid, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.set_provider_key_scope(uuid, uuid)
+  IS 'Set an owned provider key to personal (NULL team_id) or a team where the caller is a member.';
+
+-- ============ 3. Tighten direct provider_key writes ============
+DROP POLICY IF EXISTS "provider_keys_insert" ON public.provider_keys;
+CREATE POLICY "provider_keys_insert" ON public.provider_keys
+  FOR INSERT WITH CHECK (
+    owner_user_id = auth.uid()
+    AND (
+      team_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM public.team_members tm
+        WHERE tm.team_id = provider_keys.team_id
+          AND tm.user_id = auth.uid()
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "provider_keys_update_own" ON public.provider_keys;
+CREATE POLICY "provider_keys_update_own" ON public.provider_keys
+  FOR UPDATE USING (owner_user_id = auth.uid())
+  WITH CHECK (
+    owner_user_id = auth.uid()
+    AND (
+      team_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM public.team_members tm
+        WHERE tm.team_id = provider_keys.team_id
+          AND tm.user_id = auth.uid()
+      )
+    )
+  );

--- a/migrations/0016_provider_refresh_speed.sql
+++ b/migrations/0016_provider_refresh_speed.sql
@@ -1,0 +1,118 @@
+-- 0016_provider_refresh_speed.sql
+-- Provider list refresh speed:
+--   - team ledger today query index
+--   - ensure_provider_ledger_rows batch-initializes today rows for many keys in one RPC
+-- Idempotent: CREATE OR REPLACE + IF NOT EXISTS + explicit GRANTs.
+
+CREATE INDEX IF NOT EXISTS idx_quota_ledger_team_date
+  ON public.quota_ledger (team_id, date DESC);
+
+CREATE OR REPLACE FUNCTION public.ensure_provider_ledger_rows(
+  p_user_id UUID,
+  p_team_id UUID DEFAULT NULL,
+  p_key_ids UUID[] DEFAULT '{}'::uuid[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_today DATE := (now() AT TIME ZONE 'Asia/Shanghai')::date;
+  v_rows JSON;
+BEGIN
+  IF v_user_id IS NULL OR p_user_id IS DISTINCT FROM v_user_id THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_team_id IS NULL THEN
+    IF EXISTS (
+      SELECT 1
+      FROM public.provider_keys pk
+      WHERE pk.id = ANY(p_key_ids)
+        AND (pk.owner_user_id <> v_user_id OR pk.team_id IS NOT NULL)
+    ) THEN
+      RAISE EXCEPTION 'forbidden: personal scope only' USING ERRCODE = '42501';
+    END IF;
+  ELSE
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.team_members tm
+      WHERE tm.team_id = p_team_id
+        AND tm.user_id = v_user_id
+    ) THEN
+      RAISE EXCEPTION 'forbidden: not a team member' USING ERRCODE = '42501';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.teams t
+      WHERE t.id = p_team_id
+        AND t.status = 'active'
+    ) THEN
+      RAISE EXCEPTION 'team not active';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1
+      FROM public.provider_keys pk
+      WHERE pk.id = ANY(p_key_ids)
+        AND pk.team_id IS DISTINCT FROM p_team_id
+    ) THEN
+      RAISE EXCEPTION 'forbidden: team scope mismatch' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  INSERT INTO public.quota_ledger (
+    date,
+    team_id,
+    owner_user_id,
+    account_key_id,
+    provider_id,
+    unit_name,
+    daily_total,
+    used,
+    remaining,
+    reserved
+  )
+  SELECT
+    v_today,
+    pk.team_id,
+    pk.owner_user_id,
+    pk.id,
+    pk.provider_id,
+    COALESCE(p.unit_name, '点'),
+    COALESCE(pk.daily_quota, p.default_daily_quota, 0),
+    0,
+    COALESCE(pk.daily_quota, p.default_daily_quota, 0),
+    0
+  FROM public.provider_keys pk
+  JOIN public.providers p ON p.id = pk.provider_id
+  WHERE pk.id = ANY(p_key_ids)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.quota_ledger l
+      WHERE l.date = v_today
+        AND l.team_id IS NOT DISTINCT FROM pk.team_id
+        AND l.owner_user_id IS NOT DISTINCT FROM pk.owner_user_id
+        AND l.account_key_id = pk.id
+        AND l.provider_id = pk.provider_id
+    )
+  ON CONFLICT DO NOTHING;
+
+  SELECT COALESCE(json_agg(l ORDER BY l.account_key_id), '[]'::json)
+  INTO v_rows
+  FROM public.quota_ledger l
+  WHERE l.date = v_today
+    AND l.account_key_id = ANY(p_key_ids)
+    AND l.team_id IS NOT DISTINCT FROM p_team_id;
+
+  RETURN v_rows::jsonb;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.ensure_provider_ledger_rows(uuid, uuid, uuid[]) TO authenticated;
+
+COMMENT ON FUNCTION public.ensure_provider_ledger_rows(uuid, uuid, uuid[])
+  IS 'Batch-ensure today quota_ledger rows for owned personal keys or keys shared to a team the caller belongs to. Owner/team-member only.';

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -20,6 +20,9 @@ export function todayKey(): string {
 
 export type TeamRole = 'admin' | 'member'
 
+export type ViewScope = 'personal' | 'team' | 'global'
+export type UsageScope = 'personal' | 'team'
+
 export interface TeamContext {
   id: string
   role: TeamRole
@@ -73,6 +76,22 @@ export interface TeamDetail {
   total_usage: number
   key_count: number
   current_user_role: TeamRole
+  quota: TeamQuota | null
+}
+
+export interface TeamQuota {
+  provider_id: string
+  daily_total: number
+  used: number
+  remaining: number
+  reserved: number
+}
+
+export interface TeamQuotaSummary {
+  team_id: string
+  quota: TeamQuota
+  member_used: number
+  member_limit: number | null
 }
 
 export interface TeamMemberView {
@@ -138,6 +157,16 @@ export class TeamService {
     return normalizeTeamDetail(raw.team)
   }
 
+  async getQuota(teamId: string, providerId = 'doubao'): Promise<TeamQuotaSummary | null> {
+    const { data, error } = await this.client.rpc('get_team_quota', {
+      p_team_id: teamId,
+      p_provider_id: providerId
+    })
+    if (error) throw error
+    if (!data) return null
+    return normalizeTeamQuotaSummary(data as Record<string, unknown>)
+  }
+
   async listMembers(teamId: string): Promise<TeamMemberView[]> {
     const { data, error } = await this.client.rpc('get_team_members', { p_team_id: teamId })
     if (error) throw error
@@ -186,6 +215,11 @@ export class TeamService {
       .eq('user_id', targetUserId)
     if (error) throw error
   }
+
+  async leaveTeam(teamId: string): Promise<void> {
+    const { error } = await this.client.rpc('team_leave', { p_team_id: teamId })
+    if (error) throw error
+  }
 }
 
 function normalizeTeamDetail(it: Record<string, unknown>): TeamDetail {
@@ -206,7 +240,30 @@ function normalizeTeamDetail(it: Record<string, unknown>): TeamDetail {
     month_usage: Number(it.month_usage ?? 0),
     total_usage: Number(it.total_usage ?? 0),
     key_count: Number(it.key_count ?? 0),
-    current_user_role: (it.current_user_role === 'admin' ? 'admin' : 'member') as TeamRole
+    current_user_role: (it.current_user_role === 'admin' ? 'admin' : 'member') as TeamRole,
+    quota: normalizeTeamQuota(it.quota as Record<string, unknown> | null)
+  }
+}
+
+function normalizeTeamQuota(it: Record<string, unknown> | null | undefined): TeamQuota | null {
+  if (!it) return null
+  return {
+    provider_id: String(it.provider_id ?? ''),
+    daily_total: Number(it.daily_total ?? 0),
+    used: Number(it.used ?? 0),
+    remaining: Number(it.remaining ?? 0),
+    reserved: Number(it.reserved ?? 0)
+  }
+}
+
+function normalizeTeamQuotaSummary(it: Record<string, unknown>): TeamQuotaSummary | null {
+  const quota = normalizeTeamQuota(it.quota as Record<string, unknown> | null)
+  if (!quota) return null
+  return {
+    team_id: String(it.team_id ?? ''),
+    quota,
+    member_used: Number(it.member_used ?? 0),
+    member_limit: it.member_limit == null ? null : Number(it.member_limit)
   }
 }
 
@@ -382,6 +439,16 @@ export class ProviderService {
     return (data ?? []) as unknown as ProviderKey[]
   }
 
+  async listTeamProviderKeys(teamId: string): Promise<ProviderKey[]> {
+    const { data, error } = await this.client
+      .from('provider_keys')
+      .select('*')
+      .eq('team_id', teamId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as unknown as ProviderKey[]
+  }
+
   async addProviderKey(input: AddProviderKeyInput): Promise<ProviderKey | null> {
     const payload: Record<string, unknown> = {
       owner_user_id: input.ownerUserId,
@@ -483,6 +550,14 @@ export class ProviderService {
     if (error) throw error
   }
 
+  async setProviderKeyScope(keyId: string, teamId: string | null): Promise<void> {
+    const { error } = await this.client.rpc('set_provider_key_scope', {
+      p_key_id: keyId,
+      p_team_id: teamId ?? null
+    })
+    if (error) throw error
+  }
+
   /** 设为默认账号：通过 RPC 事务化完成清旧+设新，消除中间态空窗 */
   async setDefaultKey(userId: string, providerId: string, keyId: string): Promise<LedgerResult> {
     const { data, error } = await this.client.rpc('set_default_key', {
@@ -501,6 +576,56 @@ export class ProviderService {
       .select('*')
       .eq('owner_user_id', userId)
       .order('date', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as unknown as QuotaLedgerRow[]
+  }
+
+  async listTeamLedger(teamId: string): Promise<QuotaLedgerRow[]> {
+    const { data, error } = await this.client
+      .from('quota_ledger')
+      .select('*')
+      .eq('team_id', teamId)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as unknown as QuotaLedgerRow[]
+  }
+
+  async listTodayLedger(userId: string): Promise<QuotaLedgerRow[]> {
+    const today = todayKey()
+    const { data, error } = await this.client
+      .from('quota_ledger')
+      .select('*')
+      .eq('owner_user_id', userId)
+      .eq('date', today)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as unknown as QuotaLedgerRow[]
+  }
+
+  async listTeamTodayLedger(teamId: string): Promise<QuotaLedgerRow[]> {
+    const today = todayKey()
+    const { data, error } = await this.client
+      .from('quota_ledger')
+      .select('*')
+      .eq('team_id', teamId)
+      .eq('date', today)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as unknown as QuotaLedgerRow[]
+  }
+
+  /** 批量初始化缺失的今日额度行，避免厂商列表/调度前对每个账号逐个请求。 */
+  async ensureProviderLedgerRows(
+    userId: string,
+    teamId: string | null,
+    keyIds: string[]
+  ): Promise<QuotaLedgerRow[]> {
+    if (keyIds.length === 0) return []
+    const { data, error } = await this.client.rpc('ensure_provider_ledger_rows', {
+      p_user_id: userId,
+      p_team_id: teamId ?? null,
+      p_key_ids: keyIds
+    })
     if (error) throw error
     return (data ?? []) as unknown as QuotaLedgerRow[]
   }
@@ -614,6 +739,43 @@ export class ProviderService {
     throw new Error(`[${result.code || 'UNKNOWN'}] ${result.message || '额度扣减失败'}`)
   }
 
+  async consumeTeamQuotaAndFinalize(
+    input: {
+      teamId: string
+      userId: string
+      providerId: string
+      amount: number
+      keyId?: string | null
+      date?: string
+      jobId?: string | null
+    }
+  ): Promise<{ ok: boolean; code?: string; message?: string; row?: QuotaLedgerRow | null; quota?: TeamQuota | null }> {
+    const { data, error } = await this.client.rpc('team_consume_quota_and_finalize', {
+      p_team_id: input.teamId,
+      p_user_id: input.userId,
+      p_provider_id: input.providerId,
+      p_amount: input.amount,
+      p_account_key_id: input.keyId ?? null,
+      p_date: input.date ?? todayKey(),
+      p_job_id: input.jobId ?? null
+    })
+    if (error) throw error
+    const raw = (data ?? { ok: false, code: 'DB_ERROR', message: 'RPC 返回空' }) as {
+      ok?: boolean
+      code?: string
+      message?: string
+      row?: Record<string, unknown> | null
+      quota?: Record<string, unknown> | null
+    }
+    return {
+      ok: !!raw.ok,
+      code: raw.code,
+      message: raw.message,
+      row: raw.row ? (raw.row as unknown as QuotaLedgerRow) : null,
+      quota: normalizeTeamQuota(raw.quota)
+    }
+  }
+
   /** 释放预占额度（RPC 原子操作） */
   async releaseLedger(
     userId: string,
@@ -663,10 +825,10 @@ export class ProviderService {
   }
 
   /** reconciliation：查找已成功但未 finalize 的 job */
-  async findUnfinalizedJobs(userId: string): Promise<Array<{ jobId: string; costAmount: number; keyId: string | null }>> {
+  async findUnfinalizedJobs(userId: string): Promise<Array<{ jobId: string; costAmount: number; keyId: string | null; teamId: string | null }>> {
     const { data, error } = await this.client
       .from('jobs')
-      .select('id, cost_amount, account_id')
+      .select('id, cost_amount, account_id, team_id')
       .eq('user_id', userId)
       .eq('status', 'success')
       .gt('cost_amount', 0)
@@ -682,9 +844,9 @@ export class ProviderService {
     if (opsError) throw opsError
     const finalizedIds = new Set((ops ?? []).map((o: { job_id: string }) => o.job_id))
 
-    return (data as Array<{ id: string; cost_amount: number; account_id: string | null }>)
+    return (data as Array<{ id: string; cost_amount: number; account_id: string | null; team_id: string | null }>)
       .filter((j) => !finalizedIds.has(j.id))
-      .map((j) => ({ jobId: j.id, costAmount: Number(j.cost_amount ?? 0), keyId: j.account_id }))
+      .map((j) => ({ jobId: j.id, costAmount: Number(j.cost_amount ?? 0), keyId: j.account_id, teamId: j.team_id }))
   }
 }
 


### PR DESCRIPTION
Closes #17

## 提交信息
feat: 团队额度与账号作用域（额度池共享 + 成员账号授权 + 刷新频率配置）

- desktop: 团队额度池共享（membership 拉取 + 额度看板/占用明细），个人/团队额度切换
- desktop: 账号作用域授权（成员可将自己的账号共享给团队，所有者可移除）
- desktop: 新增厂商刷新频率配置（provider_refresh_speed），Dashboard 重排
- admin: 团队详情展示额度与共享账号
- db: 0014_team_quota_rpc / 0015_team_account_scope_rpc / 0016_provider_refresh_speed 迁移
- docs: team-module-mvp.md 更新