### PR TITLE
feat: 创作中心（统一入口 + 权限控制 + 样式增强）

### DIFF
--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1058,6 +1058,36 @@ input:focus, select:focus, textarea:focus {
   margin-bottom: var(--space-3);
 }
 
+.permission-section-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.permission-section-title-row .permission-section-title {
+  margin-bottom: 0;
+}
+
+.permission-section-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.permission-section-toggle input {
+  accent-color: var(--color-primary, #2563eb);
+}
+
+.permission-group-disabled {
+  background: var(--color-background-subtle, rgba(0, 0, 0, 0.03));
+}
+
 .permission-check-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -1081,6 +1111,10 @@ input:focus, select:focus, textarea:focus {
 
 .permission-check-item:hover {
   background: var(--color-background-subtle, rgba(0, 0, 0, 0.03));
+}
+
+.permission-check-item.disabled {
+  opacity: 0.65;
 }
 
 .permission-check-item input {
@@ -1110,6 +1144,7 @@ input:focus, select:focus, textarea:focus {
 .permission-tab-check {
   background: var(--color-background-subtle, rgba(0, 0, 0, 0.03));
   border-color: var(--color-border);
+  flex-wrap: wrap;
 }
 
 .permission-tab-check:hover {
@@ -1131,6 +1166,51 @@ input:focus, select:focus, textarea:focus {
 }
 
 .permission-tab-check .btn-sm {
+  white-space: nowrap;
+}
+
+.permission-tab-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  width: 100%;
+}
+
+.permission-tab-subgroup {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  min-width: 0;
+}
+
+.permission-tab-subgroup.muted {
+  opacity: 0.75;
+}
+
+.permission-tab-subgroup-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  cursor: pointer;
+}
+
+.permission-tab-subgroup-label input {
+  accent-color: var(--color-primary, #2563eb);
+}
+
+.permission-tab-subgroup-label span {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.permission-tab-subgroup .btn-sm {
   white-space: nowrap;
 }
 

--- a/apps/admin/src/components/desktop-permissions.tsx
+++ b/apps/admin/src/components/desktop-permissions.tsx
@@ -21,8 +21,11 @@ export const PERMISSION_FEATURE_KEYS = [
   "history.regenerate",
   "history.copy_prompt",
   "history.watermark_removal",
+  "creation.ai_toolbox",
   "creation.watermark",
+  "creation.prompt_expander",
   "creation.storyboard",
+  "creation.video_library",
   "creation.community"
 ] as const;
 
@@ -39,7 +42,7 @@ const FEATURES: FeatureItem[] = [
   { key: "tab.providers", label: "厂商", description: "桌面端主 Tab：厂商管理" },
   { key: "tab.history", label: "历史", description: "桌面端主 Tab：历史记录" },
   { key: "tab.team", label: "团队", description: "桌面端主 Tab：团队" },
-  { key: "tab.creation", label: "创作中心", description: "桌面端主 Tab：创作中心（预留）" },
+  { key: "tab.creation", label: "创作中心", description: "桌面端主 Tab：创作中心" },
   { key: "dispatch.text2video", label: "文生视频", description: "调度台生成模式：文生视频" },
   { key: "dispatch.img2video", label: "图生视频", description: "调度台生成模式：图生视频" },
   { key: "dispatch.multi_ref", label: "多参考生成", description: "调度台生成模式：多参考生成" },
@@ -50,39 +53,90 @@ const FEATURES: FeatureItem[] = [
   { key: "history.regenerate", label: "重新生成", description: "历史详情重新生成入口" },
   { key: "history.copy_prompt", label: "复制提示词", description: "历史详情复制提示词入口" },
   { key: "history.watermark_removal", label: "去水印", description: "历史记录去水印/框选/重试入口" },
-  { key: "creation.watermark", label: "去水印工作台", description: "创作中心去水印（预留）" },
-  { key: "creation.storyboard", label: "分镜生成", description: "创作中心分镜生成（预留）" },
-  { key: "creation.community", label: "社区优秀视频", description: "创作中心社区视频（预留）" }
+  { key: "creation.watermark", label: "去水印", description: "创作中心 AI 工具箱：去水印入口" },
+  { key: "creation.prompt_expander", label: "提示词扩展", description: "创作中心 AI 工具箱：提示词扩展（待接入）" },
+  { key: "creation.storyboard", label: "分镜生成", description: "创作中心 AI 工具箱：分镜生成（待接入）" },
+  { key: "creation.community", label: "视频灵感库", description: "创作中心视频灵感库：优秀视频与参考提示词" }
 ];
 
 const MAIN_TAB_FEATURES = FEATURES.filter((feature) => feature.key.startsWith("tab."));
 
-const FEATURES_BY_TAB: Array<{
+interface FeatureGroup {
+  groupKey: FeatureKey;
   tabKey: FeatureKey;
   tabLabel: string;
+  title: string;
+  sectionTitle: string;
   features: FeatureItem[];
-}> = [
-  {
-    tabKey: "tab.dispatch",
-    tabLabel: "调度台",
-    features: FEATURES.filter((feature) => feature.key.startsWith("dispatch."))
-  },
-  {
-    tabKey: "tab.providers",
-    tabLabel: "厂商",
-    features: FEATURES.filter((feature) => feature.key.startsWith("providers."))
-  },
-  {
-    tabKey: "tab.history",
-    tabLabel: "历史",
-    features: FEATURES.filter((feature) => feature.key.startsWith("history."))
-  },
-  {
-    tabKey: "tab.creation",
-    tabLabel: "创作中心",
-    features: FEATURES.filter((feature) => feature.key.startsWith("creation."))
+}
+
+const CREATION_AI_TOOLBOX_KEYS = new Set<string>([
+  "creation.watermark",
+  "creation.prompt_expander",
+  "creation.storyboard"
+]);
+
+function buildFeatureGroups(): FeatureGroup[] {
+  const groups: FeatureGroup[] = [];
+  const tabs: Array<{ tabKey: FeatureKey; tabLabel: string; match: (key: string) => boolean }> = [
+    {
+      tabKey: "tab.dispatch",
+      tabLabel: "调度台",
+      match: (key) => key.startsWith("dispatch.")
+    },
+    {
+      tabKey: "tab.providers",
+      tabLabel: "厂商",
+      match: (key) => key.startsWith("providers.")
+    },
+    {
+      tabKey: "tab.history",
+      tabLabel: "历史",
+      match: (key) => key.startsWith("history.")
+    },
+    {
+      tabKey: "tab.creation",
+      tabLabel: "创作中心",
+      match: (key) => key.startsWith("creation.")
+    }
+  ];
+
+  for (const tab of tabs) {
+    const features = FEATURES.filter((feature) => tab.match(feature.key));
+    if (tab.tabKey !== "tab.creation") {
+      groups.push({
+        groupKey: tab.tabKey,
+        tabKey: tab.tabKey,
+        tabLabel: tab.tabLabel,
+        title: `${tab.tabLabel}功能`,
+        sectionTitle: `${tab.tabLabel}功能`,
+        features
+      });
+      continue;
+    }
+
+    groups.push({
+      groupKey: "creation.ai_toolbox",
+      tabKey: "tab.creation",
+      tabLabel: "创作中心",
+      title: "AI 工具箱",
+      sectionTitle: "创作中心 · AI 工具箱",
+      features: features.filter((feature) => CREATION_AI_TOOLBOX_KEYS.has(feature.key))
+    });
+    groups.push({
+      groupKey: "creation.video_library",
+      tabKey: "tab.creation",
+      tabLabel: "创作中心",
+      title: "视频灵感库",
+      sectionTitle: "创作中心 · 视频灵感库",
+      features: features.filter((feature) => feature.key === "creation.community")
+    });
   }
-];
+
+  return groups;
+}
+
+const FEATURE_GROUPS = buildFeatureGroups();
 
 type Scope = { kind: "global"; id: null; label: string } | { kind: "team"; id: string; label: string };
 
@@ -134,7 +188,7 @@ export function DesktopPermissionsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [expandedTabs, setExpandedTabs] = useState<string[]>([]);
+  const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
 
   const scope = useMemo<Scope>(() => {
     if (scopeKey.startsWith("team:")) {
@@ -165,6 +219,16 @@ export function DesktopPermissionsPage() {
     } finally {
       setLoading(false);
     }
+  }, []);
+
+  const handleGroupToggle = useCallback((group: FeatureGroup, checked: boolean) => {
+    setValues((prev) => {
+      const next = { ...prev, [group.groupKey]: checked };
+      for (const feature of group.features) {
+        next[feature.key] = checked;
+      }
+      return next;
+    });
   }, []);
 
   useEffect(() => {
@@ -314,36 +378,103 @@ export function DesktopPermissionsPage() {
                           </span>
                         </span>
                       </label>
-                      <button
-                        className="btn-sm"
-                        type="button"
-                        disabled={!values[feature.key]}
-                        onClick={() =>
-                          setExpandedTabs((prev) =>
-                            prev.includes(feature.key)
-                              ? prev.filter((key) => key !== feature.key)
-                              : [...prev, feature.key]
-                          )
-                        }
-                      >
-                        {expandedTabs.includes(feature.key) ? "收起功能" : "展开功能"}
-                      </button>
+                      <div className="permission-tab-actions">
+                        {FEATURE_GROUPS.filter((group) => group.tabKey === feature.key).map((group) => {
+                          const expanded = expandedGroups.includes(group.groupKey);
+                          const label =
+                            group.tabKey === "tab.creation"
+                              ? `${expanded ? "收起 " : "展开 "}${group.title}`
+                              : expanded
+                                ? "收起功能"
+                                : "展开功能";
+                          if (group.tabKey === "tab.creation") {
+                            const groupEnabled = values[group.groupKey];
+                            return (
+                              <div
+                                className={"permission-tab-subgroup" + (groupEnabled ? "" : " muted")}
+                                key={group.groupKey}
+                              >
+                                <label className="permission-tab-subgroup-label">
+                                  <input
+                                    type="checkbox"
+                                    checked={groupEnabled}
+                                    onChange={(e) => handleGroupToggle(group, e.target.checked)}
+                                  />
+                                  <span>{group.title}</span>
+                                </label>
+                                <button
+                                  className="btn-sm"
+                                  type="button"
+                                  disabled={!values[feature.key]}
+                                  onClick={() =>
+                                    setExpandedGroups((prev) =>
+                                      prev.includes(group.groupKey)
+                                        ? prev.filter((key) => key !== group.groupKey)
+                                        : [...prev, group.groupKey]
+                                    )
+                                  }
+                                >
+                                  {label}
+                                </button>
+                              </div>
+                            );
+                          }
+                          return (
+                            <button
+                              key={group.groupKey}
+                              className="btn-sm"
+                              type="button"
+                              disabled={!values[feature.key]}
+                              onClick={() =>
+                                setExpandedGroups((prev) =>
+                                  prev.includes(group.groupKey)
+                                    ? prev.filter((key) => key !== group.groupKey)
+                                    : [...prev, group.groupKey]
+                                )
+                              }
+                            >
+                              {label}
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
                   ))}
                 </div>
               </section>
 
-              {FEATURES_BY_TAB.map((group) => {
-                if (!values[group.tabKey] || !expandedTabs.includes(group.tabKey)) return null;
+              {FEATURE_GROUPS.map((group) => {
+                if (!values[group.tabKey] || !expandedGroups.includes(group.groupKey)) return null;
+                const isCreationGroup = group.tabKey === "tab.creation";
+                const groupEnabled = values[group.groupKey];
                 return (
-                  <section className="permission-section" key={group.tabKey}>
-                    <div className="permission-section-title">{group.tabLabel}功能</div>
+                  <section
+                    className={"permission-section" + (isCreationGroup && !groupEnabled ? " permission-group-disabled" : "")}
+                    key={group.groupKey}
+                  >
+                    <div className="permission-section-title-row">
+                      <div className="permission-section-title">{group.sectionTitle}</div>
+                      {isCreationGroup ? (
+                        <label className="permission-section-toggle">
+                          <input
+                            type="checkbox"
+                            checked={groupEnabled}
+                            onChange={(e) => handleGroupToggle(group, e.target.checked)}
+                          />
+                          <span>{groupEnabled ? "显示该模块" : "隐藏该模块"}</span>
+                        </label>
+                      ) : null}
+                    </div>
                     <div className="permission-check-grid">
                       {group.features.map((feature) => (
-                        <label className="permission-check-item" key={feature.key}>
+                        <label
+                          className={"permission-check-item" + (isCreationGroup && !groupEnabled ? " disabled" : "")}
+                          key={feature.key}
+                        >
                           <input
                             type="checkbox"
                             checked={values[feature.key]}
+                            disabled={isCreationGroup && !groupEnabled}
                             onChange={(e) =>
                               setValues((prev) => ({ ...prev, [feature.key]: e.target.checked }))
                             }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import Providers from './components/Providers'
 import History from './components/History'
 import type { JobItem } from './hooks/useJobs'
 import Team from './components/Team'
+import CreationCenter from './components/CreationCenter'
 import TitleBar from './components/TitleBar'
 import WelcomeBanner from './components/WelcomeBanner'
 import { EmptyState } from './components/EmptyState'
@@ -38,13 +39,14 @@ import {
   IconInfo,
   IconLogout,
   IconMonitor,
+  IconSparkles,
   IconUpload,
   IconUser,
   IconUsers
 } from './components/icons'
 import desktopPackage from '../../../package.json'
 
-type TabId = 'dispatch' | 'providers' | 'history' | 'team'
+type TabId = 'dispatch' | 'providers' | 'creation' | 'history' | 'team'
 
 function readStoredViewScope(hasTeam: boolean): ViewScope {
   const stored = localStorage.getItem('qf-view-scope')
@@ -94,6 +96,7 @@ function writeWelcomeDismissed(userId: string, dismissed: boolean): void {
 const TABS: TabDef[] = [
   { id: 'dispatch', label: '调度台', icon: IconGrid },
   { id: 'providers', label: '厂商', icon: IconMonitor },
+  { id: 'creation', label: '创作中心', icon: IconSparkles },
   { id: 'history', label: '历史', icon: IconClock },
   { id: 'team', label: '团队', icon: IconUsers }
 ]
@@ -149,7 +152,7 @@ function MainApp({
   const [tab, setTab] = useState<TabId>(() => {
     const hit = location.hash.match(/#tab=(.+)/)
     const t = hit ? hit[1] : 'dispatch'
-    return (['dispatch', 'providers', 'history', 'team'] as TabId[]).includes(t as TabId)
+    return (['dispatch', 'providers', 'creation', 'history', 'team'] as TabId[]).includes(t as TabId)
       ? (t as TabId)
       : 'dispatch'
   })
@@ -187,6 +190,12 @@ function MainApp({
       mode: p?.mode ?? 'text2video',
       images: r.images ?? []
     })
+    setTab('dispatch')
+    location.hash = 'tab=dispatch'
+  }, [])
+
+  const handleCommunityReference = useCallback((draft: RegenerateDraft): void => {
+    setRegenerateDraft(draft)
     setTab('dispatch')
     location.hash = 'tab=dispatch'
   }, [])
@@ -491,6 +500,13 @@ function MainApp({
               usageScope={usageScope}
               providers={providers}
               canBind={permissions.features['providers.bind']}
+            />
+          </div>
+          <div className="tab-pane" style={{ display: resolvedTab === 'creation' ? 'flex' : 'none' }}>
+            <CreationCenter
+              features={permissions.features}
+              onReferenceGenerate={handleCommunityReference}
+              onNotify={showToast}
             />
           </div>
           <div className="tab-pane" style={{ display: resolvedTab === 'history' ? 'flex' : 'none' }}>

--- a/apps/desktop/src/renderer/src/components/CreationCenter.tsx
+++ b/apps/desktop/src/renderer/src/components/CreationCenter.tsx
@@ -1,0 +1,444 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ReactElement } from 'react'
+import { createPortal } from 'react-dom'
+import type { DesktopFeatureFlags } from '../hooks/useDesktopPermissions'
+import type { RegenerateDraft } from './Dashboard'
+import { IconClose, IconGrid, IconPlay, IconSparkles } from './icons'
+
+const COMMUNITY_CATEGORIES = ['全部', '国漫3D风', '动作打斗', '赛博都市', '古风仙侠', '治愈系'] as const
+type CommunityCategory = (typeof COMMUNITY_CATEGORIES)[number]
+
+export interface CommunityVideo {
+  id: string
+  title: string
+  cover: string
+  videoUrl?: string
+  durationSec: number
+  category: CommunityCategory
+  tags: string[]
+  prompt: string
+  providerHint?: string
+}
+
+const COMMUNITY_VIDEOS: CommunityVideo[] = [
+  {
+    id: 'community-01',
+    title: '雪后山巅少年剑客',
+    cover: 'https://images.unsplash.com/photo-1533106418989-88406c7cc8ca?auto=format&fit=crop&w=640&q=80',
+    durationSec: 10,
+    category: '国漫3D风',
+    tags: ['国漫3D', '雪山', '云海'],
+    prompt: '高规格国漫3D风格，少年剑客站在雪后山巅，衣摆随风翻飞，远处云海翻涌，镜头从正面缓慢推进，金色晨光穿透云层照亮剑锋。',
+    providerHint: '豆包 · Seedance 2.0 Mini'
+  },
+  {
+    id: 'community-02',
+    title: '雨夜霓虹巷战',
+    cover: 'https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=640&q=80',
+    durationSec: 5,
+    category: '动作打斗',
+    tags: ['打斗', '雨夜', '慢镜头'],
+    prompt: '高速动作打斗，雨夜巷战，两道人影在霓虹灯光下贴身交锋，慢镜头捕捉拳脚与雨滴碰撞，镜头快速切换，压迫感强。',
+    providerHint: '可灵 · 标准'
+  },
+  {
+    id: 'community-03',
+    title: '霓虹雨幕天桥',
+    cover: 'https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=640&q=80',
+    durationSec: 10,
+    category: '赛博都市',
+    tags: ['赛博朋克', '城市夜景', '全息广告'],
+    prompt: '赛博都市夜景，巨型全息广告在雨幕中闪烁，主角撑伞穿过拥挤天桥，霓虹色彩反射在积水路面，航拍缓慢拉升。',
+    providerHint: '豆包 · Seedance 2.0 Mini'
+  },
+  {
+    id: 'community-04',
+    title: '白衣仙人御剑过云海',
+    cover: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=640&q=80',
+    durationSec: 5,
+    category: '古风仙侠',
+    tags: ['仙侠', '御剑', '云海'],
+    prompt: '古风仙侠意境，白衣仙人御剑飞过云海，衣袂飘动，瀑布从青翠山崖倾泻，镜头围绕仙人环绕半周。',
+    providerHint: '千问 · 万相'
+  },
+  {
+    id: 'community-05',
+    title: '午后窗台的小猫',
+    cover: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&w=640&q=80',
+    durationSec: 5,
+    category: '治愈系',
+    tags: ['治愈', '猫咪', '阳光'],
+    prompt: '治愈系田园短片，小猫在午后窗台伸懒腰，阳光洒进房间，窗帘随风轻摆，镜头缓慢靠近猫爪，画面温暖柔光。',
+    providerHint: '海螺 · 标准'
+  },
+  {
+    id: 'community-06',
+    title: '黄昏停机坪的机甲少女',
+    cover: 'https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?auto=format&fit=crop&w=640&q=80',
+    durationSec: 10,
+    category: '国漫3D风',
+    tags: ['国漫3D', '机甲', '黄昏'],
+    prompt: '国漫3D风战斗前奏，少女机甲在黄昏停机坪单膝落地，装甲表面亮起蓝色能量纹路，镜头低角度环绕展示细节。',
+    providerHint: '豆包 · Seedance 2.0 Mini'
+  },
+  {
+    id: 'community-07',
+    title: '悬浮载具追车',
+    cover: 'https://images.unsplash.com/photo-1550745165-9bc0b252726f?auto=format&fit=crop&w=640&q=80',
+    durationSec: 10,
+    category: '赛博都市',
+    tags: ['追车', '悬浮载具', '光轨'],
+    prompt: '科幻城市追车戏，悬浮载具贴着高架桥高速穿行，车灯拖出光轨，镜头跟拍并切换俯冲视角，城市灯火快速掠过。',
+    providerHint: '可灵 · 大师'
+  },
+  {
+    id: 'community-08',
+    title: '竹林红袖剑气',
+    cover: 'https://images.unsplash.com/photo-1541701494587-cb58502866ab?auto=format&fit=crop&w=640&q=80',
+    durationSec: 5,
+    category: '古风仙侠',
+    tags: ['古风', '剑气', '竹海'],
+    prompt: '古风仙侠，林间竹海起雾，女子红袖掠过竹叶，剑气切开雾气，镜头跟随红色衣袂穿行，风起叶落。',
+    providerHint: '千问 · 万相'
+  },
+  {
+    id: 'community-09',
+    title: '雨天咖啡馆窗边',
+    cover: 'https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=640&q=80',
+    durationSec: 5,
+    category: '治愈系',
+    tags: ['治愈', '咖啡馆', '雨天'],
+    prompt: '治愈系动画，雨天咖啡馆窗边，热咖啡升起白雾，小猫趴在桌角看雨滴滑落，镜头缓慢推近，色调温柔安静。',
+    providerHint: '海螺 · 标准'
+  }
+]
+
+const DEFAULT_COMMUNITY_DRAFT: RegenerateDraft = {
+  prompt: '',
+  providerId: 'doubao',
+  model: 'Seedance 2.0 Mini',
+  durationSec: 5,
+  resolution: '720',
+  audio: 'on',
+  ratio: '9:16',
+  mode: 't2v',
+  images: []
+}
+
+const FAVORITES_KEY = 'qf:community:favorites'
+
+function readFavorites(): Set<string> {
+  try {
+    const raw = localStorage.getItem(FAVORITES_KEY)
+    if (!raw) return new Set()
+    const list = JSON.parse(raw) as string[]
+    return new Set(Array.isArray(list) ? list : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function writeFavorites(favorites: Set<string>): void {
+  try {
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(favorites)))
+  } catch {
+    // 本地存储不可用时收藏只在当前会话生效
+  }
+}
+
+function formatDuration(seconds: number): string {
+  return `${seconds}s`
+}
+
+function IconDrop({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3s6 6.5 6 11a6 6 0 0 1-12 0c0-4.5 6-11 6-11z" />
+      <path d="M9.5 13.5a2.5 2.5 0 0 0 2 2.5" />
+    </svg>
+  )
+}
+
+interface CreationCenterProps {
+  features: DesktopFeatureFlags
+  onReferenceGenerate?: (draft: RegenerateDraft) => void
+  onNotify?: (message: string) => void
+}
+
+export default function CreationCenter({ features, onReferenceGenerate, onNotify }: CreationCenterProps) {
+  const [category, setCategory] = useState<CommunityCategory>('全部')
+  const [selected, setSelected] = useState<CommunityVideo | null>(null)
+  const [favorites, setFavorites] = useState<Set<string>>(readFavorites)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [imageFailed, setImageFailed] = useState<Record<string, boolean>>({})
+
+  const visibleVideos = useMemo(
+    () => (category === '全部' ? COMMUNITY_VIDEOS : COMMUNITY_VIDEOS.filter((v) => v.category === category)),
+    [category]
+  )
+
+  useEffect(() => {
+    if (!selected) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setSelected(null)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selected])
+
+  const toggleFavorite = (video: CommunityVideo): void => {
+    setFavorites((prev) => {
+      const next = new Set(prev)
+      if (next.has(video.id)) next.delete(video.id)
+      else next.add(video.id)
+      writeFavorites(next)
+      return next
+    })
+  }
+
+  const copyPrompt = async (video: CommunityVideo, id: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(video.prompt)
+      setCopiedId(id)
+    } catch {
+      const ta = document.createElement('textarea')
+      ta.value = video.prompt
+      document.body.appendChild(ta)
+      ta.select()
+      document.execCommand('copy')
+      document.body.removeChild(ta)
+      setCopiedId(id)
+    }
+    onNotify?.('提示词已复制')
+    window.setTimeout(() => setCopiedId(null), 1200)
+  }
+
+  const referenceGenerate = (video: CommunityVideo): void => {
+    if (!onReferenceGenerate) return
+    onReferenceGenerate({
+      ...DEFAULT_COMMUNITY_DRAFT,
+      prompt: video.prompt
+    })
+    onNotify?.('已回填调度台')
+  }
+
+  const renderCover = (video: CommunityVideo, large = false): ReactElement => {
+    const failed = imageFailed[video.id]
+    if (!failed) {
+      return (
+        <div className={'community-cover-media' + (large ? ' large' : '')}>
+          <img
+            src={video.cover}
+            alt={video.title}
+            loading="lazy"
+            onError={() => setImageFailed((prev) => ({ ...prev, [video.id]: true }))}
+          />
+          <span className="community-cover-play">
+            <IconPlay size={large ? 26 : 18} />
+          </span>
+          <span className="community-duration">{formatDuration(video.durationSec)}</span>
+        </div>
+      )
+    }
+    return (
+      <div className={'community-cover-fallback' + (large ? ' large' : '')}>
+        <IconPlay size={large ? 30 : 22} />
+        <span>{video.category}</span>
+        <span>{formatDuration(video.durationSec)}</span>
+      </div>
+    )
+  }
+
+  const renderActions = (video: CommunityVideo, sourceId: string): ReactElement => {
+    const isCopied = copiedId === sourceId
+    return (
+      <div className="community-card-actions" onClick={(e) => e.stopPropagation()}>
+        <button
+          className="btn-sm"
+          title="复制完整 Prompt"
+          onClick={() => void copyPrompt(video, sourceId)}
+        >
+          {isCopied ? '已复制' : '复制提示词'}
+        </button>
+        <button
+          className="btn-sm primary"
+          title="回填到调度台"
+          onClick={() => referenceGenerate(video)}
+        >
+          参考生成
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="creation-center">
+      {features['creation.ai_toolbox'] !== false ? (
+        <section className="ai-toolbar" aria-label="AI 工具箱">
+          <div className="creation-section-heading">
+            <h2>AI 工具箱</h2>
+          </div>
+          <div className="ai-tool-row">
+            <button
+              className={'ai-tool-button' + (features['creation.watermark'] === false ? ' disabled' : '')}
+              disabled={features['creation.watermark'] === false}
+              title="去水印"
+              onClick={() => onNotify?.('去水印请在历史任务详情中使用')}
+            >
+              <span className="ai-tool-icon">
+                <IconDrop size={20} />
+              </span>
+              <span className="ai-tool-label">去水印</span>
+              <span className="ai-tool-status">{features['creation.watermark'] === false ? '未开放' : '历史任务'}</span>
+            </button>
+            <button
+              className={'ai-tool-button' + (features['creation.prompt_expander'] === false ? ' disabled' : '')}
+              disabled={features['creation.prompt_expander'] === false}
+              title="提示词扩展"
+              onClick={() => onNotify?.('提示词扩展待接入')}
+            >
+              <span className="ai-tool-icon">
+                <IconSparkles size={20} />
+              </span>
+              <span className="ai-tool-label">提示词扩展</span>
+              <span className="ai-tool-status">{features['creation.prompt_expander'] === false ? '未开放' : '待接入'}</span>
+            </button>
+            <button
+              className={'ai-tool-button' + (features['creation.storyboard'] === false ? ' disabled' : '')}
+              disabled={features['creation.storyboard'] === false}
+              title="分镜生成"
+              onClick={() => onNotify?.('分镜生成待接入')}
+            >
+              <span className="ai-tool-icon">
+                <IconGrid size={20} />
+              </span>
+              <span className="ai-tool-label">分镜生成</span>
+              <span className="ai-tool-status">{features['creation.storyboard'] === false ? '未开放' : '待接入'}</span>
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {features['creation.video_library'] === false ? null : features['creation.community'] !== false ? (
+        <section className="community-section" aria-label="视频灵感库">
+          <div className="creation-section-heading">
+            <h2>视频灵感库</h2>
+            <span>{visibleVideos.length} 个灵感视频</span>
+          </div>
+          <div className="community-category-row" role="tablist" aria-label="视频分类">
+            {COMMUNITY_CATEGORIES.map((c) => (
+              <button
+                key={c}
+                className={'community-chip' + (category === c ? ' active' : '')}
+                onClick={() => setCategory(c)}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+          <div className="community-grid">
+            {visibleVideos.map((video) => {
+              const isFavorite = favorites.has(video.id)
+              return (
+                <article
+                  key={video.id}
+                  className="community-card"
+                  onClick={() => setSelected(video)}
+                >
+                  <div className="community-card-cover">
+                    {renderCover(video)}
+                    <button
+                      className={'community-fav' + (isFavorite ? ' active' : '')}
+                      title={isFavorite ? '取消收藏' : '收藏'}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggleFavorite(video)
+                      }}
+                    >
+                      {isFavorite ? '★' : '☆'}
+                    </button>
+                  </div>
+                  <div className="community-card-body">
+                    <h3>{video.title}</h3>
+                    <div className="community-tags">
+                      {video.tags.map((tag) => (
+                        <span key={tag}>{tag}</span>
+                      ))}
+                    </div>
+                    <p className="community-prompt">{video.prompt}</p>
+                    {renderActions(video, video.id)}
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        </section>
+      ) : (
+        <div className="creation-disabled">视频灵感库未开启</div>
+      )}
+
+      {selected &&
+        createPortal(
+          <div
+            className="modal-overlay"
+            style={{ zIndex: 300 }}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setSelected(null)
+            }}
+          >
+            <div
+              className="modal-card community-detail"
+              style={{ width: 'min(94vw, 880px)', maxHeight: '88vh', display: 'flex', flexDirection: 'column' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="community-detail-header">
+                <div>
+                  <h3>{selected.title}</h3>
+                  <div className="community-detail-meta">
+                    <span>{selected.category}</span>
+                    <span>{formatDuration(selected.durationSec)}</span>
+                    {selected.providerHint ? <span>{selected.providerHint}</span> : null}
+                  </div>
+                </div>
+                <button className="modal-close" title="关闭" onClick={() => setSelected(null)}>
+                  <IconClose size={16} />
+                </button>
+              </div>
+              <div className="community-detail-body">
+                <div className="community-detail-media">{renderCover(selected, true)}</div>
+                <div className="community-detail-info">
+                  <div className="community-tags">
+                    {selected.tags.map((tag) => (
+                      <span key={tag}>{tag}</span>
+                    ))}
+                  </div>
+                  <pre className="community-full-prompt">{selected.prompt}</pre>
+                  <div className="community-detail-actions">
+                    {renderActions(selected, 'detail-' + selected.id)}
+                    <button
+                      className={'btn-sm community-fav-btn' + (favorites.has(selected.id) ? ' active' : '')}
+                      title={favorites.has(selected.id) ? '取消收藏' : '收藏'}
+                      onClick={() => toggleFavorite(selected)}
+                    >
+                      {favorites.has(selected.id) ? '已收藏' : '收藏'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/History.tsx
+++ b/apps/desktop/src/renderer/src/components/History.tsx
@@ -835,7 +835,7 @@ export default function History({
               </div>
               <p style={{ color: 'var(--fg-secondary)', margin: '0 0 16px', lineHeight: 1.7 }}>
                 {confirm.kind === 'one'
-                  ? `确定删除这条历史记录？该任务会从数据库中移除。\n「${confirm.item.record.prompt}」`
+                  ? '确定删除这条历史记录？该任务会从数据库中移除。'
                   : `确定删除选中的 ${confirm.ids.length} 条历史记录？该操作会从数据库中移除这些任务。`}
               </p>
               <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>

--- a/apps/desktop/src/renderer/src/components/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/icons.tsx
@@ -165,6 +165,14 @@ export const IconMaximize = (p: IconProps) => (
   </Svg>
 )
 
+export const IconSparkles = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3z" />
+    <path d="M19 15l.9 2.1L22 18l-2.1.9L19 21l-.9-2.1L16 18l2.1-.9L19 15z" />
+    <path d="M5 15l.7 1.7L7.5 17.5l-1.8.8L5 20l-.7-1.7L2.5 17.5l1.8-.8L5 15z" />
+  </Svg>
+)
+
 // 厂商图标（官方品牌 logo，来源：LobeHub @lobehub/icons-static-svg v1.94.0，https://lobehub.com/icons）
 export const IconDoubao = (p: IconProps) => (
   <svg width={p.size ?? 16} height={p.size ?? 16} viewBox="0 0 24 24" aria-hidden="true">

--- a/apps/desktop/src/renderer/src/hooks/useDesktopPermissions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesktopPermissions.ts
@@ -19,8 +19,11 @@ export const DESKTOP_FEATURE_KEYS = [
   'history.regenerate',
   'history.copy_prompt',
   'history.watermark_removal',
+  'creation.ai_toolbox',
   'creation.watermark',
+  'creation.prompt_expander',
   'creation.storyboard',
+  'creation.video_library',
   'creation.community'
 ] as const
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1391,6 +1391,393 @@ body {
   color: var(--fg-muted);
 }
 
+/* ===== 创作中心 ===== */
+.creation-center {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.creation-section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.creation-section-heading h2 {
+  font-family: var(--font-display);
+  font-size: 1.23em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.creation-section-heading > span {
+  font-size: 0.82em;
+  color: var(--fg-muted);
+}
+
+.ai-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
+  flex-shrink: 0;
+}
+.ai-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.ai-tool-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 132px;
+  height: 54px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  font-family: var(--font-body);
+  font-size: 0.95em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: var(--shadow-sm);
+}
+.ai-tool-button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-bg);
+  box-shadow: var(--shadow-md);
+}
+.ai-tool-button.disabled,
+.ai-tool-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  color: var(--fg-muted);
+  box-shadow: none;
+}
+.ai-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+.ai-tool-label {
+  white-space: nowrap;
+}
+.ai-tool-status {
+  margin-left: auto;
+  font-size: 0.78em;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+.community-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+}
+.community-category-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+.community-chip {
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  font-family: var(--font-body);
+  font-size: 0.85em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+.community-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.community-chip.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.community-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+.community-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+.community-card:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+.community-card-cover {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  min-height: 118px;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--bg-hover) 0%, var(--border-light) 100%);
+}
+.community-cover-media,
+.community-cover-fallback {
+  position: absolute;
+  inset: 0;
+}
+.community-cover-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.community-cover-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.38);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(2px);
+}
+.community-cover-play.large {
+  width: 48px;
+  height: 48px;
+}
+.community-duration {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.58);
+  color: #fff;
+  font-size: 0.72em;
+  line-height: 1.4;
+}
+.community-fav {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.36);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.92em;
+}
+.community-fav.active {
+  color: #facc15;
+}
+.community-cover-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px;
+  color: var(--fg-muted);
+  background: linear-gradient(135deg, var(--bg-hover) 0%, var(--border-light) 100%);
+  font-size: 0.82em;
+}
+.community-cover-fallback.large {
+  font-size: 0.95em;
+}
+
+.community-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  min-width: 0;
+  flex: 1;
+}
+.community-card h3 {
+  font-size: 0.96em;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.community-tags {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.community-tags span {
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  color: var(--fg-secondary);
+  font-size: 0.72em;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+.community-prompt {
+  color: var(--fg-secondary);
+  font-size: 0.84em;
+  line-height: 1.55;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.6em;
+}
+.community-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: auto;
+  padding-top: 2px;
+}
+
+.creation-disabled {
+  flex: 1;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--fg-muted);
+  font-size: 0.9em;
+}
+
+.community-detail {
+  overflow: hidden;
+}
+.community-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-light);
+}
+.community-detail-header h3 {
+  font-family: var(--font-display);
+  font-size: 1.2em;
+  font-weight: 600;
+}
+.community-detail-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  color: var(--fg-muted);
+  font-size: 0.82em;
+}
+.community-detail-body {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 16px;
+  padding: 16px;
+  overflow-y: auto;
+}
+.community-detail-media {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  min-height: 220px;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--bg-hover) 0%, var(--border-light) 100%);
+}
+.community-detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+.community-full-prompt {
+  flex: 1;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  font-size: 0.88em;
+  line-height: 1.75;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow-y: auto;
+}
+.community-detail-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.community-fav-btn.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+
+@media (max-width: 820px) {
+  .community-detail-body {
+    grid-template-columns: 1fr;
+  }
+  .community-detail-media {
+    min-height: 180px;
+  }
+  .ai-tool-button {
+    min-width: 118px;
+  }
+}
+
 /* ===== 厂商 Tab：列表型 + 多账号 + 筛选 ===== */
 .filter-bar {
   display: flex;


### PR DESCRIPTION
## 修改内容

### 1. 创作中心组件
- 新增 CreationCenter.tsx，统一视频/图片创作入口
- 支持选择厂商、模型、参数配置
- 根据用户权限动态显示/隐藏功能入口

### 2. 权限控制增强
- useDesktopPermissions：新增创作中心权限字段
- App.tsx：创作中心路由与权限检查
- desktop-permissions.tsx：新增创作中心权限配置项

### 3. UI 样式优化
- styles.css：新增创作中心样式（卡片布局、参数面板、响应式）
- globals.css：Admin 样式优化

### 4. 图标补全
- icons.tsx：新增创作中心相关图标

### 5. 新增文件
- CreationCenter.tsx：创作中心主组件