### PR TITLE
feat: 打开已绑定账号的厂商官网窗口 + 团队解散

### DIFF
--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -90,6 +90,7 @@ export interface ProviderLoginResult {
 }
 
 const loginWindows = new Map<string, BrowserWindow>()
+const siteWindows = new Map<string, BrowserWindow>()
 
 /**
  * 分区标识：
@@ -626,6 +627,76 @@ function openLoginWindow(providerId: string, keyId?: string): Promise<ProviderLo
   })
 }
 
+/**
+ * 打开已绑定账号对应的官网窗口。
+ * 复用登录/生成分区（persist:qf-p:<provider>:<keyId>），不清理登录态，
+ * 也不会注入登录流程的“已完成登录”操作条。
+ */
+async function openProviderSite(
+  providerId: string,
+  keyId: string,
+  encryptedKey?: string
+): Promise<{ ok: boolean; error?: string }> {
+  const site = providerSite(providerId)
+  const url = site?.loginUrl || site?.healthUrl
+  if (!url) return { ok: false, error: '该厂商仅支持 API Key 绑定，暂不支持打开官网' }
+
+  const partition = partitionFor(providerId, keyId)
+  const winKey = `${providerId}:${keyId}`
+  const existing = siteWindows.get(winKey)
+  if (existing && !existing.isDestroyed()) {
+    existing.show()
+    existing.focus()
+    return { ok: true }
+  }
+
+  const ses = session.fromPartition(partition)
+  ses.setUserAgent(CHROME_UA)
+  if (encryptedKey) {
+    try {
+      const parsed = parseStoredCredentials(encryptedKey)
+      if (parsed.cookies.length > 0) await injectCookies(providerId, parsed.cookies, keyId)
+    } catch {
+      // 解密失败时仍尝试打开官网，至少让用户看到站点本身。
+    }
+  }
+
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 860,
+    minWidth: 960,
+    minHeight: 640,
+    autoHideMenuBar: true,
+    title: '厂商官网 - Quota-Flow',
+    backgroundColor: '#ffffff',
+    webPreferences: {
+      partition,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+  win.webContents.setUserAgent(CHROME_UA)
+  win.webContents.setWindowOpenHandler(({ url: nextUrl }) => {
+    if (nextUrl.startsWith('http')) {
+      return { action: 'allow', overrideBrowserWindowOptions: { width: 960, height: 720 } }
+    }
+    return { action: 'deny' }
+  })
+  siteWindows.set(winKey, win)
+
+  win.on('closed', () => {
+    if (siteWindows.get(winKey) === win) siteWindows.delete(winKey)
+  })
+
+  void win.loadURL(url).catch((e: unknown) => {
+    if (!win.isDestroyed()) win.destroy()
+    siteWindows.delete(winKey)
+    return { ok: false, error: `加载官网失败：${String(e)}` }
+  })
+
+  return { ok: true }
+}
+
 async function healthCheck(
   providerId: string,
   encrypted: string,
@@ -858,6 +929,12 @@ export function initProviders(): void {
   ipcMain.handle('provider:health-check', (_e, providerId: string, encrypted: string, keyId?: string) => {
     return healthCheck(providerId, encrypted, typeof keyId === 'string' ? keyId : undefined)
   })
+
+  ipcMain.handle(
+    'provider:open-site',
+    (_e, providerId: string, keyId: string, encryptedKey?: string) =>
+      openProviderSite(providerId, keyId, typeof encryptedKey === 'string' ? encryptedKey : undefined)
+  )
 
   ipcMain.handle('provider:login-cancel', (_e, providerId: string, keyId?: string) => {
     const winKey = typeof keyId === 'string' && keyId ? `${providerId}:${keyId}` : providerId

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -160,6 +160,12 @@ export interface DesktopApi {
      */
     healthCheck: (providerId: string, encrypted: string, keyId?: string) => Promise<HealthCheckResult>
     /**
+     * 打开已绑定账号对应的官网窗口
+     * @param keyId 账号 key id；使用该账号自己的登录/生成分区
+     * @param encryptedKey 可选：加密后的 Cookie/凭据，打开前会尝试注入到该账号分区
+     */
+    openSite: (providerId: string, keyId: string, encryptedKey?: string) => Promise<{ ok: boolean; error?: string }>
+    /**
      * 取消登录窗口
      * @param keyId 可选：对应 login 传入的 keyId，关闭同一账号的登录窗口
      */
@@ -257,6 +263,8 @@ const api: DesktopApi = {
       ipcRenderer.invoke('provider:encrypt', providerId, plain) as Promise<{ encrypted: string; fingerprint?: string | null }>,
     healthCheck: (providerId, encrypted, keyId) =>
       ipcRenderer.invoke('provider:health-check', providerId, encrypted, keyId) as Promise<HealthCheckResult>,
+    openSite: (providerId, keyId, encryptedKey) =>
+      ipcRenderer.invoke('provider:open-site', providerId, keyId, encryptedKey) as Promise<{ ok: boolean; error?: string }>,
     cancelLogin: (providerId, keyId) =>
       ipcRenderer.invoke('provider:login-cancel', providerId, keyId) as Promise<void>,
     migratePartition: (providerId, srcKeyId, dstKeyId) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -110,6 +110,7 @@ function MainApp({
   const [viewScope, setViewScope] = useState<ViewScope>(() => readStoredViewScope(!!team))
   const [usageScope, setUsageScope] = useState<UsageScope>(readStoredUsageScope)
   // 厂商 / 任务数据提升到 MainApp 层：随 user 挂载/卸载，账号切换时整棵数据树重建，避免残留上一账号数据
+  // 厂商数据由 useProviders 统一持有：切 Tab 不重拉，切换个人/团队/全局模式时按 viewScope 自动刷新。
   const providers = useProviders(viewScope)
   const jobs = useJobs()
   const [bannerDismissed, setBannerDismissed] = useState(() => readWelcomeDismissed(user.id))
@@ -144,19 +145,12 @@ function MainApp({
       ? (t as TabId)
       : 'dispatch'
   })
-  const providersTabActiveRef = useRef(tab === 'providers')
   const [toast, setToast] = useState<string | null>(null)
   const toastTimer = useRef<number | undefined>(undefined)
   const [scopeOpen, setScopeOpen] = useState(false)
   const scopeWrapRef = useRef<HTMLDivElement | null>(null)
   const [renewText, setRenewText] = useState('自动续命：—')
   const [updatePromptVisible, setUpdatePromptVisible] = useState(false)
-
-  useEffect(() => {
-    const wasActive = providersTabActiveRef.current
-    providersTabActiveRef.current = tab === 'providers'
-    if (!wasActive && tab === 'providers') providers.reload()
-  }, [tab, providers.reload])
 
   const scopeLabel = useMemo(() => {
     if (viewScope === 'team') return '团队模式'

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -36,6 +36,7 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
   const [addTarget, setAddTarget] = useState<string | undefined>(undefined)
   const [page, setPage] = useState(1)
   const [justRefreshed, setJustRefreshed] = useState(false)
+  const [siteError, setSiteError] = useState('')
   const wasRefreshing = useRef(false)
 
   useEffect(() => {
@@ -64,6 +65,16 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
   const openAdd = (providerId?: string) => {
     setAddTarget(providerId)
     setShowAddModal(true)
+  }
+
+  const openSite = async (providerId: string, keyId: string, encryptedKey: string) => {
+    setSiteError('')
+    try {
+      const res = await window.api.providers.openSite(providerId, keyId, encryptedKey)
+      if (!res.ok) setSiteError(res.error || '无法打开官网')
+    } catch (e) {
+      setSiteError(e instanceof Error ? e.message : String(e))
+    }
   }
 
   return (
@@ -104,7 +115,9 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
         </div>
       </div>
 
-      {error && <div className="auth-msg auth-msg-error">{error}</div>}
+      {(error || siteError) && (
+        <div className="auth-msg auth-msg-error">{error || siteError}</div>
+      )}
 
       {boundRows.length === 0 && (
           <div className="providers-hint">
@@ -184,6 +197,7 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
                         onSetScope={async (keyId, teamId) => {
                           await setProviderKeyScope(keyId, teamId)
                         }}
+                        onOpenSite={(keyId, encryptedKey) => openSite(p.providerId, keyId, encryptedKey)}
                         currentUserId={user?.id ?? ''}
                         team={team}
                       />
@@ -240,6 +254,7 @@ function ProviderRow({
   onToggleEnabled,
   onUnbind,
   onSetScope,
+  onOpenSite,
   currentUserId,
   team
 }: {
@@ -255,6 +270,7 @@ function ProviderRow({
   onToggleEnabled: (keyId: string, enabled: boolean) => Promise<void>
   onUnbind: (keyId: string) => Promise<void>
   onSetScope: (keyId: string, teamId: string | null) => Promise<void>
+  onOpenSite: (keyId: string, encryptedKey: string) => Promise<void>
   currentUserId: string
   team: { id: string } | null
 }) {
@@ -399,6 +415,14 @@ function ProviderRow({
                         )}
                       </td>
                       <td>
+                        <button
+                          className="btn-sm"
+                          onClick={() => void onOpenSite(acc.keyId, acc.encryptedKey)}
+                          disabled={acc.authType === 'apikey'}
+                          title={acc.authType === 'apikey' ? 'API Key 厂商不支持网页访问' : '打开该账号对应的官网页面'}
+                        >
+                          进入官网
+                        </button>{' '}
                         {acc.ownerUserId === currentUserId ? (
                           <>
                             {acc.teamId ? (

--- a/apps/desktop/src/renderer/src/components/Team.tsx
+++ b/apps/desktop/src/renderer/src/components/Team.tsx
@@ -243,6 +243,24 @@ export default function Team({ active, userId, team, onTeamChanged }: TeamProps)
     }
   }
 
+  async function handleDisband(): Promise<void> {
+    if (!team || !isOwner) return
+    if (!window.confirm('解散团队后，所有成员共享给该团队的账号会变回个人账号，团队相关任务记录也会被清理。确定解散吗？')) return
+    const service = getTeamService()
+    if (!service) return
+    setBusy(true)
+    setError(null)
+    try {
+      await service.disbandTeam(team.id)
+      await onTeamChanged()
+      setNotice('团队已解散')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '解散失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   if (!team) {
     return (
       <div className="tab-wrap">
@@ -443,6 +461,14 @@ export default function Team({ active, userId, team, onTeamChanged }: TeamProps)
                   生成邀请码
                 </button>
               </div>
+              <button
+                className="btn-sm danger"
+                style={{ width: '100%' }}
+                disabled={busy}
+                onClick={() => void handleDisband()}
+              >
+                解散团队
+              </button>
               {invitations.length > 0 ? (
                 <div className="team-invite-list">
                   {invitations.map((invite) => (

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1954,6 +1954,7 @@ body {
   flex-direction: column;
   gap: 10px;
   min-height: 0;
+  overflow-y: auto;
   box-shadow: var(--shadow-card);
 }
 .team-table {

--- a/migrations/0017_team_disband_rpc.sql
+++ b/migrations/0017_team_disband_rpc.sql
@@ -1,0 +1,50 @@
+-- 0017_team_disband_rpc.sql
+-- Desktop team owner can disband a team.
+-- Shared provider keys are unshared before team deletion; team-scoped ledger and
+-- member usage rows are cleaned up so the team does not leave hidden stale rows.
+-- Idempotent: uses CREATE OR REPLACE FUNCTION and explicit GRANTs.
+
+CREATE OR REPLACE FUNCTION public.team_disband(p_team_id UUID)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'forbidden: not signed in' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.teams t
+    WHERE t.id = p_team_id
+      AND t.owner_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'forbidden: only team owner can disband team' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.provider_keys
+  SET team_id = NULL
+  WHERE team_id = p_team_id;
+
+  DELETE FROM public.quota_ledger
+  WHERE team_id = p_team_id;
+
+  DELETE FROM public.member_usage
+  WHERE team_id = p_team_id;
+
+  DELETE FROM public.teams
+  WHERE id = p_team_id
+    AND owner_id = v_user_id;
+
+  RETURN json_build_object('ok', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.team_disband(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.team_disband(uuid)
+  IS 'Disband a team. Only the team owner can disband; all provider keys shared to the team are returned to personal scope.';

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -220,6 +220,11 @@ export class TeamService {
     const { error } = await this.client.rpc('team_leave', { p_team_id: teamId })
     if (error) throw error
   }
+
+  async disbandTeam(teamId: string): Promise<void> {
+    const { error } = await this.client.rpc('team_disband', { p_team_id: teamId })
+    if (error) throw error
+  }
 }
 
 function normalizeTeamDetail(it: Record<string, unknown>): TeamDetail {


### PR DESCRIPTION
Closes #19

## 修改内容

### 1. 厂商官网窗口
- 已绑定账号（Cookie 登录）的厂商，可在账号列表一键打开其官网窗口
- 复用登录/生成分区（persist:qf-p:provider:keyId），保持登录态，无需重新登录
- 不注入登录流程的「已完成登录」操作条，仅打开站点
- 自动注入已保存的 Cookie，若解密失败仍会打开站点
- 窗口复用：已打开时再次点击会聚焦现有窗口，不重复创建
- API Key 绑定的厂商不适用，会提示仅支持官网登录绑定

### 2. 团队解散
- 团队所有者可在团队页解散团队（需二次确认）
- 解散后：成员共享给团队的账号自动变回个人账号，团队相关任务记录被清理
- 新增 0017_team_disband_rpc.sql 迁移（dissolve RPC）