### PR TITLE
feat(admin): 实现审计日志列表页并统一审计写入入口

### DIFF
--- a/apps/admin/src/app/(dashboard)/audit/page.tsx
+++ b/apps/admin/src/app/(dashboard)/audit/page.tsx
@@ -1,6 +1,149 @@
-import { PrototypePage } from "@/components/prototype-page";
-import { PROTOTYPE_PAGE_HTML } from "@/lib/prototype-pages";
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  downloadCsv,
+  listAuditLogs,
+  toCsv,
+  type AuditLog,
+  type AuditLogActionCategory,
+  type AuditLogTimeRange
+} from "@/lib/api/audit";
+import { AuditFilters } from "@/components/audit/audit-filters";
+import { AuditTable } from "@/components/audit/audit-table";
+import { Pagination } from "@/components/users/pagination";
+
+const PAGE_SIZE = 20;
 
 export default function AuditPage() {
-  return <PrototypePage html={PROTOTYPE_PAGE_HTML["audit"]} />;
+  const [action, setAction] = useState<AuditLogActionCategory>("");
+  const [timeRange, setTimeRange] = useState<AuditLogTimeRange>("7d");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const [result, setResult] = useState<{ total: number; items: AuditLog[] }>({ total: 0, items: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  // 搜索输入 300ms 防抖后提交
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        setPage(1);
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listAuditLogs({
+        action,
+        timeRange,
+        search: debouncedSearch,
+        page,
+        pageSize: PAGE_SIZE
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [action, timeRange, debouncedSearch, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // 提示自动消失
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const res = await listAuditLogs({
+        action,
+        timeRange,
+        search: debouncedSearch,
+        page: 1,
+        pageSize: Math.min(result.total || 5000, 5000)
+      });
+      downloadCsv("audit-logs.csv", toCsv(res.items));
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "导出失败");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">审计日志</h1>
+          <p className="page-subtitle">记录管理员关键操作，便于追溯与合规审计</p>
+        </div>
+        <div className="page-actions">
+          <button className="btn btn-secondary btn-sm" onClick={() => void handleExport()} disabled={exporting}>
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            {exporting ? "导出中..." : "导出 CSV"}
+          </button>
+        </div>
+      </div>
+
+      <AuditFilters
+        value={{ action, timeRange, search }}
+        onChange={(v) => {
+          if (v.action !== action) {
+            setAction(v.action);
+            setPage(1);
+          }
+          if (v.timeRange !== timeRange) {
+            setTimeRange(v.timeRange);
+            setPage(1);
+          }
+          if (v.search !== search) setSearch(v.search);
+        }}
+      />
+
+      <AuditTable logs={result.items} loading={loading} error={error} />
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <Pagination page={page} total={result.total} pageSize={PAGE_SIZE} onPageChange={setPage} />
+      </div>
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/admin/src/components/audit/audit-filters.tsx
+++ b/apps/admin/src/components/audit/audit-filters.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  AUDIT_ACTION_GROUPS,
+  type AuditLogActionCategory,
+  type AuditLogTimeRange
+} from "@/lib/api/audit";
+
+export interface AuditFiltersValue {
+  action: AuditLogActionCategory;
+  timeRange: AuditLogTimeRange;
+  search: string;
+}
+
+export function AuditFilters({
+  value,
+  onChange
+}: {
+  value: AuditFiltersValue;
+  onChange: (value: AuditFiltersValue) => void;
+}) {
+  return (
+    <div className="filter-bar">
+      <div className="filter-group">
+        <span className="filter-label">操作类型</span>
+        <select
+          className="form-select"
+          style={{ width: 140 }}
+          value={value.action}
+          onChange={(e) => onChange({ ...value, action: e.target.value as AuditLogActionCategory })}
+        >
+          <option value="">全部</option>
+          {AUDIT_ACTION_GROUPS.map((group) => (
+            <optgroup key={group.value} label={group.label}>
+              <option value={group.value}>{group.label}（全部）</option>
+              {group.actions.map((action) => (
+                <option key={action.value} value={action.value}>
+                  {action.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+
+      <div className="filter-group">
+        <span className="filter-label">时间范围</span>
+        <select
+          className="form-select"
+          style={{ width: 120 }}
+          value={value.timeRange}
+          onChange={(e) => onChange({ ...value, timeRange: e.target.value as AuditLogTimeRange })}
+        >
+          <option value="24h">近 24 小时</option>
+          <option value="7d">近 7 天</option>
+          <option value="30d">近 30 天</option>
+          <option value="all">全部</option>
+        </select>
+      </div>
+
+      <div className="filter-group" style={{ marginLeft: "auto" }}>
+        <input
+          type="text"
+          placeholder="搜索对象 ID 或详情..."
+          style={{ width: 240 }}
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/audit/audit-table.tsx
+++ b/apps/admin/src/components/audit/audit-table.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import type { AuditLog } from "@/lib/api/audit";
+import { actionLabel, metadataSummary } from "@/lib/api/audit";
+import { formatDateTime } from "@/lib/utils/format";
+
+function actionTone(action: string): "info" | "success" | "warning" | "danger" | "muted" {
+  if (action.startsWith("user.ban") || action.startsWith("team.ban") || action.startsWith("provider.delete")) {
+    return "danger";
+  }
+  if (action.startsWith("user.unban") || action.startsWith("team.unban")) {
+    return "success";
+  }
+  if (action.startsWith("quota.")) {
+    return "warning";
+  }
+  if (action.startsWith("provider.")) {
+    return "info";
+  }
+  return "muted";
+}
+
+export function AuditTable({
+  logs,
+  loading,
+  error
+}: {
+  logs: AuditLog[];
+  loading: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="card">
+      <div className="table-container">
+        <table className="table audit-table">
+          <thead>
+            <tr>
+              <th>时间</th>
+              <th>操作</th>
+              <th>操作人</th>
+              <th>团队</th>
+              <th>用户</th>
+              <th>对象</th>
+              <th>详情</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && logs.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="empty-state" style={{ textAlign: "center" }}>
+                  加载中...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="empty-state"
+                  style={{ textAlign: "center", color: "var(--color-destructive)" }}
+                >
+                  {error}
+                </td>
+              </tr>
+            ) : logs.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="empty-state" style={{ textAlign: "center" }}>
+                  暂无匹配的审计日志
+                </td>
+              </tr>
+            ) : (
+              logs.map((log) => (
+                <tr key={log.id}>
+                  <td style={{ whiteSpace: "nowrap" }}>{formatDateTime(log.created_at)}</td>
+                  <td style={{ whiteSpace: "nowrap" }}>
+                    <span className={`badge badge-${actionTone(log.action)}`}>{actionLabel(log.action)}</span>
+                  </td>
+                  <td>
+                    <div>
+                      <div className="cell-primary">{log.admin_name ?? "—"}</div>
+                      {log.admin_email ? (
+                        <div style={{ fontSize: 11, color: "#94A3B8" }}>{log.admin_email}</div>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td>
+                    {log.team_name ? (
+                      <div>
+                        <div className="cell-primary">{log.team_name}</div>
+                      </div>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td>
+                    {log.user_name || log.user_email ? (
+                      <div>
+                        <div className="cell-primary">{log.user_name ?? "—"}</div>
+                        {log.user_email ? (
+                          <div style={{ fontSize: 11, color: "#94A3B8" }}>{log.user_email}</div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="cell-mono">{log.target ?? "—"}</td>
+                  <td style={{ maxWidth: 280 }}>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: "#475569",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap"
+                      }}
+                      title={metadataSummary(log.metadata)}
+                    >
+                      {metadataSummary(log.metadata)}
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/provider-manager.tsx
+++ b/apps/admin/src/components/provider-manager.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from "react";
 import { AlertTriangle, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
 import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { insertAuditLog } from "@/lib/utils/audit";
 import { PROVIDER_ICONS } from "./provider-icons";
 
 export interface ProviderRow {
@@ -49,28 +50,6 @@ function formatNumber(value: number | null | undefined): string {
 
 function isRemoteLogo(logo: string | null | undefined): logo is string {
   return typeof logo === "string" && /^(https?:\/\/|data:image\/)/i.test(logo);
-}
-
-async function insertAuditLog(
-  action: string,
-  target: string,
-  metadata: Record<string, unknown>
-): Promise<string | null> {
-  try {
-    const supabase = createAdminBrowserClient();
-    const { data: auth, error: userError } = await supabase.auth.getUser();
-    if (userError || !auth.user) return null;
-    const { error } = await supabase.from("audit_logs").insert({
-      admin_user_id: auth.user.id,
-      action,
-      target,
-      metadata
-    });
-    if (error) return error.message;
-    return null;
-  } catch {
-    return "审计日志写入失败。";
-  }
 }
 
 interface ToggleMessage {
@@ -158,32 +137,10 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
 
       setMessage({ tone: "success", text: `已${nextEnabled ? "启用" : "停用"} ${provider.name}。` });
 
-      try {
-        const { data: auth, error: userError } = await supabase.auth.getUser();
-        if (!userError && auth.user) {
-          const { error: auditError } = await supabase.from("audit_logs").insert({
-            admin_user_id: auth.user.id,
-            action: "provider.toggle_enabled",
-            target: `providers:${provider.id}`,
-            metadata: {
-              provider_id: provider.id,
-              enabled: nextEnabled
-            }
-          });
-
-          if (auditError) {
-            setMessage({
-              tone: "warning",
-              text: `已${nextEnabled ? "启用" : "停用"} ${provider.name}，但审计日志写入失败：${auditError.message}`
-            });
-          }
-        }
-      } catch {
-        setMessage({
-          tone: "warning",
-          text: `已${nextEnabled ? "启用" : "停用"} ${provider.name}，但审计日志写入失败。`
-        });
-      }
+      await insertAuditLog("provider.toggle_enabled", {
+        target: provider.id,
+        metadata: { provider_id: provider.id, enabled: nextEnabled }
+      });
     } catch (e) {
       setMessage({
         tone: "danger",
@@ -238,21 +195,20 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
         )
       );
 
-      const auditWarning = await insertAuditLog("provider.update", `providers:${editing.id}`, {
-        provider_id: editing.id,
-        name,
-        auth_type: values.auth_type,
-        unit_name: values.unit_name,
-        default_daily_quota: values.default_daily_quota,
-        equivalent_count_divisor: values.equivalent_count_divisor,
-        enabled: values.enabled
+      await insertAuditLog("provider.update", {
+        target: editing.id,
+        metadata: {
+          provider_id: editing.id,
+          name,
+          auth_type: values.auth_type,
+          unit_name: values.unit_name,
+          default_daily_quota: values.default_daily_quota,
+          equivalent_count_divisor: values.equivalent_count_divisor,
+          enabled: values.enabled
+        }
       });
 
-      setMessage(
-        auditWarning
-          ? { tone: "warning", text: `已更新 ${name}，但${auditWarning}` }
-          : { tone: "success", text: `已更新 ${name}。` }
-      );
+      setMessage({ tone: "success", text: `已更新 ${name}。` });
       setEditing(null);
     } catch (e) {
       setMessage({
@@ -354,21 +310,20 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
       };
       setProviders((prev) => sortProviders([...prev, newRow]));
 
-      const auditWarning = await insertAuditLog("provider.create", `providers:${id}`, {
-        provider_id: id,
-        name,
-        auth_type: values.auth_type,
-        unit_name: values.unit_name,
-        default_daily_quota: values.default_daily_quota,
-        equivalent_count_divisor: values.equivalent_count_divisor,
-        enabled: values.enabled
+      await insertAuditLog("provider.create", {
+        target: id,
+        metadata: {
+          provider_id: id,
+          name,
+          auth_type: values.auth_type,
+          unit_name: values.unit_name,
+          default_daily_quota: values.default_daily_quota,
+          equivalent_count_divisor: values.equivalent_count_divisor,
+          enabled: values.enabled
+        }
       });
 
-      setMessage(
-        auditWarning
-          ? { tone: "warning", text: `已创建 ${name}，但${auditWarning}` }
-          : { tone: "success", text: `已创建 ${name}。` }
-      );
+      setMessage({ tone: "success", text: `已创建 ${name}。` });
       setCreating(false);
     } catch (e) {
       setMessage({
@@ -393,16 +348,12 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
 
       setProviders((prev) => prev.filter((row) => row.id !== deleting.id));
 
-      const auditWarning = await insertAuditLog("provider.delete", `providers:${deleting.id}`, {
-        provider_id: deleting.id,
-        name: deleting.name
+      await insertAuditLog("provider.delete", {
+        target: deleting.id,
+        metadata: { provider_id: deleting.id, name: deleting.name }
       });
 
-      setMessage(
-        auditWarning
-          ? { tone: "warning", text: `已删除 ${deleting.name}，但${auditWarning}` }
-          : { tone: "success", text: `已删除 ${deleting.name}。` }
-      );
+      setMessage({ tone: "success", text: `已删除 ${deleting.name}。` });
       setDeleting(null);
     } catch (e) {
       setMessage({

--- a/apps/admin/src/lib/api/announcements.ts
+++ b/apps/admin/src/lib/api/announcements.ts
@@ -1,4 +1,5 @@
 import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { insertAuditLog } from "@/lib/utils/audit";
 
 export type AnnouncementKind = "notice" | "update";
 export type AnnouncementKindFilter = "" | AnnouncementKind;
@@ -71,10 +72,9 @@ export async function createAnnouncement(input: AnnouncementInput): Promise<Admi
     .single();
   if (error) throw error;
 
-  await insertAuditLog("announcement.create", data.id, {
-    title: data.title,
-    kind: data.kind,
-    published: data.published
+  await insertAuditLog("announcement.create", {
+    target: data.id,
+    metadata: { title: data.title, kind: data.kind, published: data.published }
   });
   return data as AdminAnnouncement;
 }
@@ -96,10 +96,9 @@ export async function updateAnnouncement(id: string, input: AnnouncementInput): 
     .single();
   if (error) throw error;
 
-  await insertAuditLog("announcement.update", id, {
-    title: data.title,
-    kind: data.kind,
-    published: data.published
+  await insertAuditLog("announcement.update", {
+    target: id,
+    metadata: { title: data.title, kind: data.kind, published: data.published }
   });
   return data as AdminAnnouncement;
 }
@@ -116,7 +115,7 @@ export async function deleteAnnouncement(id: string, title: string): Promise<voi
     .eq("id", id);
   if (error) throw error;
 
-  await insertAuditLog("announcement.delete", id, { title });
+  await insertAuditLog("announcement.delete", { target: id, metadata: { title } });
 }
 
 export async function toggleAnnouncementPublished(id: string, published: boolean, title: string): Promise<void> {
@@ -131,7 +130,10 @@ export async function toggleAnnouncementPublished(id: string, published: boolean
     .eq("id", id);
   if (error) throw error;
 
-  await insertAuditLog(published ? "announcement.publish" : "announcement.unpublish", id, { title });
+  await insertAuditLog(published ? "announcement.publish" : "announcement.unpublish", {
+    target: id,
+    metadata: { title }
+  });
 }
 
 export function kindLabel(kind: AnnouncementKind): string {
@@ -142,18 +144,3 @@ export function publishedLabel(published: boolean): string {
   return published ? "已发布" : "草稿";
 }
 
-async function insertAuditLog(action: string, target: string, metadata: Record<string, unknown>): Promise<void> {
-  try {
-    const supabase = createAdminBrowserClient();
-    const { data: authData } = await supabase.auth.getUser();
-    if (!authData.user?.id) return;
-    await supabase.from("audit_logs").insert({
-      admin_user_id: authData.user.id,
-      action,
-      target,
-      metadata
-    });
-  } catch {
-    // 审计失败不阻断主操作，避免公告管理被日志写入影响。
-  }
-}

--- a/apps/admin/src/lib/api/audit.ts
+++ b/apps/admin/src/lib/api/audit.ts
@@ -1,0 +1,216 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { formatDateTime } from "@/lib/utils/format";
+
+export type AuditLogActionCategory = "" | "team" | "user" | "provider" | "announcement" | "quota";
+export type AuditLogTimeRange = "24h" | "7d" | "30d" | "all";
+
+export interface AuditLog {
+  id: string;
+  admin_user_id: string;
+  admin_name: string | null;
+  admin_email: string | null;
+  team_id: string | null;
+  team_name: string | null;
+  user_id: string | null;
+  user_name: string | null;
+  user_email: string | null;
+  action: string;
+  target: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface AuditLogListParams {
+  action?: AuditLogActionCategory;
+  teamId?: string;
+  userId?: string;
+  timeRange?: AuditLogTimeRange;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface AuditLogListResult {
+  total: number;
+  items: AuditLog[];
+}
+
+export interface ActionGroup {
+  value: AuditLogActionCategory;
+  label: string;
+  actions: { value: string; label: string }[];
+}
+
+/** action → 中文标签。 */
+export function actionLabel(action: string): string {
+  const map: Record<string, string> = {
+    "team.update": "团队更新",
+    "team.ban": "团队封禁",
+    "team.unban": "团队解封",
+    "user.ban": "用户封禁",
+    "user.unban": "用户解封",
+    "provider.create": "创建 Provider",
+    "provider.update": "更新 Provider",
+    "provider.delete": "删除 Provider",
+    "provider.toggle_enabled": "启用/停用 Provider",
+    "announcement.create": "创建公告",
+    "announcement.update": "更新公告",
+    "announcement.delete": "删除公告",
+    "announcement.publish": "发布公告",
+    "announcement.unpublish": "下架公告",
+    "quota.reset": "重置额度",
+    "key.bind": "绑定账号",
+    "key.unbind": "解绑账号",
+    "sub.update": "订阅变更",
+    "cost.update": "消耗表更新"
+  };
+  return map[action] ?? action;
+}
+
+/** 按资源类型分组的 action 白名单，供筛选下拉使用。 */
+export const AUDIT_ACTION_GROUPS: ActionGroup[] = [
+  {
+    value: "team",
+    label: "团队",
+    actions: [
+      { value: "team.update", label: "团队更新" },
+      { value: "team.ban", label: "团队封禁" },
+      { value: "team.unban", label: "团队解封" }
+    ]
+  },
+  {
+    value: "user",
+    label: "用户",
+    actions: [
+      { value: "user.ban", label: "用户封禁" },
+      { value: "user.unban", label: "用户解封" }
+    ]
+  },
+  {
+    value: "provider",
+    label: "Provider",
+    actions: [
+      { value: "provider.create", label: "创建 Provider" },
+      { value: "provider.update", label: "更新 Provider" },
+      { value: "provider.delete", label: "删除 Provider" },
+      { value: "provider.toggle_enabled", label: "启用/停用 Provider" }
+    ]
+  },
+  {
+    value: "announcement",
+    label: "公告",
+    actions: [
+      { value: "announcement.create", label: "创建公告" },
+      { value: "announcement.update", label: "更新公告" },
+      { value: "announcement.delete", label: "删除公告" },
+      { value: "announcement.publish", label: "发布公告" },
+      { value: "announcement.unpublish", label: "下架公告" }
+    ]
+  },
+  {
+    value: "quota",
+    label: "额度",
+    actions: [
+      { value: "quota.reset", label: "重置额度" }
+    ]
+  }
+];
+
+/** 全部 action 条目（平铺），用于按具体 action 筛选。 */
+export const AUDIT_ACTIONS = AUDIT_ACTION_GROUPS.flatMap((g) => g.actions);
+
+function timeRangeToDates(range: AuditLogTimeRange): { from: Date | null; to: Date | null } {
+  const now = new Date();
+  switch (range) {
+    case "24h":
+      return { from: new Date(now.getTime() - 24 * 60 * 60 * 1000), to: null };
+    case "7d":
+      return { from: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), to: null };
+    case "30d":
+      return { from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000), to: null };
+    default:
+      return { from: null, to: null };
+  }
+}
+
+export async function listAuditLogs(params: AuditLogListParams = {}): Promise<AuditLogListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+  const { from, to } = timeRangeToDates(params.timeRange ?? "all");
+
+  const { data, error } = await supabase.rpc("admin_list_audit_logs", {
+    p_action: params.action || null,
+    p_team_id: params.teamId || null,
+    p_user_id: params.userId || null,
+    p_from: from?.toISOString() || null,
+    p_to: to?.toISOString() || null,
+    p_search: params.search?.trim() || null,
+    p_limit: pageSize,
+    p_offset: (page - 1) * pageSize
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { total: 0, items: [] }) as { total: number; items: unknown[] };
+  return {
+    total: Number(raw.total ?? 0),
+    items: (raw.items ?? []).map((it) => normalizeAuditLog(it as Record<string, unknown>))
+  };
+}
+
+export function toCsv(logs: AuditLog[]): string {
+  const header = ["时间", "操作", "操作人", "操作人邮箱", "团队", "用户", "用户邮箱", "对象", "详情"];
+  const rows = logs.map((log) => [
+    formatDateTime(log.created_at),
+    actionLabel(log.action),
+    log.admin_name ?? log.admin_email ?? "—",
+    log.admin_email ?? "—",
+    log.team_name ?? "—",
+    log.user_name ?? log.user_email ?? "—",
+    log.user_email ?? "—",
+    log.target ?? "—",
+    metadataSummary(log.metadata)
+  ]);
+  const csv = [header, ...rows]
+    .map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(","))
+    .join("\n");
+  return "\ufeff" + csv;
+}
+
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/** metadata 摘要：取前 3 个非内部字段，以 key=value 形式展示。 */
+export function metadataSummary(metadata: Record<string, unknown> | null | undefined): string {
+  if (!metadata || typeof metadata !== "object") return "—";
+  const entries = Object.entries(metadata)
+    .filter(([key]) => key !== "id" && key !== "created_at" && key !== "updated_at")
+    .slice(0, 3)
+    .map(([key, value]) => `${key}=${String(value ?? "")}`);
+  return entries.length ? entries.join(", ") : "—";
+}
+
+function normalizeAuditLog(it: Record<string, unknown>): AuditLog {
+  return {
+    id: String(it.id ?? ""),
+    admin_user_id: String(it.admin_user_id ?? ""),
+    admin_name: (it.admin_name as string) ?? null,
+    admin_email: (it.admin_email as string) ?? null,
+    team_id: (it.team_id as string) ?? null,
+    team_name: (it.team_name as string) ?? null,
+    user_id: (it.user_id as string) ?? null,
+    user_name: (it.user_name as string) ?? null,
+    user_email: (it.user_email as string) ?? null,
+    action: String(it.action ?? ""),
+    target: (it.target as string) ?? null,
+    metadata: (it.metadata as Record<string, unknown>) ?? {},
+    created_at: String(it.created_at ?? "")
+  };
+}

--- a/apps/admin/src/lib/api/teams.ts
+++ b/apps/admin/src/lib/api/teams.ts
@@ -1,4 +1,5 @@
 import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { insertAuditLog } from "@/lib/utils/audit";
 
 export type TeamStatus = "active" | "banned" | "exhausted" | "expired";
 export type TeamStatusFilter = "" | TeamStatus;
@@ -119,20 +120,11 @@ export async function updateTeamSettings(teamId: string, input: TeamSettingsInpu
     .eq("id", teamId);
   if (error) throw error;
 
-  try {
-    const { data: authData } = await supabase.auth.getUser();
-    if (authData.user?.id) {
-      await supabase.from("audit_logs").insert({
-        admin_user_id: authData.user.id,
-        team_id: teamId,
-        action: "team.update",
-        target: teamId,
-        metadata: payload
-      });
-    }
-  } catch {
-    // 审计日志失败不阻断主操作。
-  }
+  await insertAuditLog("team.update", {
+    teamId,
+    target: teamId,
+    metadata: payload
+  });
 }
 
 export async function resetTeamQuota(teamId: string): Promise<void> {

--- a/apps/admin/src/lib/api/users.ts
+++ b/apps/admin/src/lib/api/users.ts
@@ -1,4 +1,5 @@
 import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { insertAuditLog } from "@/lib/utils/audit";
 import { formatDate } from "@/lib/utils/format";
 
 export type UserStatus = "active" | "banned" | "exhausted";
@@ -75,17 +76,11 @@ export async function setUserStatus(userId: string, status: UserStatus): Promise
   if (error) throw error;
 
   // 写审计日志（失败不阻断主操作，仅静默忽略）
-  const { data: authData } = await supabase.auth.getUser();
-  const adminUserId = authData.user?.id;
-  if (adminUserId) {
-    await supabase.from("audit_logs").insert({
-      admin_user_id: adminUserId,
-      user_id: userId,
-      action: status === "banned" ? "user.ban" : "user.unban",
-      target: userId,
-      metadata: {}
-    });
-  }
+  await insertAuditLog(status === "banned" ? "user.ban" : "user.unban", {
+    userId,
+    target: userId,
+    metadata: { previous_status: status === "banned" ? "active" : "banned" }
+  });
 }
 
 export async function listRecentJobs(userId: string, limit = 10): Promise<RecentJob[]> {

--- a/apps/admin/src/lib/utils/audit.ts
+++ b/apps/admin/src/lib/utils/audit.ts
@@ -1,0 +1,32 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+
+export interface AuditLogInput {
+  teamId?: string | null;
+  userId?: string | null;
+  target?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * 统一写入审计日志入口。
+ * 通过 SECURITY DEFINER RPC 写入，服务端强制使用 auth.uid() 作为操作人，
+ * 失败时静默忽略，不阻断主业务操作。
+ */
+export async function insertAuditLog(action: string, input: AuditLogInput = {}): Promise<void> {
+  try {
+    const supabase = createAdminBrowserClient();
+    const { error } = await supabase.rpc("admin_write_audit_log", {
+      p_action: action,
+      p_team_id: input.teamId ?? null,
+      p_user_id: input.userId ?? null,
+      p_target: input.target ?? null,
+      p_metadata: input.metadata ?? {}
+    });
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.warn("audit log write failed:", error.message);
+    }
+  } catch {
+    // 审计日志失败不阻断主操作。
+  }
+}

--- a/docs/develop/admin-audit-log.md
+++ b/docs/develop/admin-audit-log.md
@@ -1,0 +1,208 @@
+# 后台「审计日志」实现总结
+
+> 完成日期：2026-08-14
+> 实现范围：apps/admin 审计日志页（从静态原型替换为真实数据驱动）+ 统一审计写入入口
+> 关联设计：[admin-system-plan.md](./admin-system-plan.md)、REQUIREMENTS.md §13.4.5
+
+---
+
+## 1. 背景
+
+`apps/admin` 审计日志页此前为纯静态原型：仅渲染 `PrototypePage` 注入的 `docs/prototype/admin.html` 片段，筛选器、表格、分页、导出均为假数据。
+
+同时，审计日志写入逻辑散落在多个模块：
+
+- `apps/admin/src/lib/api/teams.ts` 内联 `insert`
+- `apps/admin/src/lib/api/users.ts` 内联 `insert`
+- `apps/admin/src/lib/api/announcements.ts` 私有 `insertAuditLog`
+- `apps/admin/src/components/provider-manager.tsx` 另一份私有 `insertAuditLog`（返回错误串）
+- `migrations/0014_team_quota_rpc.sql` 服务端 RPC 内写
+
+存在以下问题：
+
+1. 缺少列表 RPC，页面无法接入真实数据。
+2. 写入逻辑重复 3 份，签名不一致。
+3. action 命名不统一：`team.update` / `user.ban` vs `provider.toggle_enabled`。
+4. target 语义混乱：`teams.ts` 存 `teamId`，`provider-manager.tsx` 存 `providers:${id}`。
+5. 客户端直接 insert 时 `admin_user_id` 取自 `auth.getUser()`，存在管理员伪造操作人风险。
+
+本次改造：新增数据库 RPC、统一写入工具、API 层、页面组件，并重构所有现有写入点。
+
+---
+
+## 2. 改动总览
+
+| 文件 | 改动类型 | 说明 |
+|------|---------|------|
+| `migrations/0018_audit_rpc.sql` | 新增 | `admin_list_audit_logs` + `admin_write_audit_log` RPC + 索引 |
+| `apps/admin/src/lib/utils/audit.ts` | 新增 | 统一审计写入入口 `insertAuditLog` |
+| `apps/admin/src/lib/api/audit.ts` | 新增 | 列表查询、类型、action 中文标签、分组白名单、CSV 导出 |
+| `apps/admin/src/components/audit/audit-filters.tsx` | 新增 | 操作类型/时间范围/搜索筛选 |
+| `apps/admin/src/components/audit/audit-table.tsx` | 新增 | 审计日志表格 |
+| `apps/admin/src/app/(dashboard)/audit/page.tsx` | 重写 | 由静态原型改为真实数据驱动页面 |
+| `apps/admin/src/lib/api/users.ts` | 重构 | 封禁/解封改为统一 `insertAuditLog` |
+| `apps/admin/src/lib/api/teams.ts` | 重构 | 团队更新改为统一 `insertAuditLog` |
+| `apps/admin/src/lib/api/announcements.ts` | 重构 | 公告操作改为统一 `insertAuditLog` |
+| `apps/admin/src/components/provider-manager.tsx` | 重构 | Provider CRUD/启停改为统一 `insertAuditLog`，target 规范为纯 id |
+
+---
+
+## 3. 数据库改动
+
+### 3.1 `admin_list_audit_logs`
+
+```sql
+CREATE OR REPLACE FUNCTION public.admin_list_audit_logs(
+  p_action TEXT DEFAULT NULL,        -- action 前缀匹配，如 'user.' / 'provider.'
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_from TIMESTAMPTZ DEFAULT NULL,
+  p_to TIMESTAMPTZ DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,        -- 模糊匹配 target / metadata::text
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json   -- { total, items: [...] }
+```
+
+关键点：
+
+- **安全**：`SECURITY DEFINER SET search_path = public, auth`，首行 `IF NOT public.is_admin() THEN RAISE EXCEPTION` 兜底。
+- **可读字段**：item 中 `LEFT JOIN profiles`（操作人 + 目标用户）、`LEFT JOIN teams`（团队名），前端无需二次拼装。
+- **筛选**：`p_action` 用 `LIKE p_action || '%'`，支持按资源类别（如 `team`）或具体 action（如 `team.update`）过滤。
+- **搜索**：`target` + `metadata::text` 双字段 ILIKE 模糊匹配；配合 GIN 索引优化 JSONB 搜索。
+- **排序**：`ORDER BY al.created_at DESC, al.id DESC`，保证分页稳定。
+
+### 3.2 `admin_write_audit_log`
+
+```sql
+CREATE OR REPLACE FUNCTION public.admin_write_audit_log(
+  p_action TEXT,
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_target TEXT DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS json   -- { ok: true }
+```
+
+关键点：
+
+- **强制操作人**：`v_admin_id UUID := auth.uid()`，由服务端会话决定，无法通过客户端参数伪造。
+- **权限校验**：同样通过 `public.is_admin()` 守卫。
+- **幂等可重试**：函数内部只做单次 `INSERT`，失败由调用方静默处理。
+
+### 3.3 索引优化
+
+- `idx_audit_logs_action_created`：`action + created_at DESC`，加速按操作类型过滤。
+- `idx_audit_logs_metadata_gin`：`metadata` GIN 索引，加速 metadata 关键字搜索。
+- `idx_audit_logs_target`：`target` 文本模式索引，加速对象 ID 搜索。
+
+### 3.4 依赖的前置迁移
+
+审计日志功能依赖以下对象，需先执行：
+
+- `migrations/0007_admin_tables.sql`：`audit_logs` 表、`profiles`、`is_admin()`、相关 RLS 策略。
+- `migrations/0014_team_quota_rpc.sql`：`admin_reset_team_quota` 已在 RPC 内写入 `quota.reset` 审计记录。
+
+---
+
+## 4. 前端改动
+
+### 4.1 统一写入工具（lib/utils/audit.ts）
+
+```ts
+export async function insertAuditLog(action: string, input: AuditLogInput = {}): Promise<void>
+```
+
+- 所有业务模块统一调用此函数。
+- 内部调用 `admin_write_audit_log` RPC。
+- 失败时 `console.warn` 并静默吞掉异常，不阻断主操作。
+
+### 4.2 数据访问层（lib/api/audit.ts）
+
+- `listAuditLogs(params)` → 调 `admin_list_audit_logs` RPC，返回 `{ total, items }`。
+- `actionLabel(action)` → action 到中文标签映射。
+- `AUDIT_ACTION_GROUPS` → 按资源类型分组的 action 白名单（团队/用户/Provider/公告/额度），供筛选下拉使用。
+- `metadataSummary(metadata)` → 提取前 3 个非内部字段作为表格详情摘要。
+- `toCsv` / `downloadCsv` → 客户端导出 CSV（带 BOM，兼容 Excel）。
+
+### 4.3 筛选器（components/audit/audit-filters.tsx）
+
+- **操作类型**：`<select>` + `<optgroup>`，既可选大类（如 `team`），也可选具体 action（如 `team.update`）。
+- **时间范围**：近 24 小时 / 近 7 天 / 近 30 天 / 全部。
+- **搜索框**：模糊匹配 `target` 与 `metadata`。
+
+### 4.4 表格（components/audit/audit-table.tsx）
+
+列：时间 / 操作（badge 中文标签）/ 操作人 / 团队 / 用户 / 对象 / 详情摘要。
+
+操作 badge 按 action 前缀着色：
+
+- 封禁/删除类 → `danger`
+- 解封类 → `success`
+- 额度类 → `warning`
+- Provider 类 → `info`
+- 其他 → `muted`
+
+### 4.5 页面（app/(dashboard)/audit/page.tsx）
+
+- 客户端组件，参考 `users/page.tsx` 模式。
+- 搜索 300ms 防抖；操作类型/时间范围变化重置到第 1 页。
+- 分页复用 `components/users/pagination.tsx`。
+- 导出 CSV 时以当前筛选条件拉取全部数据（上限 5000 条）。
+- toast 提示自动 3 秒消失。
+
+---
+
+## 5. 关键设计决策
+
+| 决策点 | 结论 |
+|--------|------|
+| 操作类型筛选 | 按资源类别分组下拉（团队/用户/Provider/公告/额度），而非平铺所有中文标签，便于归类 |
+| target 规范 | 统一只存对象 id（如 `teamId`、`providerId`、`announcementId`），类型信息放进 action 与 metadata |
+| action 命名 | 统一为 `<resource>.<verb>`，例如 `provider.toggle_enabled` 保留，新增 `team.ban`/`team.unban` 占位 |
+| 写入安全 | 审计写入全部下沉为 `admin_write_audit_log` SECURITY DEFINER RPC，`admin_user_id` 强制取自 `auth.uid()` |
+| 失败策略 | 审计日志写入失败静默忽略，不阻断主业务操作 |
+| 原型样式 | 复用 `globals.css` 中已有 `filter-bar` / `table` / `badge-*` / `pagination` / `toast-*` 类，与其他页面视觉统一 |
+
+---
+
+## 6. 部署与验证
+
+### 部署步骤
+
+1. 确认 `migrations/0007_admin_tables.sql` 已执行（`audit_logs` 表与 RLS）。
+2. 执行 `migrations/0018_audit_rpc.sql`（SQL Editor 或迁移 runner）。
+3. `pnpm dev` 启动 admin 应用，登录管理员账号后进入「审计日志」。
+
+### 验证点
+
+| 项 | 预期 |
+|----|------|
+| 列表 | 默认展示近 7 天真实审计记录，含操作人/团队/用户可读字段 |
+| 操作类型筛选 | 选「团队」显示 `team.*`，选「团队更新」仅显示 `team.update` |
+| 时间范围 | 24h/7d/30d/全部 过滤结果正确 |
+| 搜索 | 输入对象 ID 或 metadata 关键字可命中对应记录 |
+| 分页 | 按 `total` 分页，切换页码正常 |
+| 导出 CSV | 下载文件内容与当前筛选结果一致 |
+| 写入联动 | 封禁用户/更新团队/编辑 Provider/发布公告后，审计日志页出现对应记录 |
+| 权限 | 非 admin 调用 RPC 返回 `forbidden: admin only` |
+
+---
+
+## 7. 已知残留项
+
+| 项 | 优先级 | 说明 |
+|----|--------|------|
+| 部分原型 action 暂无业务触发 | LOW | `key.bind` / `key.unbind` / `sub.update` / `cost.update` 等 action 已加入标签映射，但对应模块（账号绑定、订阅管理、消耗表编辑器）尚未实现 |
+| `admin_reset_team_quota` 仍内联写审计 | LOW | 该 RPC 本身已是 SECURITY DEFINER 且用 `auth.uid()`，安全上无问题；如追求完全统一可后续改为调用 `admin_write_audit_log` |
+| 审计日志无详情弹窗 | LOW | 当前表格仅展示 metadata 摘要，超长内容可后续加行展开或详情抽屉 |
+
+---
+
+## 8. 相关文档
+
+- [admin-system-plan.md](./admin-system-plan.md) — 后台整体开发方案与分阶段规划
+- [admin-users-page.md](./admin-users-page.md) — 用户管理页实现套路（本次审计页参考模板）
+- [data-consistency-fix-summary.md](./data-consistency-fix-summary.md) — RPC 与 Supabase 迁移先例写法

--- a/migrations/0018_audit_rpc.sql
+++ b/migrations/0018_audit_rpc.sql
@@ -1,0 +1,146 @@
+-- 0018_audit_rpc.sql
+-- 后台「审计日志」读写 RPC：列表查询 + 服务端安全写入。
+-- Idempotent: CREATE OR REPLACE FUNCTION；在 Supabase SQL Editor 或迁移 runner 执行。
+
+-- ============ 1. 索引优化 ============
+-- action 前缀筛选（如 'user.' / 'provider.'）
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action_created
+  ON audit_logs (action, created_at DESC);
+
+-- metadata JSONB 全文搜索
+CREATE INDEX IF NOT EXISTS idx_audit_logs_metadata_gin
+  ON audit_logs USING GIN (metadata jsonb_path_ops);
+
+-- target 模糊搜索
+CREATE INDEX IF NOT EXISTS idx_audit_logs_target
+  ON audit_logs (target text_pattern_ops);
+
+-- ============ 2. admin_write_audit_log ============
+-- SECURITY DEFINER 强制使用 auth.uid() 作为 admin_user_id，避免客户端伪造操作人。
+CREATE OR REPLACE FUNCTION public.admin_write_audit_log(
+  p_action TEXT,
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_target TEXT DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_admin_id UUID := auth.uid();
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'unauthorized: missing auth uid' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_action IS NULL OR p_action = '' THEN
+    RAISE EXCEPTION 'invalid input: action is required' USING ERRCODE = '22004';
+  END IF;
+
+  INSERT INTO public.audit_logs (admin_user_id, team_id, user_id, action, target, metadata)
+  VALUES (v_admin_id, p_team_id, p_user_id, p_action, p_target, COALESCE(p_metadata, '{}'::jsonb));
+
+  RETURN json_build_object('ok', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_write_audit_log(text, uuid, uuid, text, jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_write_audit_log(text, uuid, uuid, text, jsonb)
+  IS '服务端安全写入审计日志，操作人强制取自 auth.uid()，仅 admin 可调用。';
+
+-- ============ 3. admin_list_audit_logs ============
+-- 返回 json { total, items: [...] }，支持 action 前缀 / 团队 / 用户 / 时间 / 搜索 + 分页。
+-- item 中 join 出 admin_name / admin_email / team_name / user_name / user_email，前端无需二次拼装。
+CREATE OR REPLACE FUNCTION public.admin_list_audit_logs(
+  p_action TEXT DEFAULT NULL,
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_from TIMESTAMPTZ DEFAULT NULL,
+  p_to TIMESTAMPTZ DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM public.audit_logs al
+  WHERE
+    (p_action IS NULL OR p_action = '' OR al.action LIKE p_action || '%')
+    AND (p_team_id IS NULL OR al.team_id = p_team_id)
+    AND (p_user_id IS NULL OR al.user_id = p_user_id)
+    AND (p_from IS NULL OR al.created_at >= p_from)
+    AND (p_to IS NULL OR al.created_at < p_to)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      al.target ILIKE '%' || p_search || '%' OR
+      al.metadata::text ILIKE '%' || p_search || '%'
+    );
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      al.id,
+      al.admin_user_id,
+      al.team_id,
+      al.user_id,
+      al.action,
+      al.target,
+      al.metadata,
+      al.created_at,
+      ap.display_name AS admin_name,
+      ap.email AS admin_email,
+      t.name AS team_name,
+      up.display_name AS user_name,
+      up.email AS user_email
+    FROM public.audit_logs al
+    LEFT JOIN public.profiles ap ON ap.id = al.admin_user_id
+    LEFT JOIN public.teams t ON t.id = al.team_id
+    LEFT JOIN public.profiles up ON up.id = al.user_id
+    WHERE
+      (p_action IS NULL OR p_action = '' OR al.action LIKE p_action || '%')
+      AND (p_team_id IS NULL OR al.team_id = p_team_id)
+      AND (p_user_id IS NULL OR al.user_id = p_user_id)
+      AND (p_from IS NULL OR al.created_at >= p_from)
+      AND (p_to IS NULL OR al.created_at < p_to)
+      AND (
+        p_search IS NULL OR p_search = '' OR
+        al.target ILIKE '%' || p_search || '%' OR
+        al.metadata::text ILIKE '%' || p_search || '%'
+      )
+    ORDER BY al.created_at DESC, al.id DESC
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_audit_logs(text, uuid, uuid, timestamptz, timestamptz, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_audit_logs(text, uuid, uuid, timestamptz, timestamptz, text, integer, integer)
+  IS '后台审计日志列表：聚合操作人/团队/用户信息，支持多维度筛选与分页（仅 admin 可调用）。';


### PR DESCRIPTION
- 新增 migrations/0018_audit_rpc.sql：admin_list_audit_logs + admin_write_audit_log
- 新增 lib/utils/audit.ts 统一写入入口
- 新增 lib/api/audit.ts 列表/筛选/CSV 导出
- 重构 teams.ts / users.ts / announcements.ts / provider-manager.tsx
- 重写 audit/page.tsx + components/audit/
- 新增 docs/develop/admin-audit-log.md 实现总结

Closes #<填写Issue编号>"