### PR TITLE
feat(admin): 审计日志新增清除日志功能

### DIFF
--- a/apps/admin/src/app/(dashboard)/audit/page.tsx
+++ b/apps/admin/src/app/(dashboard)/audit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import {
+  clearAuditLogs,
   downloadCsv,
   listAuditLogs,
   toCsv,
@@ -28,6 +29,8 @@ export default function AuditPage() {
 
   const [toast, setToast] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [clearing, setClearing] = useState(false);
 
   // 搜索输入 300ms 防抖后提交
   useEffect(() => {
@@ -89,6 +92,28 @@ export default function AuditPage() {
     }
   }
 
+  async function handleClearLogs() {
+    setClearing(true);
+    try {
+      const deleted = await clearAuditLogs({
+        action,
+        timeRange,
+        search: debouncedSearch
+      });
+      setConfirmClear(false);
+      setToast(`已清除 ${deleted} 条日志`);
+      if (page === 1) {
+        void load();
+      } else {
+        setPage(1);
+      }
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "清除失败");
+    } finally {
+      setClearing(false);
+    }
+  }
+
   return (
     <div>
       <div className="page-header">
@@ -97,6 +122,17 @@ export default function AuditPage() {
           <p className="page-subtitle">记录管理员关键操作，便于追溯与合规审计</p>
         </div>
         <div className="page-actions">
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setConfirmClear(true)}
+            disabled={clearing || exporting || result.total === 0}
+          >
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+            清除日志
+          </button>
           <button className="btn btn-secondary btn-sm" onClick={() => void handleExport()} disabled={exporting}>
             <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -128,6 +164,33 @@ export default function AuditPage() {
       <div className="card" style={{ marginTop: 12 }}>
         <Pagination page={page} total={result.total} pageSize={PAGE_SIZE} onPageChange={setPage} />
       </div>
+
+      {confirmClear ? (
+        <div className="modal-overlay show" role="dialog" aria-modal="true">
+          <div className="modal">
+            <div className="modal-header">
+              <div className="modal-title">清除日志</div>
+              <button className="modal-close" type="button" onClick={() => setConfirmClear(false)} disabled={clearing} aria-label="关闭">
+                <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="modal-body">
+              <p style={{ margin: 0 }}>
+                确认清除当前筛选条件下的 <strong>{result.total}</strong> 条审计日志吗？此操作不可恢复。
+              </p>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-secondary" type="button" onClick={() => setConfirmClear(false)} disabled={clearing}>取消</button>
+              <button className="btn btn-danger" type="button" onClick={() => void handleClearLogs()} disabled={clearing}>
+                {clearing ? "清除中..." : "确认清除"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {toast ? (
         <div className="toast-container">

--- a/apps/admin/src/lib/api/audit.ts
+++ b/apps/admin/src/lib/api/audit.ts
@@ -62,7 +62,8 @@ export function actionLabel(action: string): string {
     "key.bind": "绑定账号",
     "key.unbind": "解绑账号",
     "sub.update": "订阅变更",
-    "cost.update": "消耗表更新"
+    "cost.update": "消耗表更新",
+    "audit.clear": "清除日志"
   };
   return map[action] ?? action;
 }
@@ -133,19 +134,33 @@ function timeRangeToDates(range: AuditLogTimeRange): { from: Date | null; to: Da
   }
 }
 
-export async function listAuditLogs(params: AuditLogListParams = {}): Promise<AuditLogListResult> {
-  const supabase = createAdminBrowserClient();
-  const page = params.page ?? 1;
-  const pageSize = params.pageSize ?? 20;
+/** 将筛选参数映射为 RPC 命名参数，供列表 / 清除共用，保证范围一致。 */
+function buildFilterArgs(params: AuditLogListParams): {
+  p_action: string | null;
+  p_team_id: string | null;
+  p_user_id: string | null;
+  p_from: string | null;
+  p_to: string | null;
+  p_search: string | null;
+} {
   const { from, to } = timeRangeToDates(params.timeRange ?? "all");
-
-  const { data, error } = await supabase.rpc("admin_list_audit_logs", {
+  return {
     p_action: params.action || null,
     p_team_id: params.teamId || null,
     p_user_id: params.userId || null,
     p_from: from?.toISOString() || null,
     p_to: to?.toISOString() || null,
-    p_search: params.search?.trim() || null,
+    p_search: params.search?.trim() || null
+  };
+}
+
+export async function listAuditLogs(params: AuditLogListParams = {}): Promise<AuditLogListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+
+  const { data, error } = await supabase.rpc("admin_list_audit_logs", {
+    ...buildFilterArgs(params),
     p_limit: pageSize,
     p_offset: (page - 1) * pageSize
   });
@@ -156,6 +171,16 @@ export async function listAuditLogs(params: AuditLogListParams = {}): Promise<Au
     total: Number(raw.total ?? 0),
     items: (raw.items ?? []).map((it) => normalizeAuditLog(it as Record<string, unknown>))
   };
+}
+
+/** 清除当前筛选条件下的审计日志，返回被删除条数。 */
+export async function clearAuditLogs(params: AuditLogListParams = {}): Promise<number> {
+  const supabase = createAdminBrowserClient();
+  const { data, error } = await supabase.rpc("admin_clear_audit_logs", buildFilterArgs(params));
+  if (error) throw error;
+
+  const raw = (data ?? { deleted: 0 }) as { deleted?: number };
+  return Number(raw.deleted ?? 0);
 }
 
 export function toCsv(logs: AuditLog[]): string {

--- a/docs/develop/admin-audit-clear-log.md
+++ b/docs/develop/admin-audit-clear-log.md
@@ -1,0 +1,103 @@
+# 后台「审计日志 · 清除日志」实现总结
+
+> 完成日期：2026-08-14
+> 实现范围：在审计日志页「导出 CSV」左侧新增「清除日志」功能，按当前筛选条件删除命中日志
+> 关联文档：[admin-audit-log.md](./admin-audit-log.md)（审计日志列表页）、REQUIREMENTS.md §13.4.5
+
+---
+
+## 1. 背景
+
+审计日志页已支持列表查询与 CSV 导出，但缺少清除能力。合规场景下需要「只保留近 N 天 / 定期清理」的运维手段，因此新增「清除日志」入口。
+
+为与「导出 CSV」保持一致、避免误清全表，清除范围采用**当前筛选条件**（操作类型 / 团队 / 用户 / 时间范围 / 搜索），而非无条件清空。无任何筛选时等价于清除全部。
+
+---
+
+## 2. 改动总览
+
+| 文件 | 改动类型 | 说明 |
+|------|---------|------|
+| `migrations/0019_audit_clear_rpc.sql` | 新增 | `admin_clear_audit_logs` 清除 RPC |
+| `apps/admin/src/lib/api/audit.ts` | 扩展 | `clearAuditLogs`、`buildFilterArgs` 复用、`audit.clear` 中文标签 |
+| `apps/admin/src/app/(dashboard)/audit/page.tsx` | 扩展 | 「清除日志」按钮 + 确认弹窗 + 清除后刷新 |
+
+---
+
+## 3. 数据库改动
+
+### 3.1 `admin_clear_audit_logs`
+
+```sql
+CREATE OR REPLACE FUNCTION public.admin_clear_audit_logs(
+  p_action TEXT DEFAULT NULL,
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_from TIMESTAMPTZ DEFAULT NULL,
+  p_to TIMESTAMPTZ DEFAULT NULL,
+  p_search TEXT DEFAULT NULL
+)
+RETURNS json   -- { deleted: 被删除条数 }
+```
+
+关键点：
+
+- **安全**：`SECURITY DEFINER SET search_path = public, auth`，首行 `IF NOT public.is_admin()` 兜底，仅 admin 可调用。
+- **范围一致**：筛选条件与 `admin_list_audit_logs` 逐条对齐（`action LIKE p_action || '%'`、时间区间、`target` / `metadata::text` ILIKE），保证「清除」与「列表 / 导出」命中同一批数据。
+- **计数**：`GET DIAGNOSTICS v_deleted = ROW_COUNT` 取删除条数，返回给前端展示。
+- **留痕**：清除后内联写入一条 `audit.clear` 记录，metadata 记录删除条数与原筛选条件（`jsonb_strip_nulls` 去掉空字段）。「清除」动作本身可追溯。
+
+---
+
+## 4. 前端改动
+
+### 4.1 数据访问层（lib/api/audit.ts）
+
+- 抽出 `buildFilterArgs(params)`，将 `AuditLogListParams` 映射为 RPC 命名参数，列表 / 清除共用，杜绝两处筛选条件漂移。
+- 新增 `clearAuditLogs(params)` → 调 `admin_clear_audit_logs` RPC，返回删除条数。
+- `actionLabel` 增加 `"audit.clear": "清除日志"`，使清除记录在表格中展示中文标签。
+
+### 4.2 页面（app/(dashboard)/audit/page.tsx）
+
+- 表头「导出 CSV」左侧新增「清除日志」按钮（无数据即 `result.total === 0` 时禁用）。
+- 点击弹出确认弹窗，文案显示将清除的条数（`result.total`）并标注「不可恢复」；确认按钮为 `btn-danger`。
+- 清除成功后 toast 提示「已清除 N 条日志」，并刷新列表：当前第 1 页直接重载，非第 1 页重置回第 1 页。
+
+---
+
+## 5. 关键设计决策
+
+| 决策点 | 结论 |
+|--------|------|
+| 清除范围 | 复用当前筛选条件，与「导出 CSV」对称，避免误清全表；无筛选即全清 |
+| 权限与安全 | 下沉为 `SECURITY DEFINER` RPC，`is_admin()` 守卫，客户端不可绕过 |
+| 留痕 | 清除动作写入 `audit.clear` 记录；清除「全部」时该条作为唯一残留项保留 |
+| 计数展示 | 前端直接复用 `result.total`（列表 RPC 已返回当前筛选总数）作为弹窗中的待删条数 |
+| 交互 | 破坏性操作走确认弹窗（复用 `modal-overlay` / `modal` 样式），与公告删除弹窗一致 |
+
+---
+
+## 6. 部署与验证
+
+### 部署步骤
+
+1. 确认 `migrations/0007_admin_tables.sql`、`migrations/0018_audit_rpc.sql` 已执行。
+2. 执行 `migrations/0019_audit_clear_rpc.sql`（SQL Editor 或迁移 runner）。
+
+### 验证点
+
+| 项 | 预期 |
+|----|------|
+| 权限 | 非 admin 调用 RPC 返回 `forbidden: admin only` |
+| 范围 | 按操作类型 / 时间范围 / 搜索清除时，仅命中对应记录 |
+| 全清 | 无筛选时清除全部，仅残留一条 `audit.clear` 记录 |
+| 反馈 | 弹窗显示待删条数；成功后 toast 提示「已清除 N 条日志」并刷新列表 |
+| 联动 | 清除动作本身出现在审计日志中（`audit.clear`），操作人正确 |
+
+---
+
+## 7. 相关文档
+
+- [admin-audit-log.md](./admin-audit-log.md) — 审计日志列表页整体实现
+- [admin-users-page.md](./admin-users-page.md) — 用户管理页实现套路（本页参考模板）
+- [data-consistency-fix-summary.md](./data-consistency-fix-summary.md) — RPC 与 Supabase 迁移先例写法

--- a/migrations/0019_audit_clear_rpc.sql
+++ b/migrations/0019_audit_clear_rpc.sql
@@ -1,0 +1,66 @@
+-- 0019_audit_clear_rpc.sql
+-- 后台「审计日志」清除 RPC：按当前筛选条件删除命中的日志（仅 admin 可调用）。
+-- Idempotent: CREATE OR REPLACE FUNCTION；在 Supabase SQL Editor 或迁移 runner 执行。
+
+-- 与 admin_list_audit_logs 使用同一套筛选条件，保证「清除」与「列表 / 导出」范围一致。
+CREATE OR REPLACE FUNCTION public.admin_clear_audit_logs(
+  p_action TEXT DEFAULT NULL,
+  p_team_id UUID DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_from TIMESTAMPTZ DEFAULT NULL,
+  p_to TIMESTAMPTZ DEFAULT NULL,
+  p_search TEXT DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_deleted BIGINT;
+  v_admin_id UUID := auth.uid();
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.audit_logs al
+  WHERE
+    (p_action IS NULL OR p_action = '' OR al.action LIKE p_action || '%')
+    AND (p_team_id IS NULL OR al.team_id = p_team_id)
+    AND (p_user_id IS NULL OR al.user_id = p_user_id)
+    AND (p_from IS NULL OR al.created_at >= p_from)
+    AND (p_to IS NULL OR al.created_at < p_to)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      al.target ILIKE '%' || p_search || '%' OR
+      al.metadata::text ILIKE '%' || p_search || '%'
+    );
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  -- 记录本次清除操作本身（审计「清除」也需可追溯），保留操作人 / 范围 / 数量。
+  INSERT INTO public.audit_logs (admin_user_id, action, target, metadata)
+  VALUES (
+    v_admin_id,
+    'audit.clear',
+    NULL,
+    jsonb_strip_nulls(jsonb_build_object(
+      'deleted', v_deleted,
+      'action', p_action,
+      'team_id', p_team_id,
+      'user_id', p_user_id,
+      'from', p_from,
+      'to', p_to,
+      'search', p_search
+    ))
+  );
+
+  RETURN json_build_object('deleted', v_deleted);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_clear_audit_logs(text, uuid, uuid, timestamptz, timestamptz, text) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_clear_audit_logs(text, uuid, uuid, timestamptz, timestamptz, text)
+  IS '清除当前筛选条件下的审计日志，返回被删除条数；操作本身写入一条 audit.clear 记录（仅 admin 可调用）。';


### PR DESCRIPTION
Closes #22

## 改动

- 新增 `admin_clear_audit_logs` RPC：按当前筛选条件删除日志，并写入 `audit.clear` 留痕
- 前端新增「清除日志」按钮 + 确认弹窗，抽出 `buildFilterArgs` 复用筛选条件
- 补充 `docs/develop/admin-audit-clear-log.md` 实现总结

## 验证

- `tsc --noEmit` 通过
- 清除范围与列表/导出一致（复用同一筛选参数）