### PR TITLE
feat: 千问视频生成支持 + 多厂商调度优化

### DIFF
--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -9,6 +9,9 @@ import { createSupabaseClient, JobService, ProviderService, todayKey } from '@qu
 import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
 import { runDoubaoGeneration } from './webview-engine'
 import type { ProviderCookie, OriginStorage } from './webview-engine'
+import { parseStoredCredentials as parseProviderCredentials } from './providers'
+import { runQwenGeneration } from './qwen-webview'
+import type { QwenGenerateResult } from './qwen-webview'
 import { processWatermarkJob } from './watermark-remover/job'
 
 export interface GenerateInput {
@@ -20,6 +23,7 @@ export interface GenerateInput {
   teamId?: string | null
   prompt: string
   providerId: string
+  model?: string
   durationSec: number
   mode?: string
   resolution?: string
@@ -31,41 +35,6 @@ export interface GenerateInput {
   images?: string[]
   /** 测试开关：显示豆包 WebView 窗口（默认隐藏） */
   showWebview?: boolean
-}
-
-/**
- * 兼容 v0/v1/v2 三种存储格式（与 providers.ts parseStoredCredentials 逻辑一致）
- *  - v0 (最旧): ProviderCookie[]
- *  - v1 (旧):   { cookies: ProviderCookie[], localStorage: {key,value}[] }
- *  - v2 (新):   { cookies: ProviderCookie[], storages: OriginStorage[], localStorage?: legacy }
- */
-function parseProviderCredentials(encrypted: string): {
-  cookies: ProviderCookie[]
-  storages: OriginStorage[]
-  localStorage: Array<{ key: string; value: string }>
-} {
-  const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
-  const parsed = JSON.parse(plain) as unknown
-  if (Array.isArray(parsed)) {
-    return { cookies: parsed as ProviderCookie[], storages: [], localStorage: [] }
-  }
-  const obj = parsed as {
-    cookies?: ProviderCookie[]
-    storages?: OriginStorage[]
-    localStorage?: Array<{ key: string; value: string }>
-  }
-  const cookies = obj.cookies ?? []
-  const storages: OriginStorage[] = Array.isArray(obj.storages) ? obj.storages : []
-  if (obj.localStorage?.length && !storages.length) {
-    storages.push({
-      origin: 'https://www.doubao.com',
-      localStorage: obj.localStorage,
-      sessionStorage: []
-    })
-  }
-  const mainStorage = storages.find((s) => s.origin === 'https://www.doubao.com') || storages[0]
-  const localStorage = mainStorage?.localStorage ?? []
-  return { cookies, storages, localStorage }
 }
 
 export interface DispatchEvent {
@@ -90,6 +59,18 @@ function resolveDispatchProvider(providerId: string): string {
   return providerId === 'auto' ? 'doubao' : providerId
 }
 
+function normalizeJobMode(mode?: string): string {
+  if (mode === 'img' || mode === 'img2video') return 'img2video'
+  if (mode === 'multi_ref' || mode === 'first_last' || mode === 'first_frame' || mode === 'firstlast') {
+    return mode === 'firstlast' ? 'first_last' : mode
+  }
+  return 'text2video'
+}
+
+function providerLabel(providerId: string): string {
+  return providerId === 'qwenwan' ? '千问（通义万相）' : '豆包'
+}
+
 function parseSupportedDurations(meta: { capabilities?: Record<string, unknown> | null } | undefined): number[] {
   const raw = meta?.capabilities?.supported_durations
   if (!Array.isArray(raw)) return [...DEFAULT_SUPPORTED_DURATIONS]
@@ -99,14 +80,17 @@ function parseSupportedDurations(meta: { capabilities?: Record<string, unknown> 
   return durations.length > 0 ? durations : [...DEFAULT_SUPPORTED_DURATIONS]
 }
 
-function doubaoCost(durationSec: number): number {
-  if (durationSec <= 5) return 1
-  if (durationSec <= 10) return 2
-  return 3
+function providerCost(providerId: string, durationSec: number, resolution?: string): { amount: number; unitName: string } {
+  const durationPoint = durationSec <= 5 ? 0 : durationSec <= 10 ? 1 : 2
+  if (providerId === 'qwenwan') {
+    const amount = 1 + durationPoint + (resolution === '1080' ? 1 : 0)
+    return { amount, unitName: '额度' }
+  }
+  return { amount: 1 + durationPoint, unitName: '点' }
 }
 
 /** 下载视频到 userData/videos/<jobId>.mp4（生成后立即落盘，避免签名 URL 过期） */
-function downloadVideo(url: string, jobId: string, redirects = 0): Promise<string | null> {
+function downloadVideo(url: string, jobId: string, providerId = 'doubao', redirects = 0): Promise<string | null> {
   return new Promise((resolve) => {
     if (redirects > 4) {
       resolve(null)
@@ -131,12 +115,16 @@ function downloadVideo(url: string, jobId: string, redirects = 0): Promise<strin
     const req = httpsGet(
       url,
       {
-        headers: { 'User-Agent': UA, Accept: '*/*', Referer: 'https://www.doubao.com/' }
+        headers: {
+          'User-Agent': UA,
+          Accept: '*/*',
+          Referer: providerId === 'qwenwan' ? 'https://www.qianwen.com/' : 'https://www.doubao.com/'
+        }
       },
       (res) => {
         if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume()
-          void downloadVideo(res.headers.location, jobId, redirects + 1).then((p) => finish(!!p, p))
+          void downloadVideo(res.headers.location, jobId, providerId, redirects + 1).then((p) => finish(!!p, p))
           return
         }
         if (!res.statusCode || res.statusCode !== 200) {
@@ -211,7 +199,7 @@ export async function runGenerate(
   try {
     job = await jobSvc.insertJob(input.userId, {
       teamId: input.teamId,
-      mode: input.mode === 'img2video' ? 'img2video' : 'text2video',
+      mode: normalizeJobMode(input.mode),
       prompt: input.prompt,
       status: 'pending',
       providerId: input.providerId
@@ -224,7 +212,9 @@ export async function runGenerate(
   onJobCreated?.(job.id, runCancelState)
 
   // 1) 选号 + 解析 cookie：默认账号优先 → 剩余额度预检 → 失败自动换号（有界）
-  const cost = doubaoCost(input.durationSec)
+  const costInfo = providerCost(resolvedProviderId, input.durationSec, input.resolution)
+  const cost = costInfo.amount
+  const costUnit = costInfo.unitName
   const images = (input.images ?? [])
     .filter((p) => typeof p === 'string' && /\.(jpe?g|png|webp|gif)$/i.test(p))
     .slice(0, 10)
@@ -246,6 +236,7 @@ export async function runGenerate(
   }
   const jobOptions: Record<string, unknown> = {
     mode: input.mode,
+    model: input.model,
     durationSec: input.durationSec,
     ratio: input.ratio,
     audio: input.audio,
@@ -256,14 +247,14 @@ export async function runGenerate(
   const keys = input.teamId
     ? await providerSvc.listTeamProviderKeys(input.teamId)
     : (await providerSvc.listProviderKeys(input.userId)).filter((k) => !k.team_id)
-  const doubaoKeys = keys.filter((k) => k.provider_id === 'doubao' && k.enabled !== false)
+  const providerKeys = keys.filter((k) => k.provider_id === resolvedProviderId && k.enabled !== false)
 
   let selectedKey: { id: string; accountName: string | null } | null = null
-  let result: Awaited<ReturnType<typeof runDoubaoGeneration>> | null = null
+  let result: Awaited<ReturnType<typeof runDoubaoGeneration>> | Awaited<ReturnType<typeof runQwenGeneration>> | null = null
   let lastError = ''
 
-  if (doubaoKeys.length === 0) {
-    const err = '未绑定豆包账号（请在厂商页绑定后重试）'
+  if (providerKeys.length === 0) {
+    const err = `未绑定${providerLabel(resolvedProviderId)}账号（请在厂商页绑定后重试）`
     await jobSvc.updateJob(input.userId, job.id, {
       status: 'failed',
       error: err,
@@ -276,7 +267,7 @@ export async function runGenerate(
     try {
       const today = todayKey()
       // 批量确保今日 ledger 行存在，避免逐账号请求拖慢生成前的额度排序。
-      await providerSvc.ensureProviderLedgerRows(input.userId, input.teamId ?? null, doubaoKeys.map((k) => k.id))
+      await providerSvc.ensureProviderLedgerRows(input.userId, input.teamId ?? null, providerKeys.map((k) => k.id))
       const freshLedgers = input.teamId
         ? await providerSvc.listTeamTodayLedger(input.teamId)
         : await providerSvc.listTodayLedger(input.userId)
@@ -285,7 +276,7 @@ export async function runGenerate(
         // 用 daily_total - used - reserved 而非 remaining，与 RPC 原子扣减条件一致
         return row ? Math.max(Number(row.daily_total) - Number(row.used) - Number(row.reserved ?? 0), 0) : 0
       }
-      const sorted = [...doubaoKeys].sort((a, b) => {
+      const sorted = [...providerKeys].sort((a, b) => {
         if (!!a.is_default !== !!b.is_default) return a.is_default ? -1 : 1
         // 已失效账号排最后，避免默认账号过期时浪费尝试
         const expiredA = a.health_status === 'expired' ? 1 : 0
@@ -295,10 +286,10 @@ export async function runGenerate(
       })
 
       const tried = new Set<string>()
-      for (let round = 0; round < Math.min(doubaoKeys.length, 3); round++) {
+      for (let round = 0; round < Math.min(providerKeys.length, 3); round++) {
         const cand = sorted.find((k) => !tried.has(k.id) && remainingOf(k.id) >= cost)
         if (!cand) {
-          lastError = lastError || `所有豆包账号剩余额度不足（本次需 ${cost} 点）`
+          lastError = lastError || `所有${providerLabel(resolvedProviderId)}账号剩余额度不足（本次需 ${cost} ${costUnit}）`
           break
         }
         tried.add(cand.id)
@@ -307,7 +298,7 @@ export async function runGenerate(
         let storages: OriginStorage[] = []
         try {
           if (safeStorage.isEncryptionAvailable()) {
-            const parsed = parseProviderCredentials(cand.encrypted_key)
+            const parsed = parseProviderCredentials(cand.encrypted_key, resolvedProviderId)
             c = parsed.cookies
             s = parsed.localStorage
             storages = parsed.storages
@@ -336,30 +327,50 @@ export async function runGenerate(
         if (runCancelState.aborted) {
           result = {
             ok: false,
-            providerId: 'doubao',
+            providerId: resolvedProviderId as 'doubao' | 'qwenwan',
             cancelled: true,
             error: '已手动终止生成（提示词未发送）',
             attempts: []
           }
           break
         }
-        result = await runDoubaoGeneration({
-          cookies: c,
-          localStorage: s,
-          storages,
-          prompt: input.prompt,
-          durationSec: input.durationSec,
-          mode: input.mode,
-          resolution: input.resolution,
-          audio: input.audio,
-          ratio: input.ratio,
-          images,
-          keyId: cand.id,
-          cancel: runCancelState,
-          showWebview: input.showWebview,
-          onProgress: (stage, detail) =>
-            emit({ jobId: job.id, status: 'running', stage, message: stage, data: detail })
-        })
+        if (resolvedProviderId === 'qwenwan') {
+          result = await runQwenGeneration({
+            cookies: c,
+            storages,
+            prompt: input.prompt,
+            model: input.model,
+            mode: input.mode,
+            durationSec: input.durationSec,
+            resolution: input.resolution,
+            audio: input.audio,
+            ratio: input.ratio,
+            images,
+            keyId: cand.id,
+            cancel: runCancelState,
+            showWebview: input.showWebview,
+            onProgress: (stage, detail) =>
+              emit({ jobId: job.id, status: 'running', stage, message: stage, data: detail })
+          })
+        } else {
+          result = await runDoubaoGeneration({
+            cookies: c,
+            localStorage: s,
+            storages,
+            prompt: input.prompt,
+            durationSec: input.durationSec,
+            mode: input.mode,
+            resolution: input.resolution,
+            audio: input.audio,
+            ratio: input.ratio,
+            images,
+            keyId: cand.id,
+            cancel: runCancelState,
+            showWebview: input.showWebview,
+            onProgress: (stage, detail) =>
+              emit({ jobId: job.id, status: 'running', stage, message: stage, data: detail })
+          })
+        }
         if (result.ok && result.videoUrl) break
         lastError = result.error || '生成失败'
         // 用户手动终止（提示词未发送）：标记为意外中断，不再换号
@@ -408,7 +419,7 @@ export async function runGenerate(
   }
 
   if (!result || !result.ok || !result.videoUrl) {
-    const err = result ? result.error || lastError || '生成失败' : lastError || '未找到可用豆包账号'
+    const err = result ? result.error || lastError || '生成失败' : lastError || `未找到可用${providerLabel(resolvedProviderId)}账号`
     try {
       await jobSvc.updateJob(input.userId, job.id, {
         status: 'failed',
@@ -427,7 +438,7 @@ export async function runGenerate(
   // 2) 成功：下载落盘 → 先扣额度 → 再写 job success
   let localPath: string | null = null
   try {
-    localPath = await downloadVideo(result.videoUrl, job.id)
+    localPath = await downloadVideo(result.videoUrl, job.id, resolvedProviderId)
   } catch (e) {
     emit({
       jobId: job.id,
@@ -445,7 +456,7 @@ export async function runGenerate(
       const teamResult = await providerSvc.consumeTeamQuotaAndFinalize({
         teamId: input.teamId,
         userId: input.userId,
-        providerId: 'doubao',
+        providerId: resolvedProviderId,
         amount: cost,
         keyId: selectedKey?.id ?? null,
         jobId: job.id
@@ -455,8 +466,8 @@ export async function runGenerate(
       }
       consumed = teamResult.row ?? null
     } else {
-      consumed = await providerSvc.consumeLedger(input.userId, 'doubao', cost, {
-        unitName: '点',
+      consumed = await providerSvc.consumeLedger(input.userId, resolvedProviderId, cost, {
+        unitName: costUnit,
         keyId: selectedKey?.id ?? undefined
       })
       if (selectedKey?.id && consumed) {
@@ -470,7 +481,7 @@ export async function runGenerate(
       status: 'failed',
       error: errMsg,
       resultUrl,
-      costUnit: '点',
+      costUnit,
       costAmount: cost,
       attempts: result.attempts,
       options: {
@@ -494,10 +505,10 @@ export async function runGenerate(
 
   await jobSvc.updateJob(input.userId, job.id, {
     status: 'success',
-    providerId: 'doubao',
+    providerId: resolvedProviderId,
     accountId: selectedKey?.id ?? null,
     resultUrl,
-    costUnit: '点',
+    costUnit,
     costAmount: cost,
     attempts: result.attempts,
     options: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -442,7 +442,7 @@ app.whenReady().then(() => {
             ? {
                 p_team_id: u.teamId,
                 p_user_id: params.userId,
-                p_provider_id: 'doubao',
+                p_provider_id: u.providerId ?? 'doubao',
                 p_amount: u.costAmount,
                 p_account_key_id: u.keyId,
                 p_date: todayKey(),
@@ -450,7 +450,7 @@ app.whenReady().then(() => {
               }
             : {
                 p_user_id: params.userId,
-                p_provider_id: 'doubao',
+                p_provider_id: u.providerId ?? 'doubao',
                 p_amount: u.costAmount,
                 p_key_id: u.keyId,
                 p_date: todayKey(),

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -41,8 +41,8 @@ const PROVIDER_SITES: Record<ProviderId, ProviderSite> = {
     healthUrl: 'https://tongyi.aliyun.com/'
   },
   qwenwan: {
-    loginUrl: 'https://tongyi.aliyun.com/wanxiang/create',
-    healthUrl: 'https://tongyi.aliyun.com/'
+    loginUrl: 'https://www.qianwen.com/chat',
+    healthUrl: 'https://www.qianwen.com/'
   },
   yuanbao: {
     loginUrl: 'https://yuanbao.tencent.com/chat/naQivTmsDa',
@@ -122,7 +122,7 @@ function encryptCookies(
   const payload: StoredV2 = { cookies }
   if (storages.length > 0) payload.storages = storages
   // 兼容 v1 字段，供老代码读取
-  const main = storages.find((s) => s.origin.includes('doubao.com')) || storages[0]
+  const main = storages.find((s) => s.origin.includes('doubao.com') || s.origin.includes('qianwen.com')) || storages[0]
   if (main?.localStorage.length) payload.localStorage = main.localStorage
   const plain = JSON.stringify(payload)
   return safeStorage.encryptString(plain).toString('base64')
@@ -130,8 +130,12 @@ function encryptCookies(
 
 export { encryptCookies }
 
+function defaultStorageOrigin(providerId: string): string {
+  return providerId === 'qwenwan' ? 'https://www.qianwen.com' : 'https://www.doubao.com'
+}
+
 /** 兼容 v0 / v1 / v2 格式，统一返回 cookies + storages（以及为调用方保留的 localStorage 兼容字段） */
-function parseStoredCredentials(encrypted: string): {
+export function parseStoredCredentials(encrypted: string, providerId = 'doubao'): {
   cookies: ProviderCookie[]
   storages: OriginStorage[]
   localStorage: Array<{ key: string; value: string }>
@@ -145,16 +149,17 @@ function parseStoredCredentials(encrypted: string): {
   const obj = parsed as StoredV2
   const cookies = obj.cookies ?? []
   const storages: OriginStorage[] = obj.storages ?? []
-  // v1 localStorage 归一化到 storages（豆包主站 origin）
+  // v1 localStorage 归一化到 storages（按厂商主站 origin，避免千问等厂商解析后仍落到豆包）
   if (obj.localStorage?.length && !storages.length) {
     storages.push({
-      origin: 'https://www.doubao.com',
+      origin: defaultStorageOrigin(providerId),
       localStorage: obj.localStorage,
       sessionStorage: []
     })
   }
-  // 兼容调用方取 localStorage 字段（豆包主站）
-  const mainStorage = storages.find((s) => s.origin.includes('www.doubao.com')) || storages[0]
+  // 兼容调用方取 localStorage 字段（当前厂商主站优先，其次任意已收集 storage）
+  const mainOrigin = defaultStorageOrigin(providerId)
+  const mainStorage = storages.find((s) => s.origin === mainOrigin) || storages[0]
   const localStorage = mainStorage?.localStorage ?? []
   return { cookies, storages, localStorage }
 }
@@ -187,7 +192,7 @@ async function injectCookies(
   for (const c of cookies) {
     try {
       await ses.cookies.set({
-        url: `${c.secure ? 'https' : 'http'}://${(c.domain || '').replace(/^\./, '') || 'www.doubao.com'}${c.path || '/'}`,
+        url: `${c.secure ? 'https' : 'http'}://${(c.domain || '').replace(/^\./, '') || defaultStorageOrigin(providerId).replace(/^https?:\/\//, '')}${c.path || '/'}`,
         domain: c.domain || undefined,
         name: c.name,
         value: c.value,
@@ -237,8 +242,8 @@ const ACCOUNT_FINGERPRINT_EXTRACTORS: Partial<Record<ProviderId, FingerprintExtr
   // 实测豆包分区 cookie：uid_tt/uid_tt_ss = 字节用户 ID（稳定），sid_tt/sessionid 为会话令牌（会变）
   doubao: { script: COMMON_FINGERPRINT_SCRIPT, cookieFirst: true },
   jimeng: { script: COMMON_FINGERPRINT_SCRIPT },
-  qwen: { script: COMMON_FINGERPRINT_SCRIPT },
-  qwenwan: { script: COMMON_FINGERPRINT_SCRIPT },
+  qwen: { script: COMMON_FINGERPRINT_SCRIPT, cookieFirst: true },
+  qwenwan: { script: COMMON_FINGERPRINT_SCRIPT, cookieFirst: true },
   // 实测元宝分区 cookie：QQ 登录产生 pt2gguin(o+QQ号) 与 hy_user(元宝账号UUID)，均按账号稳定；
   // uin/wxuin/openid 实际不存在，cookie 标识已验证，优先于泛用 DOM 脚本
   yuanbao: { script: COMMON_FINGERPRINT_SCRIPT, cookieFirst: true },
@@ -252,8 +257,9 @@ const FINGERPRINT_COOKIE_KEYS: Partial<Record<ProviderId, string[]>> = {
   // 实测值：抖音扫码登录时 uid_tt/uid_tt_ss 每次登录会变；flow_cur_user_sec_id 才是账号级稳定标识（两次登录一致）
   doubao: ['flow_cur_user_sec_id', 'uid_tt', 'uid_tt_ss'],
   jimeng: ['user_id', 'uid', 'userId'],
-  qwen: ['login_aliyunid', 'loginaliyunid'],
-  qwenwan: ['login_aliyunid', 'loginaliyunid'],
+  // 实测千问登录后 .www.qianwen.com 会下发 b-user-id；_QW_HASH_UID/_QW_WG_UID 是账号级标识兜底。
+  qwen: ['b-user-id', '_QW_HASH_UID', '_QW_WG_UID', 'login_aliyunid', 'loginaliyunid'],
+  qwenwan: ['b-user-id', '_QW_HASH_UID', '_QW_WG_UID', 'login_aliyunid', 'loginaliyunid'],
   // 实测值：pt2gguin = o<QQ号>（.ptlogin2.qq.com），hy_user = 元宝账号 UUID（.tencent.com）
   yuanbao: ['pt2gguin', 'hy_user'],
   kling: ['userId', 'user_id', 'kk_u'],
@@ -601,7 +607,7 @@ function openLoginWindow(providerId: string, keyId?: string): Promise<ProviderLo
               const viewCookies = cookies.length
 
               // 7) 候选 C 优化：如果传入了 keyId，同步把 cookie + storages
-              //    也注入 `persist:qf-p:doubao:<keyId>` 生成分区（避免生成时注入有时序差异）
+              //    也注入 `persist:qf-p:<providerId>:<keyId>` 生成分区（避免生成时注入有时序差异）
               if (keyId) {
                 try {
                   await injectCookies(providerId, cookies, keyId)
@@ -654,7 +660,7 @@ async function openProviderSite(
   ses.setUserAgent(CHROME_UA)
   if (encryptedKey) {
     try {
-      const parsed = parseStoredCredentials(encryptedKey)
+      const parsed = parseStoredCredentials(encryptedKey, providerId)
       if (parsed.cookies.length > 0) await injectCookies(providerId, parsed.cookies, keyId)
     } catch {
       // 解密失败时仍尝试打开官网，至少让用户看到站点本身。
@@ -707,7 +713,7 @@ async function healthCheck(
 
   let cookies: ProviderCookie[]
   try {
-    cookies = parseStoredCredentials(encrypted).cookies
+    cookies = parseStoredCredentials(encrypted, providerId).cookies
   } catch {
     return { ok: false, status: 'unknown', error: '解密失败' }
   }
@@ -791,7 +797,7 @@ export async function visitAndCapture(
   let cookies: ProviderCookie[]
   let oldStorages: OriginStorage[] = []
   try {
-    const parsed = parseStoredCredentials(encrypted)
+    const parsed = parseStoredCredentials(encrypted, providerId)
     cookies = parsed.cookies
     oldStorages = parsed.storages ?? []
   } catch {

--- a/apps/desktop/src/main/qwen-webview.ts
+++ b/apps/desktop/src/main/qwen-webview.ts
@@ -1,0 +1,1217 @@
+// 千问（通义万相）WebView 生成执行引擎
+// 链路：cookie/storage 注入 → 打开千问 chat → 自动填写 prompt 并发送
+//       → 从 webRequest 捕获 chat 请求的 req_id/session_id 与 detail 所需请求头
+//       → 轮询 detail API 提取 mp4 URL / poster
+// 说明：千问 chat API 的风控签名由前端页面自身生成，因此这里不走静态 HTTP 提交，
+//       只复用页面真实提交后捕获到的会话参数。
+
+import { BrowserWindow, clipboard, nativeImage, session } from 'electron'
+import { readFile } from 'node:fs/promises'
+import { basename, extname } from 'node:path'
+import type { OriginStorage, ProviderCookie } from './webview-engine'
+
+const UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
+const QWEN_CHAT_URL = 'https://www.qianwen.com/chat'
+const CHAT_API_URLS = ['*://*.qianwen.com/api/*', '*://qianwen.com/api/*']
+const DETAIL_API_URL = 'https://chat2-api.qianwen.com/api/v1/session/req/detail'
+const BLOCKED_PATTERN = /违[规法]|内容审核|无法生成|版权|侵权|肖像|敏感|检测到.*(风险|违规)|拒绝生成|请勿生成/
+const QWEN_IMAGE_MODES = new Set(['multi_ref', 'first_last', 'first_frame', 'firstlast'])
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+export interface QwenGenerateOptions {
+  cookies: ProviderCookie[]
+  storages?: OriginStorage[]
+  prompt: string
+  model?: string
+  mode?: string
+  images?: string[]
+  resolution?: string
+  audio?: string
+  ratio?: string
+  durationSec?: number
+  keyId?: string
+  showWebview?: boolean
+  maxWaitSec?: number
+  cancel?: { aborted: boolean; submitted: boolean }
+  onProgress?: (stage: string, detail?: unknown) => void
+}
+
+export interface QwenGenerateResult {
+  ok: boolean
+  providerId: 'qwenwan'
+  videoUrl?: string
+  posterUrl?: string | null
+  error?: string
+  blocked?: boolean
+  cancelled?: boolean
+  attempts: Array<{ providerId: string; ok: boolean; errorMessage?: string }>
+}
+
+interface CapturedChatRequest {
+  reqId?: string
+  sessionId?: string
+  deviceId?: string
+  xsrfToken?: string
+  cookie?: string
+}
+
+interface ChatCaptureRegistration {
+  captured: { current: CapturedChatRequest | null }
+}
+
+interface QwenImageData {
+  name: string
+  mime: string
+  dataUrl: string
+}
+
+// webRequest 监听器无法方便地按 session 移除，重复注册会让同一分区跑多次千问任务时叠加监听。
+// 这里按 partition 只注册一次，后续任务只替换当前捕获目标，避免旧任务污染新任务的 req_id/session_id。
+const chatCaptureRegistrations = new Map<string, ChatCaptureRegistration>()
+
+function isQwenDetailUrl(url: string): boolean {
+  return /\/req\/detail\b|\/detail\b/i.test(url)
+}
+
+function qwenSessionIdFromUrl(url: string): string | undefined {
+  try {
+    const pathname = new URL(url).pathname
+    const match = pathname.match(/\/chat\/([^/?#]+)/i)
+    return match?.[1] || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function readUploadDataText(details: { uploadData?: Array<{ bytes: Buffer }> }): string {
+  const chunks = details.uploadData ?? []
+  if (chunks.length === 0) return ''
+  try {
+    return Buffer.concat(chunks.map((chunk) => chunk.bytes)).toString('utf8')
+  } catch {
+    return ''
+  }
+}
+
+function findFirstStringByKeys(value: unknown, keys: string[]): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findFirstStringByKeys(item, keys)
+      if (found) return found
+    }
+    return undefined
+  }
+  if (!value || typeof value !== 'object') return undefined
+
+  const record = value as Record<string, unknown>
+  for (const [key, child] of Object.entries(record)) {
+    if (keys.includes(key) && typeof child === 'string' && child.trim()) {
+      return child.trim()
+    }
+    if (child && typeof child === 'object') {
+      const found = findFirstStringByKeys(child, keys)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+function mergeCapturedFromJsonBody(next: CapturedChatRequest, bodyText: string): void {
+  if (!bodyText) return
+  try {
+    const json = JSON.parse(bodyText) as unknown
+    next.reqId ||= findFirstStringByKeys(json, ['req_id', 'reqId', 'request_id', 'requestId'])
+    next.sessionId ||= findFirstStringByKeys(json, ['session_id', 'sessionId'])
+  } catch {
+    // 非 JSON body
+  }
+}
+
+function mergeCapturedFromFormBody(next: CapturedChatRequest, bodyText: string): void {
+  if (!bodyText || bodyText.includes('{')) return
+  try {
+    const params = new URLSearchParams(bodyText)
+    next.reqId ||= params.get('req_id') || params.get('reqId') || params.get('request_id') || params.get('requestId') || undefined
+    next.sessionId ||= params.get('session_id') || params.get('sessionId') || undefined
+  } catch {
+    // 非 form body
+  }
+}
+
+function mergeCapturedFromUrl(next: CapturedChatRequest, url: string): void {
+  try {
+    const params = new URL(url).searchParams
+    next.reqId ||= params.get('req_id') || params.get('reqId') || params.get('request_id') || params.get('requestId') || undefined
+    next.sessionId ||= params.get('session_id') || params.get('sessionId') || undefined
+  } catch {
+    // 忽略 URL 解析失败
+  }
+}
+
+function findRequestHeader(headers: Record<string, string>, names: string[]): string | undefined {
+  const lower = new Map<string, string>()
+  for (const [key, value] of Object.entries(headers)) {
+    lower.set(key.toLowerCase(), value)
+  }
+  for (const name of names) {
+    const value = lower.get(name.toLowerCase())
+    if (value) return value
+  }
+  return undefined
+}
+
+function fail(error: string, attempts: Array<{ providerId: string; ok: boolean; errorMessage?: string }>): QwenGenerateResult {
+  attempts.push({ providerId: 'qwenwan', ok: false, errorMessage: error })
+  return { ok: false, providerId: 'qwenwan', error, attempts }
+}
+
+function failBlocked(error: string, attempts: Array<{ providerId: string; ok: boolean; errorMessage?: string }>): QwenGenerateResult {
+  const result = fail(error, attempts)
+  return { ...result, blocked: true }
+}
+
+function failCancelled(attempts: Array<{ providerId: string; ok: boolean; errorMessage?: string }>): QwenGenerateResult {
+  const error = '已手动终止生成（提示词未发送）'
+  attempts.push({ providerId: 'qwenwan', ok: false, errorMessage: error })
+  return { ok: false, providerId: 'qwenwan', cancelled: true, error, attempts }
+}
+
+function scriptError(scope: string, e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e)
+  if (/Script failed to execute/i.test(msg)) {
+    return `${scope}：页面脚本执行异常，请开启显示窗口确认页面状态或检查页面结构`
+  }
+  return `${scope}：${msg}`
+}
+
+function blockedMessageFromText(text?: string): string | null {
+  if (!text) return null
+  const line = text
+    .split('\n')
+    .map((s) => s.trim())
+    .find((s) => BLOCKED_PATTERN.test(s))
+  return line ? line.slice(0, 120) : null
+}
+
+async function injectCookies(cookies: ProviderCookie[], partition: string): Promise<number> {
+  const ses = session.fromPartition(partition)
+  ses.setUserAgent(UA)
+  let injected = 0
+  for (const c of cookies) {
+    try {
+      const cleanDomain = (c.domain || '').replace(/^\./, '') || 'www.qianwen.com'
+      const cookieUrl = `${c.secure === false ? 'http' : 'https'}://${cleanDomain}${c.path || '/'}`
+      await ses.cookies.set({
+        url: cookieUrl,
+        domain: c.domain || undefined,
+        name: c.name,
+        value: c.value,
+        httpOnly: !!c.httpOnly,
+        secure: c.secure !== false,
+        expirationDate: c.expires && c.expires > 0 ? Math.floor(c.expires / 1000) : undefined
+      })
+      injected += 1
+    } catch {
+      // 单条失败不阻断
+    }
+  }
+  return injected
+}
+
+async function readQwenImages(images: string[]): Promise<QwenImageData[]> {
+  const out: QwenImageData[] = []
+  for (const imagePath of images) {
+    try {
+      const ext = extname(imagePath).toLowerCase()
+      const mime =
+        ext === '.png' ? 'image/png' :
+        ext === '.gif' ? 'image/gif' :
+        ext === '.webp' ? 'image/webp' :
+        'image/jpeg'
+      const data = await readFile(imagePath)
+      out.push({
+        name: basename(imagePath),
+        mime,
+        dataUrl: `data:${mime};base64,${data.toString('base64')}`
+      })
+    } catch {
+      // 单张失败不阻断，只要至少有一张可上传即可
+    }
+  }
+  return out
+}
+
+async function uploadQwenReferences(
+  win: BrowserWindow,
+  images: string[]
+): Promise<{ ok: boolean; reason?: string }> {
+  const data = await readQwenImages(images)
+  if (data.length === 0) {
+    return { ok: false, reason: '读取千问素材图片失败，请确认图片文件仍存在' }
+  }
+  const savedText = clipboard.readText()
+  const savedImage = clipboard.readImage()
+  try {
+    const focus = (await win.webContents.executeJavaScript(
+      buildFocusInputScript(),
+      true
+    )) as { ok: boolean; reason?: string }
+    if (!focus.ok) {
+      return { ok: false, reason: focus.reason || '未找到千问输入框，无法通过 Ctrl+V 上传素材' }
+    }
+
+    let pasted = 0
+    for (const item of data) {
+      const image = nativeImage.createFromDataURL(item.dataUrl)
+      if (image.isEmpty()) {
+        return { ok: false, reason: `千问素材图片读取失败：${item.name}` }
+      }
+      clipboard.writeImage(image)
+      win.webContents.paste()
+      await sleep(1800)
+      pasted += 1
+    }
+
+    return { ok: true, reason: `已在千问输入框通过 Ctrl+V 上传 ${pasted} 张素材图片` }
+  } catch (e) {
+    return { ok: false, reason: scriptError('千问素材上传', e) }
+  } finally {
+    try {
+      if (!savedImage.isEmpty() || savedText) {
+        clipboard.write({ text: savedText, image: savedImage })
+      } else {
+        clipboard.clear()
+      }
+    } catch {}
+  }
+}
+
+// 千问官网的“AI生视频”入口会渲染 guide/onboarding 容器，容器本身不能删，
+// 否则视频工具栏会一起消失。这里只点击显式关闭按钮，并强制需要操作的控件可交互。
+function buildPrepareQwenComposerScript(options: QwenGenerateOptions): string {
+  const model = options.model || '万相 2.7'
+  const resolution = options.resolution || '720'
+  const ratio = options.ratio || '9:16'
+  const audio = options.audio || 'on'
+  const durationSec = options.durationSec ?? 5
+  return `(() => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim();
+  const targetModel = ${JSON.stringify(model)};
+  const targetRatio = ${JSON.stringify(ratio)};
+  const targetMode = ${JSON.stringify(options.mode || 'multi_ref')};
+  const resolutionLabel = ${JSON.stringify(resolution === '1080' ? '超清' : '高清')};
+  const durationLabel = ${JSON.stringify(durationSec + '秒')};
+  const audioLabel = ${JSON.stringify(audio === 'on' ? '开' : '关')};
+  const supportsSmartAudio = !/HappyHorse/i.test(targetModel);
+  const visible = (el) => {
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
+  };
+  const labelOf = (el) => norm((el.getAttribute('aria-label') || '') + ' ' + (el.getAttribute('title') || '') + ' ' + (el.textContent || ''));
+  const canClick = (el) => el.disabled !== true && el.getAttribute('aria-disabled') !== 'true';
+  const clickEl = (el) => {
+    el.style.pointerEvents = 'auto';
+    el.style.zIndex = '999';
+    try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+    const r = el.getBoundingClientRect();
+    const x = r.left + r.width / 2;
+    const y = r.top + r.height / 2;
+    const events = [];
+    if (typeof PointerEvent !== 'undefined') {
+      events.push(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
+      events.push(new PointerEvent('pointerup', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
+    }
+    events.push(new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    events.push(new MouseEvent('mouseup', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    events.push(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    for (const ev of events) el.dispatchEvent(ev);
+  };
+  const findButton = (matcher) => [...document.querySelectorAll('button, [role="button"], a, [class*="button" i], [class*="btn" i]')].filter((el) => visible(el) && canClick(el)).find(matcher);
+  const closeExplicitGuides = async () => {
+    for (let i = 0; i < 6; i++) {
+      const close = [...document.querySelectorAll('button, [role="button"]')].find((el) => {
+        if (!visible(el) || !canClick(el)) return false;
+        const t = labelOf(el);
+        return /^(关闭|知道了|我知道了|完成|跳过|下一项|下一步)$/.test(t);
+      });
+      if (!close) break;
+      clickEl(close);
+      await sleep(600);
+    }
+  };
+  const forceVideoControls = () => {
+    for (const el of [...document.querySelectorAll('[class*="guideComp" i], [class*="guideContainer" i], [class*="guide" i]')]) {
+      el.style.pointerEvents = 'auto';
+    }
+    for (const b of [...document.querySelectorAll('button')]) {
+      if (/AI生视频|万相|HappyHorse|多参考|首帧|首尾帧|文生视频|图生视频|720P|1080P/.test(labelOf(b))) {
+        b.style.pointerEvents = 'auto';
+        b.style.zIndex = '999';
+      }
+    }
+  };
+  const ensureVideoMode = async () => {
+    const hasVideoToolbar = [...document.querySelectorAll('button')].filter(visible).some((el) => /^(万相|HappyHorse)/.test(labelOf(el)) || /720P|1080P/.test(labelOf(el)));
+    if (hasVideoToolbar) return true;
+    const ai = findButton((el) => /AI生视频|AI视频|生视频/.test(labelOf(el)));
+    if (!ai) return false;
+    clickEl(ai);
+    await sleep(2200);
+    return true;
+  };
+  const currentModelButton = () => [...document.querySelectorAll('button')].filter(visible).find((el) => /^(万相|HappyHorse)/.test(labelOf(el)));
+  const openModelMenu = async () => {
+    const btn = currentModelButton();
+    if (!btn) return false;
+    clickEl(btn);
+    await sleep(1200);
+    return true;
+  };
+  const findModelItem = (target) => {
+    const targetKey = target.replace(/\\s+/g, '');
+    return [...document.querySelectorAll('[role="menuitemcheckbox"], [role="menuitem"], [role="option"], button, [class*="option" i]')]
+      .filter(visible)
+      .find((el) => {
+        const key = norm(el.textContent || '').replace(/\\s+/g, '');
+        return key.startsWith(targetKey);
+      });
+  };
+  const currentModeButton = () => [...document.querySelectorAll('button')].filter(visible).find((el) => /多参考生成|首帧生成|首尾帧生成|文生视频|图生视频/.test(labelOf(el)));
+  const openModeMenu = async () => {
+    const btn = currentModeButton();
+    if (!btn) return false;
+    clickEl(btn);
+    await sleep(1200);
+    return true;
+  };
+  const findModeItem = (target) => {
+    const targetKey = target.replace(/\\s+/g, '');
+    const menuItems = [...document.querySelectorAll('[role="menuitemcheckbox"], [role="menuitem"], [role="option"]')]
+      .filter(visible)
+      .find((el) => {
+        const key = norm(el.textContent || '').replace(/\\s+/g, '');
+        return key === targetKey || key.startsWith(targetKey);
+      });
+    if (menuItems) return menuItems;
+    return [...document.querySelectorAll('button')]
+      .filter(visible)
+      .find((el) => {
+        const key = norm(el.textContent || '').replace(/\\s+/g, '');
+        return key === targetKey || key.startsWith(targetKey);
+      });
+  };
+  const applyGenerationMode = async () => {
+    const targetModeMap = {
+      text2video: '文生视频',
+      t2v: '文生视频',
+      multi_ref: '多参考生成',
+      first_frame: '首帧生成',
+      first_last: '首尾帧生成',
+      firstlast: '首尾帧生成'
+    };
+    const targetModeLabel = targetModeMap[targetMode] || '';
+    if (!targetModeLabel) return { ok: true };
+    const btn = currentModeButton();
+    if (!btn) return { ok: true, reason: '未找到千问生成模式按钮，保持页面默认模式' };
+    if (norm(btn.textContent || '').includes(targetModeLabel)) return { ok: true };
+    if (!(await openModeMenu())) return { ok: false, reason: '未找到千问生成模式按钮' };
+    const item = findModeItem(targetModeLabel);
+    if (!item) {
+      const modeBtn = currentModeButton();
+      if (modeBtn) clickEl(modeBtn);
+      await sleep(600);
+      return { ok: true, reason: '千问页面未提供生成模式：' + targetModeLabel + '，保持默认模式' };
+    }
+    clickEl(item);
+    await sleep(900);
+    return { ok: true };
+  };
+  const findParamsSummaryButton = () => {
+    return [...document.querySelectorAll('button, [role="button"], [class*="button" i], [class*="btn" i]')]
+      .filter((el) => visible(el) && canClick(el) && el.getAttribute('aria-expanded') !== 'true')
+      .find((el) => {
+        const t = labelOf(el);
+        const cls = typeof el.className === 'string' ? el.className : '';
+        return /(720|1080)P\s*[··]?\s*\d+s/.test(t) || /(720|1080)P|超清|高清/.test(t) || /capsuleSecondaryGap/i.test(cls);
+      }) || null;
+  };
+  const findParamsPanel = () => {
+    const all = [...document.querySelectorAll('[role="menu"], [data-radix-menu-content], [class*="morePanel" i], [class*="menuContent" i], [class*="popup" i], [class*="drawer" i], [class*="setting" i], [class*="param" i]')].filter(visible);
+    const withText = all
+      .filter((el) => /清晰度/.test(norm(el.textContent || '')) && /(9:16|3:4|1:1|4:3|16:9|\\d+\\s*秒|智能配音)/.test(norm(el.textContent || '')))
+      .filter((el) => el.querySelectorAll('button').length >= 4)
+      .sort((a, b) => (a.textContent || '').length - (b.textContent || '').length);
+    return withText.find((el) => typeof el.className === 'string' && /morePanel/i.test(el.className))
+      || withText.find((el) => el.getAttribute('data-state') === 'open')
+      || withText[0]
+      || findAnyParamsPanel();
+  };
+  const findAnyParamsPanel = () => {
+    return [...document.querySelectorAll('div, section, [role="menu"], [data-radix-menu-content]')]
+      .filter(visible)
+      .filter((el) => /清晰度/.test(norm(el.textContent || '')) && /(9:16|3:4|1:1|4:3|16:9|\\d+\\s*秒|智能配音)/.test(norm(el.textContent || '')))
+      .filter((el) => el.querySelectorAll('button').length >= 4)
+      .sort((a, b) => (a.textContent || '').length - (b.textContent || '').length)[0] || null;
+  };
+  const openParamsPanel = async () => {
+    if (findParamsPanel()) return true;
+    const summary = findParamsSummaryButton();
+    if (!summary) return false;
+    clickEl(summary);
+    await sleep(1800);
+    return !!findParamsPanel();
+  };
+  const findSection = (panel, title) => {
+    const candidates = [...panel.querySelectorAll('[class*="moreSection" i], [class*="section" i], [class*="item" i], [class*="row" i], [class*="group" i], [class*="field" i], div')]
+      .filter(visible)
+      .filter((section) => {
+        const titleEl = section.querySelector('[class*="moreSectionTitle" i], [class*="title" i], [class*="label" i]');
+        const t = norm(section.getAttribute('aria-label') || section.getAttribute('title') || titleEl?.textContent || '');
+        const ownText = norm(section.textContent || '');
+        return t === title || t.startsWith(title) || ownText.startsWith(title);
+      })
+      .filter((section) => section.querySelectorAll('button').length > 0);
+    return candidates.sort((a, b) => a.querySelectorAll('button').length - b.querySelectorAll('button').length)[0] || null;
+  };
+  const isActiveOption = (el) => {
+    const cls = typeof el.className === 'string' ? el.className : '';
+    return cls.includes('segmentButtonActive') || el.getAttribute('aria-checked') === 'true' || el.getAttribute('data-state') === 'checked';
+  };
+  const findOptionButton = (section, optionLabel) => {
+    return [...section.querySelectorAll('button')]
+      .filter(visible)
+      .find((el) => norm(el.textContent || '') === optionLabel)
+      || [...section.querySelectorAll('button')]
+        .filter(visible)
+        .find((el) => labelOf(el) === optionLabel)
+      || null;
+  };
+  const findOptionButtonInDocument = (optionLabel) => {
+    return [...document.querySelectorAll('button, [role="button"]')]
+      .filter(visible)
+      .find((el) => norm(el.textContent || '') === optionLabel)
+      || [...document.querySelectorAll('button, [role="button"]')]
+        .filter(visible)
+        .find((el) => labelOf(el) === optionLabel)
+      || null;
+  };
+  const applyOption = async (title, optionLabel) => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      let panel = findParamsPanel();
+      let searchRoot = panel || document;
+      let btn = panel ? findOptionButton(searchRoot, optionLabel) : null;
+      if (!btn) btn = findOptionButtonInDocument(optionLabel);
+      if (!panel && !btn) {
+        if (!(await openParamsPanel())) return { ok: false, reason: '未找到千问参数面板（请确认已进入 AI生视频）' };
+        panel = findParamsPanel();
+        searchRoot = panel || document;
+        btn = findOptionButtonInDocument(optionLabel);
+      }
+      if (panel) {
+        const section = findSection(panel, title);
+        searchRoot = section || panel;
+        if (!btn) btn = findOptionButton(searchRoot, optionLabel);
+        if (!btn) btn = findOptionButton(panel, optionLabel);
+        if (!btn) btn = findOptionButtonInDocument(optionLabel);
+      }
+      if (!btn) return { ok: false, reason: '未找到“' + title + '”选项：' + optionLabel };
+      if (isActiveOption(btn)) return { ok: true };
+      clickEl(btn);
+      await sleep(900);
+      let check = findOptionButton(searchRoot, optionLabel);
+      if (!check && panel) check = findOptionButton(panel, optionLabel);
+      if (!check) check = findOptionButtonInDocument(optionLabel);
+      if (check && isActiveOption(check)) return { ok: true };
+      await sleep(700);
+      let check2 = findOptionButton(searchRoot, optionLabel);
+      if (!check2 && panel) check2 = findOptionButton(panel, optionLabel);
+      if (!check2) check2 = findOptionButtonInDocument(optionLabel);
+      if (check2 && isActiveOption(check2)) return { ok: true };
+      if (!findParamsPanel()) {
+        await openParamsPanel();
+      }
+    }
+    return { ok: false, reason: '设置“' + title + '”失败' };
+  };
+
+  return (async () => {
+    try {
+    if (!(await ensureVideoMode())) return { ok: false, reason: '未找到千问 AI生视频 入口，页面结构可能已变化' };
+    await closeExplicitGuides();
+    forceVideoControls();
+
+    const modelBtn = currentModelButton();
+    if (!modelBtn) return { ok: false, reason: '未找到千问模型选择按钮，页面结构可能已变化' };
+    if (labelOf(modelBtn) !== targetModel) {
+      if (!(await openModelMenu())) return { ok: false, reason: '未找到千问模型选择按钮' };
+      const item = findModelItem(targetModel);
+      if (!item) return { ok: false, reason: '未找到千问模型菜单项：' + targetModel };
+      clickEl(item);
+      await sleep(900);
+    }
+
+    const modeApplied = await applyGenerationMode();
+    if (!modeApplied.ok) return modeApplied;
+
+    const optionsToApply = [
+      ['清晰度', resolutionLabel],
+      ['比例', targetRatio],
+      ['视频时长', durationLabel]
+    ]
+    if (supportsSmartAudio) optionsToApply.push(['智能配音', audioLabel])
+    for (const [title, optionLabel] of optionsToApply) {
+      const applied = await applyOption(title, optionLabel)
+      if (!applied.ok) return applied
+    }
+
+    return {
+      ok: true,
+      reason: '千问视频参数已设置',
+      detail: { model: targetModel, resolution: ${JSON.stringify(resolution)}, ratio: targetRatio, durationSec: ${durationSec}, audio: ${JSON.stringify(audio)} }
+    }
+    } catch (e) {
+      return { ok: false, reason: '千问参数脚本异常: ' + (e && e.message ? e.message : String(e)) };
+    }
+  })();
+})()`
+}
+
+function buildFillPromptScript(prompt: string): string {
+  const promptJson = JSON.stringify(prompt)
+  return `(async () => {
+  try {
+  const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim();
+  const visible = (el) => {
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
+  };
+  const findInput = () => {
+    const sels = [
+      'textarea',
+      'input:not([type="file"]):not([type="hidden"]):not([type="submit"]):not([type="button"])',
+      '[contenteditable]',
+      '[contenteditable="true"]',
+      '[contenteditable="plaintext-only"]',
+      '[role="textbox"]',
+      '[data-lexical-editor]',
+      '[data-slate-editor]'
+    ];
+    for (const s of sels) {
+      const els = [...document.querySelectorAll(s)].filter(visible);
+      if (els.length) return els[0];
+    }
+    return null;
+  };
+  const setValue = (el, text) => {
+    el.focus();
+    if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+      const proto = el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement : window.HTMLInputElement;
+      const setter = Object.getOwnPropertyDescriptor(proto.prototype, 'value').set;
+      setter.call(el, text);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      return;
+    }
+    el.innerHTML = '';
+    el.appendChild(document.createTextNode(text));
+    el.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, data: text, inputType: 'insertText' }));
+    el.dispatchEvent(new InputEvent('input', { bubbles: true, data: text, inputType: 'insertText' }));
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  const input = findInput();
+  if (!input) return { ok: false, reason: '未找到千问输入框，页面结构可能已变化' };
+  setValue(input, ${promptJson});
+  return { ok: true, reason: '已填入千问 prompt', tag: input.tagName.toLowerCase(), cls: (typeof input.className === 'string' ? input.className : '').slice(0, 120) };
+  } catch (e) {
+    return { ok: false, reason: '千问 prompt 填写脚本异常: ' + (e && e.message ? e.message : String(e)) };
+  }
+})()`
+}
+
+function buildFocusInputScript(): string {
+  return `(async () => {
+  try {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const visible = (el) => {
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
+  };
+  const findInput = () => {
+    const sels = [
+      'textarea',
+      'input:not([type="file"]):not([type="hidden"]):not([type="submit"]):not([type="button"])',
+      '[contenteditable]',
+      '[contenteditable="true"]',
+      '[contenteditable="plaintext-only"]',
+      '[role="textbox"]',
+      '[data-lexical-editor]',
+      '[data-slate-editor]'
+    ];
+    for (const s of sels) {
+      const els = [...document.querySelectorAll(s)].filter(visible);
+      if (els.length) return els[0];
+    }
+    return null;
+  };
+  const chatInput = findInput();
+  if (!chatInput) return { ok: false, reason: '未找到千问输入框，无法通过 Ctrl+V 上传素材，请开启显示窗口确认已进入 AI生视频' };
+  chatInput.focus();
+  try { chatInput.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+  await sleep(300);
+  return { ok: true, reason: '千问输入框已聚焦，准备通过 Ctrl+V 上传素材' };
+  } catch (e) {
+    return { ok: false, reason: '千问素材上传脚本异常: ' + (e && e.message ? e.message : String(e)) };
+  }
+})()`
+}
+
+function buildClickSendScript(): string {
+  return `(async () => {
+  try {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim();
+  const visible = (el) => {
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
+  };
+  const canClick = (el) => el.disabled !== true && el.getAttribute('aria-disabled') !== 'true';
+  const isSendText = (t) => /发送|提交|生成/.test(t) && !/停止/.test(t);
+  const findInput = () => {
+    const sels = [
+      'textarea',
+      'input:not([type="file"]):not([type="hidden"]):not([type="submit"]):not([type="button"])',
+      '[contenteditable]',
+      '[contenteditable="true"]',
+      '[contenteditable="plaintext-only"]',
+      '[role="textbox"]',
+      '[data-lexical-editor]',
+      '[data-slate-editor]'
+    ];
+    for (const s of sels) {
+      const els = [...document.querySelectorAll(s)].filter(visible);
+      if (els.length) return els[0];
+    }
+    return null;
+  };
+  const clickEl = (el) => {
+    el.style.pointerEvents = 'auto';
+    el.style.zIndex = '999';
+    const r = el.getBoundingClientRect();
+    const x = r.left + r.width / 2;
+    const y = r.top + r.height / 2;
+    if (typeof PointerEvent !== 'undefined') {
+      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
+      el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
+    }
+    for (const type of ['mousedown', 'mouseup', 'click']) {
+      el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    }
+  };
+  const findSend = () => {
+    const candidates = [...document.querySelectorAll('button, [role="button"], [class*="send" i], [class*="submit" i], [class*="action" i], [class*="cursor-pointer" i]')].filter(visible);
+    const sendByAria = candidates.find((el) => {
+      const aria = norm(el.getAttribute('aria-label') || '');
+      const title = norm(el.getAttribute('title') || '');
+      return aria === '发送消息' || title === '发送消息' || aria === '发送' || title === '发送' || aria === '提交' || title === '提交';
+    });
+    if (sendByAria) return sendByAria;
+    const clickableCandidates = candidates.filter(canClick);
+    const hit = clickableCandidates.find((el) => {
+      return isSendText(norm(el.getAttribute('aria-label') || '')) ||
+        isSendText(norm(el.getAttribute('title') || '')) ||
+        isSendText(norm(el.getAttribute('data-testid') || '')) ||
+        isSendText(norm(el.textContent || ''));
+    });
+    if (hit) return hit;
+    const input = findInput();
+    if (!input) return null;
+    let node = input;
+    for (let i = 0; i < 6 && node; i++) {
+      const parent = node.parentElement;
+      if (!parent) break;
+      const icons = [...parent.querySelectorAll('button, [role="button"], [class*="cursor-pointer" i]')].filter((el) => visible(el) && canClick(el) && el.querySelector('svg'));
+      if (icons.length) return icons[icons.length - 1];
+      node = parent;
+    }
+    return clickableCandidates.filter((el) => el.querySelector('svg')).pop() || null;
+  };
+  await sleep(400);
+  let send = findSend();
+  if (!send) return { ok: false, reason: '已填入 prompt，但未找到发送按钮' };
+  for (let i = 0; i < 10 && (send.disabled === true || send.getAttribute('aria-disabled') === 'true'); i++) {
+    await sleep(300);
+    send = findSend();
+    if (!send) return { ok: false, reason: '已填入 prompt，但未找到发送按钮' };
+  }
+  if (send.disabled === true || send.getAttribute('aria-disabled') === 'true') {
+    return { ok: false, reason: '千问发送按钮仍为禁用状态，prompt 未进入编辑器状态' };
+  }
+  clickEl(send);
+  return { ok: true, reason: '已点击千问发送按钮', aria: send.getAttribute('aria-label') || '', text: norm(send.textContent || '').slice(0, 40), cls: (typeof send.className === 'string' ? send.className : '').slice(0, 120) };
+  } catch (e) {
+    return { ok: false, reason: '千问发送脚本异常: ' + (e && e.message ? e.message : String(e)) };
+  }
+})()`
+}
+
+function setupChatCapture(
+  partition: string,
+  ses: Electron.Session,
+  captured: { current: CapturedChatRequest | null }
+): void {
+  const existing = chatCaptureRegistrations.get(partition)
+  if (existing) {
+    existing.captured = captured
+    return
+  }
+
+  const registration: ChatCaptureRegistration = { captured }
+  chatCaptureRegistrations.set(partition, registration)
+
+  ses.webRequest.onBeforeRequest({ urls: CHAT_API_URLS }, (details, callback) => {
+    callback({})
+    const target = chatCaptureRegistrations.get(partition)?.captured
+    if (!target) return
+    if (isQwenDetailUrl(details.url)) return
+    const bodyText = readUploadDataText(details)
+    const next: CapturedChatRequest = { ...target.current }
+    mergeCapturedFromUrl(next, details.url)
+    mergeCapturedFromJsonBody(next, bodyText)
+    mergeCapturedFromFormBody(next, bodyText)
+    target.current = next
+  })
+
+  ses.webRequest.onBeforeSendHeaders({ urls: CHAT_API_URLS }, (details, callback) => {
+    const headers = details.requestHeaders
+    const target = chatCaptureRegistrations.get(partition)?.captured
+    if (target) {
+      if (isQwenDetailUrl(details.url)) {
+        callback({ requestHeaders: headers })
+        return
+      }
+      const next: CapturedChatRequest = { ...target.current }
+      const deviceId = findRequestHeader(headers, ['x-deviceid', 'x-device-id'])
+      if (deviceId) next.deviceId = deviceId
+      const xsrfToken = findRequestHeader(headers, ['x-xsrf-token'])
+      if (xsrfToken) next.xsrfToken = xsrfToken
+      const cookie = findRequestHeader(headers, ['cookie'])
+      if (cookie) next.cookie = cookie
+      const reqIdHeader = findRequestHeader(headers, ['x-chat-id', 'x-request-id', 'request-id'])
+      if (reqIdHeader && !next.reqId) next.reqId = reqIdHeader
+      const sessionHeader = findRequestHeader(headers, ['x-session-id', 'x-chat-session-id'])
+      if (sessionHeader && !next.sessionId) next.sessionId = sessionHeader
+      const chatBizHeader = findRequestHeader(headers, ['x-chat-biz'])
+      if (chatBizHeader && (!next.reqId || !next.sessionId)) {
+        mergeCapturedFromJsonBody(next, chatBizHeader)
+      }
+      target.current = next
+    }
+    callback({ requestHeaders: headers })
+  })
+}
+
+async function injectStorages(win: BrowserWindow, storages: OriginStorage[]): Promise<void> {
+  try {
+    await win.webContents.executeJavaScript(
+      `(() => {
+        const all = ${JSON.stringify(storages)};
+        const main = all.find((s) => location.origin === s.origin) || all.find((s) => (s.origin || '').includes('qianwen.com'));
+        if (main && main.localStorage) {
+          for (const { key, value } of main.localStorage) {
+            try { localStorage.setItem(key, value); } catch {}
+          }
+          if (main.sessionStorage) {
+            for (const { key, value } of main.sessionStorage) {
+              try { sessionStorage.setItem(key, value); } catch {}
+            }
+          }
+        }
+      })()`,
+      true
+    )
+    await win.webContents.executeJavaScript('location.reload()', true)
+    await sleep(3000)
+  } catch {
+    // storage 注入失败不阻断，页面可能仅依赖 cookie
+  }
+}
+
+async function waitForChatCapture(
+  captured: { current: CapturedChatRequest | null },
+  cancelState: { aborted: boolean; submitted: boolean } | undefined,
+  timeoutMs: number
+): Promise<CapturedChatRequest | null> {
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    if (captured.current?.reqId && captured.current.sessionId) return captured.current
+    if (cancelState?.aborted) return null
+    await sleep(300)
+  }
+  return null
+}
+
+async function cookieHeaderFromSession(partition: string): Promise<string> {
+  try {
+    const ses = session.fromPartition(partition)
+    const cookies = await ses.cookies.get({})
+    return cookies.map((c) => `${c.name}=${c.value}`).join('; ')
+  } catch {
+    return ''
+  }
+}
+
+function extractVideoFromDetail(data: unknown): { url: string; posterUrl: string } | null {
+  const root = data as { data?: { response_messages?: Array<Record<string, unknown>> } }
+  if (!root?.data?.response_messages) return null
+  for (const msg of root.data.response_messages) {
+    if (msg.mime_type !== 'multi_load/iframe') continue
+    const meta = msg.meta_data as { multi_load?: Array<{ html?: { sc_html?: string } }> } | undefined
+    const scHtml = meta?.multi_load?.[0]?.html?.sc_html
+    if (!scHtml) continue
+    const videoMatch = scHtml.match(/src="(https?:\/\/[^"]+\.mp4[^"]*)"/)
+    if (!videoMatch) continue
+    const posterMatch = scHtml.match(/poster="(https?:\/\/[^"]+\.jpg[^"]*)"/)
+    return { url: videoMatch[1], posterUrl: posterMatch ? posterMatch[1] : '' }
+  }
+  return null
+}
+
+function extractBlockedFromDetail(data: unknown): string | null {
+  const root = data as { data?: { response_messages?: Array<Record<string, unknown>> } }
+  const texts = (root?.data?.response_messages ?? [])
+    .map((msg) => {
+      if (typeof msg.content === 'string') return msg.content
+      if (typeof msg.text === 'string') return msg.text
+      if (typeof msg.message === 'string') return msg.message
+      if (Array.isArray(msg.content)) {
+        return msg.content
+          .map((part) => (typeof part === 'string' ? part : (part as { text?: string }).text ?? ''))
+          .filter(Boolean)
+          .join('\n')
+      }
+      return ''
+    })
+    .join('\n')
+  return blockedMessageFromText(texts)
+}
+
+interface QwenPollResult {
+  ok: boolean
+  video?: { url: string; posterUrl: string }
+  error?: string
+  blocked?: boolean
+}
+
+async function pollQwenDetail(
+  captured: CapturedChatRequest,
+  partition: string,
+  maxWaitMs: number,
+  onProgress: (stage: string, detail?: unknown) => void
+): Promise<QwenPollResult> {
+  const reqId = captured.reqId ?? ''
+  const sessionId = captured.sessionId ?? ''
+  const deviceId = captured.deviceId ?? ''
+  const xsrfToken = captured.xsrfToken ?? ''
+  const cookie = captured.cookie || (await cookieHeaderFromSession(partition))
+  const params = new URLSearchParams({
+    biz_id: 'ai_qwen',
+    chat_client: 'h5',
+    device: 'pc',
+    fr: 'pc',
+    pr: 'qwen',
+    ut: deviceId,
+    la: 'zh-CN',
+    tz: 'Asia/Shanghai',
+    wv: '4.1.4',
+    ve: '4.1.4',
+    session_id: sessionId,
+    req_id: reqId + '_complete'
+  })
+  const started = Date.now()
+  while (Date.now() - started < maxWaitMs) {
+    try {
+      const res = await fetch(`${DETAIL_API_URL}?${params.toString()}`, {
+        headers: {
+          accept: '*/*',
+          cookie,
+          'x-deviceid': deviceId,
+          'x-platform': 'pc_tongyi',
+          'x-xsrf-token': xsrfToken,
+          'user-agent': UA,
+          referer: `https://www.qianwen.com/chat/${sessionId}`
+        },
+        signal: AbortSignal.timeout(15000)
+      })
+      if (res.status === 401 || res.status === 403) {
+        return { ok: false, error: '千问接口返回 401/403，可能登录态失效或风控限制' }
+      }
+      if (res.status === 200) {
+        const json = (await res.json()) as unknown
+        const blocked = extractBlockedFromDetail(json)
+        if (blocked) {
+          return { ok: false, blocked: true, error: blocked }
+        }
+        const video = extractVideoFromDetail(json)
+        if (video) return { ok: true, video }
+      }
+    } catch {
+      // 单次轮询失败继续
+    }
+    onProgress('waiting', { message: '等待千问生成完成…' })
+    await sleep(5000)
+  }
+  return { ok: false, error: '等待超时未取到千问视频 URL' }
+}
+
+export async function runQwenGeneration(options: QwenGenerateOptions): Promise<QwenGenerateResult> {
+  const attempts: Array<{ providerId: string; ok: boolean; errorMessage?: string }> = []
+  const failWith = (error: string): QwenGenerateResult => fail(error, attempts)
+  const cancelState = options.cancel
+  let win: BrowserWindow | null = null
+
+  const abortIfCancelled = (): QwenGenerateResult | null => {
+    if (!cancelState?.aborted) return null
+    try {
+      win?.destroy()
+    } catch {}
+    return failCancelled(attempts)
+  }
+
+  const waitOrAbort = async (ms: number): Promise<boolean> => {
+    const step = 200
+    const end = Date.now() + ms
+    while (Date.now() < end) {
+      if (cancelState?.aborted) return true
+      await sleep(Math.min(step, end - Date.now()))
+    }
+    return cancelState?.aborted === true
+  }
+
+  const abortNow = (): QwenGenerateResult => abortIfCancelled() ?? failCancelled(attempts)
+
+  let qwenMode = options.mode || 'multi_ref'
+  if (qwenMode === 'firstlast') qwenMode = 'first_last'
+  if (!QWEN_IMAGE_MODES.has(qwenMode)) {
+    return failWith('千问当前仅支持多参考/首帧/首尾帧生成（需至少上传一张素材图片）')
+  }
+  if (!options.images || options.images.length === 0) {
+    return failWith('千问多参考/首帧/首尾帧生成需要至少上传一张素材图片')
+  }
+  options.mode = qwenMode
+
+  const partition = options.keyId ? `persist:qf-p:qwenwan:${options.keyId}` : 'persist:qf-p:qwenwan'
+  options.onProgress?.('inject-cookies')
+  await injectCookies(options.cookies, partition)
+
+  const captured: { current: CapturedChatRequest | null } = { current: null }
+  const ses = session.fromPartition(partition)
+  ses.setUserAgent(UA)
+  setupChatCapture(partition, ses, captured)
+
+  {
+    const aborted = abortIfCancelled()
+    if (aborted) return aborted
+  }
+
+  options.onProgress?.('open-page')
+  win = new BrowserWindow({
+    show: options.showWebview === true,
+    width: 1280,
+    height: 900,
+    title: '千问生成 - Quota-Flow',
+    autoHideMenuBar: true,
+    backgroundColor: '#0c0c0c',
+    webPreferences: {
+      partition,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  })
+  if (options.showWebview === true) {
+    try {
+      win.center()
+    } catch {}
+  }
+  win.webContents.setUserAgent(UA)
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http')) return { action: 'allow', overrideBrowserWindowOptions: { width: 560, height: 720 } }
+    return { action: 'deny' }
+  })
+
+  let loadError: { code: number; desc: string; url: string } | null = null
+  win.webContents.on('did-fail-load', (_e, code, desc, url) => {
+    loadError = { code, desc, url }
+  })
+  try {
+    await Promise.race([
+      win.loadURL(QWEN_CHAT_URL),
+      waitOrAbort(90000).then((ab) => {
+        if (ab) throw new Error('已取消')
+        throw new Error('页面加载超时')
+      })
+    ])
+  } catch (e) {
+    loadError = { code: -1, desc: e instanceof Error ? e.message : String(e), url: QWEN_CHAT_URL }
+  }
+  if (await waitOrAbort(4000)) return abortNow()
+
+  if (options.storages && options.storages.length > 0) {
+    await injectStorages(win, options.storages)
+    if (await waitOrAbort(2000)) return abortNow()
+  }
+
+  let inputFound = false
+  try {
+    inputFound = !!(await win.webContents.executeJavaScript(
+      `(() => {
+        const sels = [
+          'textarea',
+          'input:not([type="file"]):not([type="hidden"]):not([type="submit"]):not([type="button"])',
+          '[contenteditable]',
+          '[contenteditable="true"]',
+          '[contenteditable="plaintext-only"]',
+          '[role="textbox"]',
+          '[data-lexical-editor]',
+          '[data-slate-editor]'
+        ];
+        return [...document.querySelectorAll(sels.join(','))].some((el) => el.offsetParent !== null);
+      })()`,
+      true
+    ))
+  } catch {}
+
+  if (loadError || !inputFound) {
+    win.destroy()
+    return failWith(loadError ? `页面加载失败 (${loadError.code}: ${loadError.desc})` : '千问账号未登录（cookie 可能已失效），请在厂商页重新登录后重试')
+  }
+
+  const urlSessionId = qwenSessionIdFromUrl(win.webContents.getURL())
+  if (urlSessionId) {
+    captured.current = { sessionId: urlSessionId }
+  }
+
+  {
+    const aborted = abortIfCancelled()
+    if (aborted) return aborted
+  }
+
+  options.onProgress?.('apply-params', {
+    prompt: options.prompt,
+    model: options.model,
+    mode: options.mode,
+    resolution: options.resolution,
+    ratio: options.ratio,
+    audio: options.audio,
+    durationSec: options.durationSec
+  })
+  let prepareResult: { ok?: boolean; reason?: string } = {}
+  try {
+    prepareResult = (await win.webContents.executeJavaScript(
+      buildPrepareQwenComposerScript(options),
+      true
+    )) as typeof prepareResult
+  } catch (e) {
+    prepareResult = { ok: false, reason: scriptError('千问参数设置', e) }
+  }
+  if (!prepareResult.ok) {
+    win.destroy()
+    return failWith(prepareResult.reason || '千问页面参数设置失败')
+  }
+
+  {
+    const aborted = abortIfCancelled()
+    if (aborted) return aborted
+  }
+
+  options.onProgress?.('upload-images')
+  const uploadResult = await uploadQwenReferences(win, options.images ?? [])
+  if (!uploadResult.ok) {
+    win.destroy()
+    return failWith(uploadResult.reason || '千问素材上传失败')
+  }
+
+  {
+    const aborted = abortIfCancelled()
+    if (aborted) return aborted
+  }
+
+  captured.current = urlSessionId ? { sessionId: urlSessionId } : null
+  options.onProgress?.('submit', { prompt: options.prompt, model: options.model })
+  let fillResult: { ok?: boolean; reason?: string } = {}
+  try {
+    fillResult = (await win.webContents.executeJavaScript(
+      buildFillPromptScript(options.prompt),
+      true
+    )) as typeof fillResult
+  } catch (e) {
+    fillResult = { ok: false, reason: scriptError('千问 prompt 填写', e) }
+  }
+  if (!fillResult.ok) {
+    win.destroy()
+    return failWith(fillResult.reason || '千问 prompt 填写失败')
+  }
+
+  {
+    const aborted = abortIfCancelled()
+    if (aborted) return aborted
+  }
+
+  let sendResult: { ok?: boolean; reason?: string } = {}
+  try {
+    sendResult = (await win.webContents.executeJavaScript(
+      buildClickSendScript(),
+      true
+    )) as typeof sendResult
+  } catch (e) {
+    sendResult = { ok: false, reason: scriptError('千问发送', e) }
+  }
+  if (!sendResult.ok) {
+    win.destroy()
+    return failWith(sendResult.reason || '千问发送失败')
+  }
+
+  if (cancelState) cancelState.submitted = true
+  options.onProgress?.('waiting', { message: '已发送 prompt，等待千问生成…' })
+  const chat = await waitForChatCapture(captured, cancelState, 15000)
+  if (!chat?.reqId || !chat.sessionId) {
+    win.destroy()
+    return failWith('未捕获到千问生成请求（req_id/session_id），请开启显示窗口或确认页面已正常发送')
+  }
+  if (!chat.deviceId || !chat.xsrfToken) {
+    win.destroy()
+    return failWith('未捕获到千问生成请求头（x-deviceid/x-xsrf-token），请开启显示窗口后重试')
+  }
+
+  options.onProgress?.('waiting')
+  const poll = await pollQwenDetail(chat, partition, (options.maxWaitSec ?? 360) * 1000, (stage, detail) =>
+    options.onProgress?.(stage, detail)
+  )
+  win.destroy()
+
+  if (!poll.ok) {
+    if (poll.blocked) {
+      return failBlocked(poll.error ?? '千问拒绝了本次生成', attempts)
+    }
+    return failWith(poll.error ?? '等待超时未取到千问视频 URL')
+  }
+  if (!poll.video) {
+    return failWith('等待超时未取到千问视频 URL')
+  }
+  const video = poll.video
+  attempts.push({ providerId: 'qwenwan', ok: true })
+  return {
+    ok: true,
+    providerId: 'qwenwan',
+    videoUrl: video.url,
+    posterUrl: video.posterUrl || null,
+    attempts
+  }
+}

--- a/apps/desktop/src/main/webview-test.ts
+++ b/apps/desktop/src/main/webview-test.ts
@@ -68,7 +68,7 @@ const PROVIDERS: Record<ProviderId, ProviderDef> = {
     authFile: join(REPO_ROOT, 'data', 'qwen-auth.json'),
     cookieUrl: 'https://www.qianwen.com',
     cookieDomain: '.qianwen.com',
-    captureUrls: ['https://chat2.qianwen.com/api/v2/chat*']
+    captureUrls: ['*://*.qianwen.com/api/*', '*://qianwen.com/api/*']
   }
 }
 
@@ -388,16 +388,17 @@ class WebviewTestManager {
     this.captureReady.add(def.partition)
     ses.webRequest.onBeforeRequest({ urls: def.captureUrls }, (details, callback) => {
       callback({})
+      if (def.id === 'qwenwan' && /\/req\/detail\b|\/detail\b/i.test(details.url)) return
       let bodyText = ''
       try {
-        // Electron 类型定义未声明 requestBody，但运行时 onBeforeRequest 提供该字段
+        // Electron onBeforeRequest 使用 uploadData 暴露请求体，不是 Chrome 扩展的 requestBody
         const withBody = details as unknown as {
-          requestBody?: { raw?: Array<{ bytes: Buffer | string }> }
+          uploadData?: Array<{ bytes: Buffer }>
         }
-        const raw = withBody.requestBody?.raw
+        const raw = withBody.uploadData
         if (raw?.length) {
           bodyText = Buffer.concat(
-            raw.map((x) => (Buffer.isBuffer(x.bytes) ? x.bytes : Buffer.from(x.bytes)))
+            raw.map((x) => x.bytes)
           ).toString('utf8')
         }
       } catch {
@@ -406,9 +407,35 @@ class WebviewTestManager {
       const cap: CapturedRequest = { ts: Date.now() }
       if (def.id === 'qwenwan') {
         try {
-          const json = JSON.parse(bodyText) as { req_id?: string; session_id?: string }
-          if (json.req_id) cap.reqId = json.req_id
-          if (json.session_id) cap.sessionId = json.session_id
+          const params = new URL(details.url).searchParams
+          cap.reqId ||= params.get('req_id') || params.get('reqId') || undefined
+          cap.sessionId ||= params.get('session_id') || params.get('sessionId') || undefined
+        } catch {
+          /* 忽略 URL 解析失败 */
+        }
+        try {
+          const json = JSON.parse(bodyText) as Record<string, unknown>
+          const find = (value: unknown, keys: string[]): string | undefined => {
+            if (Array.isArray(value)) {
+              for (const item of value) {
+                const found = find(item, keys)
+                if (found) return found
+              }
+              return undefined
+            }
+            if (!value || typeof value !== 'object') return undefined
+            const record = value as Record<string, unknown>
+            for (const [key, child] of Object.entries(record)) {
+              if (keys.includes(key) && typeof child === 'string' && child.trim()) return child.trim()
+              if (child && typeof child === 'object') {
+                const found = find(child, keys)
+                if (found) return found
+              }
+            }
+            return undefined
+          }
+          cap.reqId ||= find(json, ['req_id', 'reqId', 'request_id', 'requestId'])
+          cap.sessionId ||= find(json, ['session_id', 'sessionId'])
         } catch {
           /* 非 JSON body */
         }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -121,6 +121,7 @@ export interface GenerateRequest {
   teamId?: string | null
   prompt: string
   providerId: string
+  model?: string
   durationSec: number
   mode?: string
   resolution?: string

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -5,6 +5,8 @@ import {
   computeCost,
   durationOptions,
   intersectDurations,
+  providerModeOptions,
+  ratioOptions,
   resolutionOptions,
   uploadHint
 } from '../spec'
@@ -22,17 +24,19 @@ import { VideoThumb } from './VideoThumb'
 import { getInitialShowWebview } from './Modals'
 
 const VIP = false
+/** 本轮 auto 仍只走豆包；避免只绑千问时把 auto 展示成可用项 */
+const AUTO_CAPABLE_PROVIDER_IDS = new Set(['doubao'])
 
 /** 生成阶段 → 用户可见文案 */
 const STAGE_LABEL: Record<string, string> = {
   pending: '正在创建任务…',
   'select-account': '选择账号中…',
   'inject-cookies': '注入登录态…',
-  'open-page': '打开豆包页面…',
+  'open-page': '打开厂商页面…',
   'wait-tab': '进入视频生成…',
   'open-video-tab': '进入视频生成…',
   'apply-duration': '设置时长…',
-  'apply-params': '发送 prompt 中…',
+  'apply-params': '设置厂商视频参数…',
   'upload-images': '上传图片中…',
   'upload-images-result': '上传图片中…',
   submit: '发送 prompt 中…',
@@ -41,7 +45,7 @@ const STAGE_LABEL: Record<string, string> = {
   'risk-verify': '需要验证，请在弹窗完成…',
   'risk-resolved': '验证完成，继续生成…',
   'account-failed': '当前账号失败，尝试切换…',
-  blocked: '豆包拒绝了本次生成（见左侧错误）',
+  blocked: '厂商拒绝了本次生成（见左侧错误）',
   watermark: '本地去水印中…'
 }
 
@@ -126,6 +130,7 @@ export default function Dashboard({
   }, [provider, activeBoundAggs, providerDurations])
   const durations = durationOptions(provider, model, mode, VIP, selectedDurations)
   const resolutions = resolutionOptions(provider)
+  const ratios = ratioOptions(provider)
   const cost = computeCost(provider === 'auto' ? 'doubao' : provider, model, duration, resolution)
   const upload = uploadHint(provider, mode)
 
@@ -135,10 +140,9 @@ export default function Dashboard({
   // 厂商选项只取「已启用且已绑定」的厂商；智能调度仅在至少绑定一家时提供
   const providerOptions = useMemo(() => {
     if (activeBoundAggs.length === 0) return []
-    return [
-      { value: 'auto', label: '智能调度（推荐）' },
-      ...activeBoundAggs.map((a) => ({ value: a.providerId, label: a.name }))
-    ]
+    const canUseAuto = activeBoundAggs.some((a) => AUTO_CAPABLE_PROVIDER_IDS.has(a.providerId))
+    const options = activeBoundAggs.map((a) => ({ value: a.providerId, label: a.name }))
+    return canUseAuto ? [{ value: 'auto', label: '智能调度（推荐）' }, ...options] : options
   }, [activeBoundAggs])
 
   // 当前选择不在可用列表时（例如厂商被解绑），回退到智能调度或第一个可用厂商
@@ -146,7 +150,9 @@ export default function Dashboard({
     if (providerOptions.length === 0) return
     const valid = providerOptions.map((o) => o.value)
     if (!valid.includes(provider)) {
-      setProvider(valid.includes('auto') ? 'auto' : valid[0])
+      const next = valid.includes('auto') ? 'auto' : valid[0]
+      setProvider(next)
+      setModel(MODELS[next]?.[0] ?? MODELS.auto[0])
     }
   }, [providerOptions, provider])
 
@@ -163,6 +169,23 @@ export default function Dashboard({
       if (last) setResolution(last.value)
     }
   }, [resolutions, resolution])
+
+  useEffect(() => {
+    const valid = ratioOptions(provider)
+    if (!valid.some((r) => r.value === ratio)) {
+      setRatio(valid[0]?.value ?? '9:16')
+    }
+  }, [provider, ratio])
+
+  // 千问生成模式按模型限定；模型变化后若当前模式不可用，自动落到该模型第一个可用模式
+  useEffect(() => {
+    const validModes = providerModeOptions(provider, model).map((m) => m.value)
+    if (!validModes.includes(mode)) {
+      setMode(validModes[0] ?? 't2v')
+      setImages([])
+      setImageFiles([])
+    }
+  }, [provider, model, mode])
 
   // 主进程生成事件：仅终态（成功/失败）刷新列表，进度事件不触发，避免历史页列表/分页反复闪加载
   useEffect(() => {
@@ -275,8 +298,8 @@ export default function Dashboard({
       setGenError('请先填写 Prompt 描述')
       return
     }
-    if (mode === 'multi_ref' || mode === 'first_last') {
-      setGenError('多参考/首尾帧暂未接入，请先用文生或图生视频')
+    if (mode !== 't2v' && mode !== 'img' && imageFiles.length === 0) {
+      setGenError('千问多参考/首帧/首尾帧生成需要至少上传一张素材图片')
       return
     }
     if (mode === 'img' && imageFiles.length === 0) {
@@ -325,7 +348,8 @@ export default function Dashboard({
         userId: user.id,
         teamId: usageScope === 'team' ? team?.id ?? null : null,
         prompt: prompt.trim(),
-        providerId: provider === 'auto' ? 'doubao' : provider,
+        providerId: provider,
+        model,
         durationSec: duration,
         mode: mode === 't2v' ? 'text2video' : mode === 'img' ? 'img2video' : mode,
         resolution,
@@ -352,7 +376,7 @@ export default function Dashboard({
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, duration, durations, resolution, audio, ratio, watermark, imageFiles, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, model, duration, durations, resolution, audio, ratio, watermark, imageFiles, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -387,12 +411,27 @@ export default function Dashboard({
 
   const onProviderChange = (value: string): void => {
     setProvider(value)
-    setModel(MODELS[value]?.[0] ?? MODELS.auto[0])
+    const nextModel = MODELS[value]?.[0] ?? MODELS.auto[0]
+    setModel(nextModel)
+    const nextModes = providerModeOptions(value, nextModel)
+    setMode(nextModes[0]?.value ?? 't2v')
+    setImages([])
+    setImageFiles([])
   }
 
   const onModeChange = (value: string): void => {
     setMode(value)
     if (value === 't2v') {
+      setImages([])
+      setImageFiles([])
+    }
+  }
+
+  const onModelChange = (value: string): void => {
+    setModel(value)
+    const nextModes = providerModeOptions(provider, value)
+    if (!nextModes.some((m) => m.value === mode)) {
+      setMode(nextModes[0]?.value ?? 't2v')
       setImages([])
       setImageFiles([])
     }
@@ -460,7 +499,7 @@ export default function Dashboard({
               <Select
                 id="model"
                 value={model}
-                onChange={setModel}
+                onChange={onModelChange}
                 options={(MODELS[provider] ?? MODELS.auto).map((m) => ({ value: m, label: m }))}
               />
             </div>
@@ -473,12 +512,7 @@ export default function Dashboard({
                 id="mode"
                 value={mode}
                 onChange={onModeChange}
-                options={[
-                  { value: 't2v', label: '文生视频' },
-                  { value: 'img', label: '图生视频' },
-                  { value: 'multi_ref', label: '多参考生成' },
-                  { value: 'first_last', label: '首尾帧' }
-                ]}
+                options={providerModeOptions(provider, model)}
               />
             </div>
             <div className="param-field">
@@ -503,29 +537,27 @@ export default function Dashboard({
           </div>
 
           <div className="param-row ratio-row">
-            <div className="param-field">
-              <label htmlFor="audio">智能配音</label>
-              <Select
-                id="audio"
-                value={audio}
-                onChange={setAudio}
-                options={[
-                  { value: 'on', label: '开' },
-                  { value: 'off', label: '关' }
-                ]}
-              />
-            </div>
+            {!(provider === 'qwenwan' && /HappyHorse/i.test(model)) && (
+              <div className="param-field">
+                <label htmlFor="audio">智能配音</label>
+                <Select
+                  id="audio"
+                  value={audio}
+                  onChange={setAudio}
+                  options={[
+                    { value: 'on', label: '开' },
+                    { value: 'off', label: '关' }
+                  ]}
+                />
+              </div>
+            )}
             <div className="param-field">
               <label htmlFor="ratio">视频比例</label>
               <Select
                 id="ratio"
                 value={ratio}
                 onChange={setRatio}
-                options={[
-                  { value: '9:16', label: '9:16' },
-                  { value: '16:9', label: '16:9' },
-                  { value: '1:1', label: '1:1' }
-                ]}
+                options={ratios}
               />
             </div>
             {viewScope === 'global' && team ? (

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -659,7 +659,8 @@ export function AddProviderModal({
           encryptedKey: encrypted,
           expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
           // 登录刚成功即视为健康（登录会话本身是最强有效性证据），无需等后台健康检查
-          healthStatus: 'healthy'
+          healthStatus: 'healthy',
+          accountFingerprint: accountFingerprint ?? null
         })
         // 把临时分区的 cookie 迁移到目标账号分区（登录分区 = 生成分区）
         if (loginTempId) {
@@ -687,7 +688,8 @@ export function AddProviderModal({
           await svc.refreshProviderKey(userId, dup.id, {
             encryptedKey: encrypted,
             expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
-            healthStatus: 'healthy'
+            healthStatus: 'healthy',
+            accountFingerprint: accountFingerprint ?? null
           })
           // 把临时分区的 cookie 迁移到已有账号分区
           if (loginTempId) {
@@ -769,10 +771,12 @@ export function AddProviderModal({
     setLoginTempId(tempId)
     const res = await window.api.providers.login(selected.providerId, tempId)
     if (res.ok && res.encrypted) {
+      const encrypted = res.encrypted
+      const expiresAt = res.expiresAt ?? null
       setCookieCount(res.cookieCount ?? 0)
       setPendingLogin({
-        encrypted: res.encrypted,
-        expiresAt: res.expiresAt ?? null,
+        encrypted,
+        expiresAt,
         fingerprint: res.accountFingerprint ?? null,
         cookieCount: res.cookieCount ?? 0
       })
@@ -790,7 +794,33 @@ export function AddProviderModal({
         } catch {}
       }
 
-      // 指纹去重优先：匹配到已有账号 → 直接刷新（不弹选择）；指纹能识别且无重复 → 暂存待「完成」时保存
+      const refreshExisting = async (
+        target: { id: string; accountName: string },
+        fingerprint?: string | null
+      ): Promise<boolean> => {
+        if (!svc) return false
+        try {
+          await svc.refreshProviderKey(userId, target.id, {
+            encryptedKey: encrypted,
+            expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+            healthStatus: 'healthy',
+            accountFingerprint: fingerprint ?? null
+          })
+          if (loginTempId) {
+            try {
+              await window.api.providers.migratePartition(selected.providerId, loginTempId, target.id)
+            } catch {}
+          }
+          setPendingLogin(null)
+          setNotice(`已刷新账号「${target.accountName}」的登录态（保留原账号记录）`)
+          return true
+        } catch {
+          return false
+        }
+      }
+
+      // 指纹去重优先：匹配到已有账号 → 直接刷新（不弹选择）；
+      // 指纹能识别且无重复 → 暂存待「完成」时保存；千问已有账号无匹配时按已有账号刷新。
       if (res.accountFingerprint && svc) {
         try {
           const scopeKeys = accountScope === 'team' && team
@@ -806,18 +836,42 @@ export function AddProviderModal({
               setStatus('login-fail')
               return
             }
-            await svc.refreshProviderKey(userId, dup.id, {
-              encryptedKey: res.encrypted,
-              expiresAt: res.expiresAt ? new Date(res.expiresAt).toISOString() : null,
-              healthStatus: 'healthy'
-            })
-            setNotice(`已刷新账号「${dup.account_name ?? '未命名账号'}」的登录态（保留原账号记录）`)
+            if (
+              await refreshExisting(
+                { id: dup.id, accountName: dup.account_name ?? '未命名账号' },
+                res.accountFingerprint
+              )
+            ) {
+              setStatus('login-ok')
+              return
+            }
+          }
+        } catch {}
+        // 千问旧账号可能没有指纹，登录成功但没匹配到时不再新增重复绑定：
+        // 先按已有账号刷新，并在刷新时补写本次指纹。
+        if (selected.providerId === 'qwenwan' && existing.length > 0) {
+          if (await refreshExisting(existing[0], res.accountFingerprint)) {
             setStatus('login-ok')
             return
           }
-        } catch {}
+          setError('刷新已有千问账号失败，请重试')
+          setStatus('login-fail')
+          return
+        }
         // 无重复：等用户点「完成」保存，此时已确认账号备注
         setStatus('login-ok')
+        return
+      }
+
+      // 千问指纹缺失或旧账号没有指纹时，不再弹「新增/刷新」选择：
+      // 已有账号直接刷新，避免同一账号重复绑定。
+      if (selected.providerId === 'qwenwan' && existing.length > 0) {
+        if (await refreshExisting(existing[0], res.accountFingerprint)) {
+          setStatus('login-ok')
+          return
+        }
+        setError('刷新已有千问账号失败，请重试')
+        setStatus('login-fail')
         return
       }
 

--- a/apps/desktop/src/renderer/src/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/src/hooks/useJobs.ts
@@ -13,7 +13,8 @@ const PROVIDER_NAME: Record<string, string> = {
 
 const MODE_LABEL: Record<string, string> = {
   text2video: '文生视频', img2video: '图生视频',
-  video2video: '视频转视频', imgs2video: '多图生视频'
+  video2video: '视频转视频', imgs2video: '多图生视频',
+  multi_ref: '多参考生成', first_last: '首尾帧生成', first_frame: '首帧生成'
 }
 
 const UNIT_MAP: Record<string, string> = {

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -5,6 +5,7 @@ export const PROVIDER_LABEL: Record<string, string> = {
   doubao: '豆包',
   jimeng: '即梦',
   qwen: '通义万相',
+  qwenwan: '千问（通义万相）',
   yuanbao: '元宝混元',
   kling: '可灵',
   hailuo: '海螺',
@@ -16,6 +17,7 @@ export const MODELS: Record<string, string[]> = {
   doubao: ['Seedance 2.0 Mini'],
   jimeng: ['视频 S2.0', '视频 S2.0 Pro'],
   qwen: ['万相 2.7', '万相 2.6', 'HappyHorse 1.0 Beta'],
+  qwenwan: ['万相 2.7', '万相 2.6', 'HappyHorse 1.0 Beta'],
   yuanbao: ['混元（固定）'],
   kling: ['可灵-标准', '可灵-大师'],
   hailuo: ['海螺-标准'],
@@ -31,6 +33,28 @@ export interface DurationOption {
 export const DEFAULT_SUPPORTED_DURATIONS = [5, 10]
 
 const DURATION_ORDER = [5, 10, 15] as const
+
+/** 千问视频生成模式按模型限定；本轮不再给 qwenwan 暴露文生/图生视频 */
+export function providerModeOptions(provider: string, model = ''): Array<{ value: string; label: string }> {
+  if (provider === 'qwenwan') {
+    if (model === '万相 2.7') {
+      return [
+        { value: 'multi_ref', label: '多参考生成' },
+        { value: 'first_last', label: '首尾帧生成' }
+      ]
+    }
+    return [
+      { value: 'multi_ref', label: '多参考生成' },
+      { value: 'first_frame', label: '首帧生成' }
+    ]
+  }
+  return [
+    { value: 't2v', label: '文生视频' },
+    { value: 'img', label: '图生视频' },
+    { value: 'multi_ref', label: '多参考生成' },
+    { value: 'first_last', label: '首尾帧生成' }
+  ]
+}
 
 export function intersectDurations(lists: number[][]): number[] {
   if (lists.length === 0) return [...DEFAULT_SUPPORTED_DURATIONS]
@@ -68,7 +92,7 @@ export function durationOptions(
     d15.label = '15 秒（仅 VIP）'
     d15.disabled = true
   }
-  if (provider === 'qwen' && d15) {
+  if ((provider === 'qwen' || provider === 'qwenwan') && d15) {
     if (model === '万相 2.6' && mode === 'multi_ref') {
       d15.label = '15 秒（多参考不支持）'
       d15.disabled = true
@@ -91,10 +115,27 @@ export function resolutionOptions(
   ]
 }
 
+export function ratioOptions(provider: string): Array<{ value: string; label: string }> {
+  if (provider === 'qwenwan') {
+    return [
+      { value: '9:16', label: '9:16' },
+      { value: '3:4', label: '3:4' },
+      { value: '1:1', label: '1:1' },
+      { value: '4:3', label: '4:3' },
+      { value: '16:9', label: '16:9' }
+    ]
+  }
+  return [
+    { value: '9:16', label: '9:16' },
+    { value: '16:9', label: '16:9' },
+    { value: '1:1', label: '1:1' }
+  ]
+}
+
 export function uploadHint(provider: string, mode: string): string {
   if (provider === 'yuanbao') return '上传图片作为参考（最多 10 张，不支持视频）'
   if (mode === 'multi_ref') return '拖拽图片 / 视频到此处（多参考生成，最多 5 个）'
-  if (mode === 'img' || mode === 'first_last') return '拖拽图片到此处，或点击选择文件'
+  if (mode === 'img' || mode === 'first_last' || mode === 'first_frame') return '拖拽图片到此处，或点击选择文件'
   return '文生视频无需上传素材'
 }
 
@@ -112,7 +153,7 @@ export function computeCost(
   resolution: string
 ): CostResult {
   const d = DURATION_POINT[duration] ?? 0
-  if (provider === 'qwen') {
+  if (provider === 'qwen' || provider === 'qwenwan') {
     const cost = 1 + d + (resolution === '1080' ? 1 : 0)
     return { text: cost + ' 额度', who: model + ' · ' + duration + 's · ' + resolution + 'p' }
   }

--- a/docs/develop/multi-provider-video-generation-plan.md
+++ b/docs/develop/multi-provider-video-generation-plan.md
@@ -1,0 +1,52 @@
+# 多厂商视频生成接入计划（含账号绑定，第一轮：豆包 / 千问 / 元宝 / MathMind）
+
+> 状态：实施中（第一轮：豆包 / 千问；千问 `qwenwan` 账号绑定完成、多参考/首帧/首尾帧已接入真实 DOM 参数选择与素材上传；文生 / 图生 / auto fallback 待后续）
+> 日期：2026-08-14
+> 适用范围：apps/desktop、packages/db-supabase、migrations
+
+## Summary
+
+- 当前 `auto` 硬解析成 `doubao`，`dispatch.ts` 只筛豆包账号，成本、下载、失败语义都写死豆包。
+- 目标：抽出 desktop 多厂商执行层，先接入豆包、千问（`qwenwan`）、元宝（`yuanbao`）、MathMind（真实 MCP），让 `auto` 真正多厂商 fallback。
+- 账号绑定与生成执行一起实现：先保证新厂商能真实绑定、能健康检查、能被调度候选池看到，再接入对应生成 adapter。
+- 本轮完成：千问账号绑定去重/刷新已对齐豆包；`qwenwan` 显式选择可走 WebView 生成，模型/生成模式/清晰度/比例/时长/配音通过页面真实 DOM 操作选择，不再拼进 prompt；生成模式按模型限定（万相 2.7 多参考/首尾帧，万相 2.6 与 HappyHorse 1.0 多参考/首帧），必须至少上传一张素材图片；HappyHorse 1.0 不设置智能配音；`auto` 暂不包含千问。
+
+## Public API / Interface Changes
+
+- `GenerateInput.providerId` 支持 `auto | doubao | qwenwan | yuanbao | mathmind`；renderer 不再把 `auto` 转成 `doubao`。
+- 新增 desktop provider 契约：`DesktopVideoProvider` 提供 `id/capabilities/supportedDurations/cost/runGenerate/downloadContext/isNonRetryable`，统一返回 `VideoGenerateResult`。
+- credential 解析统一从 `providers.ts`/共享 helper 导出，删除 `dispatch.ts` 里的重复解析；解析不再默认豆包 origin，新厂商 storage 按各自 `providerSite` origin 处理。
+- `spec.ts`/renderer 增加 `qwenwan`、`yuanbao`、`mathmind` 的显示、模型、时长、成本规则；MathMind 不提供 text2video。
+
+## Account Binding Changes
+
+- **千问/元宝（cookie 型）**：复用现有 `provider:login`、`partitionFor`、`providerSite`、`health-check` 框架；绑定窗口打开对应 loginUrl，登录完成后收集该 partition 的 cookie/storage，加密写入 `provider_keys`。
+- **MathMind（API key 型）**：不走 cookie 登录窗口；绑定页使用 API key/config 录入，`provider_keys.auth_type = 'apikey'`；健康检查改为 MCP `initialize/list tools` 或握手成功，不再依赖空 healthUrl。
+- **绑定后能力**：写入 `health_status`、`enabled`、默认账号标记；绑定成功即初始化当日 `quota_ledger` 行；被调度候选池识别，失败/过期可被 `auto` 跳过。
+- **账号去重/指纹**：qwenwan 使用千问登录后的账号级 Cookie（`b-user-id` / `_QW_HASH_UID` / `_QW_WG_UID`）指纹；yuanbao 沿用 `pt2gguin/hy_user`；MathMind 用 API key 哈希指纹，复用现有 fingerprint 字段。
+- **UI**：`Providers` 页/`AddProviderModal` 对 cookie 型显示登录窗口流程，对 MathMind 显示 API key 录入；新厂商绑定后立即出现在生成页厂商选项。
+
+## Implementation Changes
+
+- **调度执行**：`dispatch.ts` 已支持显式 `qwenwan` 走 `runQwenGeneration`；本轮继续保留 `auto` 映射到 `doubao`，不把千问纳入 auto fallback。后续再改成 provider registry + fallback，显式厂商只尝试该厂商；`blocked/content policy` 和手动取消立即停止。
+- **WebView 框架**：保留豆包 DOM 脚本，把 `webview-engine.ts` 重构为通用 WebView provider 基础（partition、cookie/storage 注入、窗口生命周期、进度事件、轮询/取消）加 `doubao/qwenwan/yuanbao` adapter。千问、元宝走真实 WebView 页面流；现有 HTTP adapter 只作参考。
+- **千问 WebView**：`qwen-webview.ts` 负责千问视频生成：cookie/storage 注入 → 打开 `www.qianwen.com/chat` → 点击“AI生视频”入口并强制 guide 容器可交互 → 选择模型、生成模式（万相 2.7：多参考/首尾帧；万相 2.6 与 HappyHorse 1.0：多参考/首帧）、上传素材图片、点击参数摘要按钮（如 `720P·5s`）设置清晰度/比例/时长/配音（HappyHorse 1.0 跳过智能配音）→ 填写 prompt → 点击发送 → 捕获 chat 请求 → 轮询 detail 提取 mp4。当前仅支持需要素材的多参考/首帧/首尾帧；参数通过页面真实 DOM 控件选择，不注入 prompt；已补充登录态、提交失败、等待超时、内容审核拒绝等错误语义。
+- **MathMind**：新增 desktop MCP provider，安装 `@modelcontextprotocol/sdk`，读 `data/mathmind-mcp.json` 的 transport（默认 stdio `npx -y mcp_mathmind-video`），实现 `imageGenVideo`，不做 dry-run。
+- **成本/额度/下载**：成本改为 provider 的 `cost(input)` 或 `provider_cost_tables` 等价规则；job 的 `providerId/costAmount/costUnit`、`consumeLedger/consumeTeamQuotaAndFinalize` 使用实际厂商；`downloadVideo` 使用 provider 的 Referer/UA 上下文。
+- **UI**：生成页 provider 选项按已绑定、启用、支持当前 mode/duration 过滤；`qwenwan` 只显示当前模型支持的素材生成模式，并显示上传区，未上传素材时阻止生成；HappyHorse 1.0 隐藏智能配音入口；`handleGenerate` 传真实 `provider` 值；MathMind 仅在 `img2video` 可调用时显示；stage 文案去掉豆包硬编码。
+- **DB**：新增小迁移修正 MathMind 能力声明（desktop v1 只允许 img2video），补齐第一轮厂商需要的 `provider_cost_tables` 行，避免调度/UI 误判。
+
+## Test Plan
+
+- 类型检查：`pnpm --filter @quota-flow/desktop typecheck`、`pnpm --filter @quota-flow/providers typecheck`。
+- 绑定：真实账号验证千问、元宝登录绑定、健康检查、账号指纹去重；MathMind API key 绑定和 MCP 握手。
+- 回归：豆包 `doubao` 与 `auto` 文生/图生视频仍能生成、下载、扣豆包额度；`blocked` 不换号。
+- 新厂商生成：千问、元宝 WebView 文生视频；MathMind `img2video`；text2video 不出现在 MathMind 候选。
+- Fallback：构造第一厂商失败（过期/额度不足/风控），`auto` 切到下一可用厂商；遇到内容政策/手动取消立即停止。
+
+## Assumptions / Defaults
+
+- 第一轮只接 `doubao / qwenwan / yuanbao / mathmind`；即梦、可灵、海螺按同一框架后续补齐。
+- 千问、元宝以 WebView 为默认，静态 cookie HTTP adapter 不进入 desktop 调度。
+- MathMind 当前 MCP 契约默认 stdio；如果实际服务器需要 HTTP 或自定义参数，只改 `data/mathmind-mcp.json` 与 client 初始化。
+- `auto` 总尝试上限默认 3 次；每个 provider 内账号排序优先 default、healthy、剩余额度充足，再按成本排序。

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -483,7 +483,7 @@ export class ProviderService {
   async refreshProviderKey(
     userId: string,
     keyId: string,
-    input: { encryptedKey: string; expiresAt?: string | null; healthStatus?: string }
+    input: { encryptedKey: string; expiresAt?: string | null; healthStatus?: string; accountFingerprint?: string | null }
   ): Promise<void> {
     const payload: Record<string, unknown> = {
       encrypted_key: input.encryptedKey,
@@ -491,6 +491,9 @@ export class ProviderService {
     }
     payload.cookie_expires_at = input.expiresAt ?? null
     payload.health_status = input.healthStatus ?? 'unknown'
+    if (typeof input.accountFingerprint !== 'undefined') {
+      payload.account_fingerprint = input.accountFingerprint ?? null
+    }
     const { error } = await this.client
       .from('provider_keys')
       .update(payload)
@@ -830,10 +833,10 @@ export class ProviderService {
   }
 
   /** reconciliation：查找已成功但未 finalize 的 job */
-  async findUnfinalizedJobs(userId: string): Promise<Array<{ jobId: string; costAmount: number; keyId: string | null; teamId: string | null }>> {
+  async findUnfinalizedJobs(userId: string): Promise<Array<{ jobId: string; providerId: string | null; costAmount: number; keyId: string | null; teamId: string | null }>> {
     const { data, error } = await this.client
       .from('jobs')
-      .select('id, cost_amount, account_id, team_id')
+      .select('id, provider_id, cost_amount, account_id, team_id')
       .eq('user_id', userId)
       .eq('status', 'success')
       .gt('cost_amount', 0)
@@ -849,9 +852,9 @@ export class ProviderService {
     if (opsError) throw opsError
     const finalizedIds = new Set((ops ?? []).map((o: { job_id: string }) => o.job_id))
 
-    return (data as Array<{ id: string; cost_amount: number; account_id: string | null; team_id: string | null }>)
+    return (data as Array<{ id: string; provider_id: string | null; cost_amount: number; account_id: string | null; team_id: string | null }>)
       .filter((j) => !finalizedIds.has(j.id))
-      .map((j) => ({ jobId: j.id, costAmount: Number(j.cost_amount ?? 0), keyId: j.account_id, teamId: j.team_id }))
+      .map((j) => ({ jobId: j.id, providerId: j.provider_id, costAmount: Number(j.cost_amount ?? 0), keyId: j.account_id, teamId: j.team_id }))
   }
 }
 


### PR DESCRIPTION
## 修改内容

### 1. 千问（qwenwan）厂商支持
- 新增千问厂商标识，支持万相 2.7/2.6 模型
- 千问独有生成模式：多参考生成、首尾帧生成（万相 2.7）、首帧生成（其他模型）
- 新增比例选项（9:16、3:4、1:1、4:3、16:9），与其他厂商区分
- 15 秒视频限制：多参考模式 + 万相 2.6 不支持

### 2. 多厂商调度优化
- dispatch 调度逻辑重构，支持多厂商并发调度
- 新增 qwen-webview.ts 模块，处理千问 WebView 交互
- Dashboard 重排，优化多厂商状态展示

### 3. 新增文件
- qwen-webview.ts：千问 WebView 登录/生成交互逻辑
- multi-provider-video-generation-plan.md：设计文档