### PR TITLE
feat: 用户问题反馈（桌面端提交 + 后台反馈管理）

### DIFF
--- a/apps/admin/src/app/(dashboard)/feedback/page.tsx
+++ b/apps/admin/src/app/(dashboard)/feedback/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  listFeedback,
+  setFeedbackStatus,
+  type FeedbackItem,
+  type FeedbackStatusFilter,
+  type FeedbackTypeFilter
+} from "@/lib/api/feedback";
+import { FeedbackFilters } from "@/components/feedback/feedback-filters";
+import { FeedbackTable } from "@/components/feedback/feedback-table";
+import { Pagination } from "@/components/users/pagination";
+
+const PAGE_SIZE = 20;
+
+export default function FeedbackPage() {
+  const [type, setType] = useState<FeedbackTypeFilter>("");
+  const [status, setStatus] = useState<FeedbackStatusFilter>("");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const [result, setResult] = useState<{ total: number; items: FeedbackItem[] }>({
+    total: 0,
+    items: []
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+
+  // 搜索输入 300ms 防抖后提交
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        setPage(1);
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listFeedback({
+        type,
+        status,
+        search: debouncedSearch,
+        page,
+        pageSize: PAGE_SIZE
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [type, status, debouncedSearch, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // 提示自动消失
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  async function handleToggleStatus(item: FeedbackItem) {
+    const next: FeedbackItem["status"] = item.status === "resolved" ? "pending" : "resolved";
+    try {
+      await setFeedbackStatus(item.id, next, {
+        userId: item.user_id,
+        previousStatus: item.status
+      });
+      setToast(next === "resolved" ? "已标记为已处理" : "已标记为待处理");
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">反馈管理</h1>
+          <p className="page-subtitle">汇总桌面端用户问题反馈，及时跟进处理</p>
+        </div>
+      </div>
+
+      <FeedbackFilters
+        value={{ type, status, search }}
+        onChange={(v) => {
+          if (v.type !== type) {
+            setType(v.type);
+            setPage(1);
+          }
+          if (v.status !== status) {
+            setStatus(v.status);
+            setPage(1);
+          }
+          if (v.search !== search) setSearch(v.search);
+        }}
+      />
+
+      <FeedbackTable items={result.items} loading={loading} error={error} onToggleStatus={handleToggleStatus} />
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <Pagination page={page} total={result.total} pageSize={PAGE_SIZE} onPageChange={setPage} />
+      </div>
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/src/components/feedback/feedback-filters.tsx
+++ b/apps/admin/src/components/feedback/feedback-filters.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+  FEEDBACK_TYPES,
+  type FeedbackStatusFilter,
+  type FeedbackTypeFilter
+} from "@/lib/api/feedback";
+
+export interface FeedbackFiltersValue {
+  type: FeedbackTypeFilter;
+  status: FeedbackStatusFilter;
+  search: string;
+}
+
+export function FeedbackFilters({
+  value,
+  onChange
+}: {
+  value: FeedbackFiltersValue;
+  onChange: (value: FeedbackFiltersValue) => void;
+}) {
+  return (
+    <div className="filter-bar">
+      <div className="filter-group">
+        <span className="filter-label">问题类型</span>
+        <select
+          className="form-select"
+          style={{ width: 130 }}
+          value={value.type}
+          onChange={(e) => onChange({ ...value, type: e.target.value as FeedbackTypeFilter })}
+        >
+          <option value="">全部</option>
+          {FEEDBACK_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="filter-group">
+        <span className="filter-label">处理状态</span>
+        <select
+          className="form-select"
+          style={{ width: 120 }}
+          value={value.status}
+          onChange={(e) => onChange({ ...value, status: e.target.value as FeedbackStatusFilter })}
+        >
+          <option value="">全部</option>
+          <option value="pending">待处理</option>
+          <option value="resolved">已处理</option>
+        </select>
+      </div>
+
+      <div className="filter-group" style={{ marginLeft: "auto" }}>
+        <input
+          type="text"
+          placeholder="搜索标题 / 描述 / 联系方式..."
+          style={{ width: 260 }}
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/feedback/feedback-table.tsx
+++ b/apps/admin/src/components/feedback/feedback-table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { FeedbackItem } from "@/lib/api/feedback";
+import { statusLabel } from "@/lib/api/feedback";
+import { formatDateTime } from "@/lib/utils/format";
+
+function statusTone(status: FeedbackItem["status"]): "success" | "warning" {
+  return status === "resolved" ? "success" : "warning";
+}
+
+export function FeedbackTable({
+  items,
+  loading,
+  error,
+  onToggleStatus
+}: {
+  items: FeedbackItem[];
+  loading: boolean;
+  error: string | null;
+  onToggleStatus: (item: FeedbackItem) => void;
+}) {
+  return (
+    <div className="card">
+      <div className="table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>时间</th>
+              <th>类型</th>
+              <th>提出者</th>
+              <th>标题</th>
+              <th>详细描述</th>
+              <th>联系方式</th>
+              <th>状态</th>
+              <th style={{ textAlign: "right" }}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && items.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                  加载中...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td
+                  colSpan={8}
+                  className="empty-state"
+                  style={{ textAlign: "center", color: "var(--color-destructive)" }}
+                >
+                  {error}
+                </td>
+              </tr>
+            ) : items.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                  暂无反馈
+                </td>
+              </tr>
+            ) : (
+              items.map((item) => (
+                <tr key={item.id}>
+                  <td style={{ whiteSpace: "nowrap" }}>{formatDateTime(item.created_at)}</td>
+                  <td>
+                    <span className="badge badge-muted">{item.type}</span>
+                  </td>
+                  <td>
+                    <div>
+                      <div className="cell-primary">{item.user_name ?? "—"}</div>
+                      {item.user_email ? (
+                        <div style={{ fontSize: 11, color: "#94A3B8" }}>{item.user_email}</div>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="cell-primary">{item.title}</td>
+                  <td style={{ maxWidth: 260 }}>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: "#475569",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap"
+                      }}
+                      title={item.description ?? ""}
+                    >
+                      {item.description || "—"}
+                    </div>
+                  </td>
+                  <td>{item.contact || "—"}</td>
+                  <td>
+                    <span className={`badge badge-${statusTone(item.status)}`}>
+                      <span className="badge-dot" />
+                      {statusLabel(item.status)}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="cell-actions">
+                      <button
+                        className={`btn ${item.status === "resolved" ? "btn-outline" : "btn-secondary"} btn-sm`}
+                        onClick={() => onToggleStatus(item)}
+                      >
+                        {item.status === "resolved" ? "标记待处理" : "标记已处理"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/sidebar.tsx
+++ b/apps/admin/src/components/sidebar.tsx
@@ -71,6 +71,15 @@ const NAV_SECTIONS: Array<{
             <rect x="1" y="5" width="15" height="14" rx="2" />
           </svg>
         )
+      },
+      {
+        href: "/feedback",
+        label: "反馈管理",
+        icon: (
+          <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+        )
       }
     ]
   },

--- a/apps/admin/src/lib/api/audit.ts
+++ b/apps/admin/src/lib/api/audit.ts
@@ -1,7 +1,7 @@
 import { createAdminBrowserClient } from "@/lib/supabase/client";
 import { formatDateTime } from "@/lib/utils/format";
 
-export type AuditLogActionCategory = "" | "team" | "user" | "provider" | "announcement" | "quota";
+export type AuditLogActionCategory = "" | "team" | "user" | "provider" | "announcement" | "quota" | "feedback";
 export type AuditLogTimeRange = "24h" | "7d" | "30d" | "all";
 
 export interface AuditLog {
@@ -63,7 +63,8 @@ export function actionLabel(action: string): string {
     "key.unbind": "解绑账号",
     "sub.update": "订阅变更",
     "cost.update": "消耗表更新",
-    "audit.clear": "清除日志"
+    "audit.clear": "清除日志",
+    "feedback.status": "反馈处理"
   };
   return map[action] ?? action;
 }
@@ -113,6 +114,13 @@ export const AUDIT_ACTION_GROUPS: ActionGroup[] = [
     label: "额度",
     actions: [
       { value: "quota.reset", label: "重置额度" }
+    ]
+  },
+  {
+    value: "feedback",
+    label: "反馈",
+    actions: [
+      { value: "feedback.status", label: "反馈处理" }
     ]
   }
 ];

--- a/apps/admin/src/lib/api/feedback.ts
+++ b/apps/admin/src/lib/api/feedback.ts
@@ -1,0 +1,102 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+import { insertAuditLog } from "@/lib/utils/audit";
+
+export type FeedbackType = "使用问题" | "额度异常" | "账号绑定" | "团队功能" | "建议";
+export type FeedbackStatus = "pending" | "resolved";
+export type FeedbackTypeFilter = "" | FeedbackType;
+export type FeedbackStatusFilter = "" | FeedbackStatus;
+
+export interface FeedbackItem {
+  id: string;
+  user_id: string;
+  type: FeedbackType;
+  title: string;
+  description: string | null;
+  contact: string | null;
+  status: FeedbackStatus;
+  created_at: string;
+  user_name: string | null;
+  user_email: string | null;
+}
+
+export interface FeedbackListParams {
+  type?: FeedbackTypeFilter;
+  status?: FeedbackStatusFilter;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface FeedbackListResult {
+  total: number;
+  items: FeedbackItem[];
+}
+
+export const FEEDBACK_TYPES: FeedbackType[] = ["使用问题", "额度异常", "账号绑定", "团队功能", "建议"];
+
+/** 类型 → 中文标签（与值一致，保留映射便于后续扩展）。 */
+export function typeLabel(type: FeedbackType | string): string {
+  return type;
+}
+
+/** 处理状态 → 中文标签。 */
+export function statusLabel(status: FeedbackStatus): string {
+  return status === "resolved" ? "已处理" : "待处理";
+}
+
+export async function listFeedback(params: FeedbackListParams = {}): Promise<FeedbackListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+
+  const { data, error } = await supabase.rpc("admin_list_feedback", {
+    p_type: params.type || null,
+    p_status: params.status || null,
+    p_search: params.search?.trim() || null,
+    p_limit: pageSize,
+    p_offset: (page - 1) * pageSize
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { total: 0, items: [] }) as { total: number; items: unknown[] };
+  return {
+    total: Number(raw.total ?? 0),
+    items: (raw.items ?? []).map((it) => normalizeFeedback(it as Record<string, unknown>))
+  };
+}
+
+/** 切换处理状态（依赖 admin RLS 直更），并写入审计日志。 */
+export async function setFeedbackStatus(
+  id: string,
+  status: FeedbackStatus,
+  item: { userId: string; previousStatus: FeedbackStatus }
+): Promise<void> {
+  const supabase = createAdminBrowserClient();
+
+  const { error } = await supabase
+    .from("feedback")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) throw error;
+
+  await insertAuditLog("feedback.status", {
+    userId: item.userId,
+    target: id,
+    metadata: { previous_status: item.previousStatus, status }
+  });
+}
+
+function normalizeFeedback(it: Record<string, unknown>): FeedbackItem {
+  return {
+    id: String(it.id ?? ""),
+    user_id: String(it.user_id ?? ""),
+    type: (it.type as FeedbackType) ?? "使用问题",
+    title: String(it.title ?? ""),
+    description: (it.description as string) ?? null,
+    contact: (it.contact as string) ?? null,
+    status: (it.status as FeedbackStatus) ?? "pending",
+    created_at: String(it.created_at ?? ""),
+    user_name: (it.user_name as string) ?? null,
+    user_email: (it.user_email as string) ?? null
+  };
+}

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 import { IconChevron, IconClose, ProviderIconMark } from './icons'
 import { BrandMark } from './Brand'
 import Select from './Select'
-import { getProviderService } from '../auth/service'
+import { getAuthService, getProviderService } from '../auth/service'
+import { ensureFreshSession } from '../auth/session'
 import { errMsg } from '../utils/error'
 import type { AuthUser } from '../hooks/useAuth'
 import type { TeamContext } from '@quota-flow/db-supabase'
@@ -414,17 +415,58 @@ export function AboutModal({ onClose }: { onClose: () => void }) {
 }
 
 export function FeedbackModal({ onClose }: { onClose: () => void }) {
+  const [type, setType] = useState('使用问题')
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [contact, setContact] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    if (!title.trim()) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const guard = await ensureFreshSession()
+      if (!guard.ok) {
+        setError('登录已过期，请重新登录')
+        return
+      }
+      const auth = getAuthService()
+      if (!auth) {
+        setError('反馈服务未配置')
+        return
+      }
+      const { error: submitError } = await auth.getClient().rpc('submit_feedback', {
+        p_type: type,
+        p_title: title.trim(),
+        p_description: description.trim() || null,
+        p_contact: contact.trim() || null
+      })
+      if (submitError) throw submitError
+      onClose()
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <Modal
       title="问题反馈"
       onClose={onClose}
       footer={
         <>
-          <button className="btn-sm" onClick={onClose}>
+          <button className="btn-sm" onClick={onClose} disabled={submitting}>
             取消
           </button>
-          <button className="btn-sm primary" disabled>
-            提交反馈
+          <button
+            className="btn-sm primary"
+            onClick={() => void handleSubmit()}
+            disabled={submitting || !title.trim()}
+          >
+            {submitting ? '提交中…' : '提交反馈'}
           </button>
         </>
       }
@@ -433,8 +475,8 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
         <div className="form-group">
           <label>问题类型</label>
           <Select
-            value="使用问题"
-            onChange={() => {}}
+            value={type}
+            onChange={setType}
             options={[
               { value: '使用问题', label: '使用问题' },
               { value: '额度异常', label: '额度异常' },
@@ -446,21 +488,32 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
         </div>
         <div className="form-group">
           <label>标题</label>
-          <input type="text" placeholder="一句话描述问题" />
+          <input
+            type="text"
+            placeholder="一句话描述问题"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
         </div>
         <div className="form-group">
           <label>详细描述</label>
-          <textarea rows={4} placeholder="补充操作步骤、预期结果和实际表现" />
-        </div>
-        <div className="form-group">
-          <label>图片</label>
-          <input type="file" accept="image/*" multiple />
-          <div className="feedback-upload-hint">支持 png、jpg、jpeg、webp，可多选</div>
+          <textarea
+            rows={4}
+            placeholder="补充操作步骤、预期结果和实际表现"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
         </div>
         <div className="form-group">
           <label>联系方式</label>
-          <input type="text" placeholder="邮箱或微信，方便跟进" />
+          <input
+            type="text"
+            placeholder="邮箱或微信，方便跟进"
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+          />
         </div>
+        {error ? <div className="auth-msg auth-msg-error">{error}</div> : null}
       </div>
     </Modal>
   )

--- a/migrations/0025_feedback.sql
+++ b/migrations/0025_feedback.sql
@@ -1,0 +1,158 @@
+-- 0025_feedback.sql
+-- 桌面端「问题反馈」链路：feedback 表 + 提交 RPC + 后台列表 RPC。
+-- Idempotent: CREATE TABLE IF NOT EXISTS / CREATE OR REPLACE FUNCTION；在 Supabase SQL Editor 或迁移 runner 执行。
+
+-- ============ 1. feedback 表 ============
+CREATE TABLE IF NOT EXISTS feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT '使用问题',
+  title TEXT NOT NULL,
+  description TEXT,
+  contact TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'resolved')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_created
+  ON feedback (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_status_created
+  ON feedback (status, created_at DESC);
+
+ALTER TABLE feedback ENABLE ROW LEVEL SECURITY;
+
+-- 本人可读自己的反馈，admin 全量可读。
+DROP POLICY IF EXISTS "feedback_select_own_or_admin" ON feedback;
+CREATE POLICY "feedback_select_own_or_admin" ON feedback
+  FOR SELECT USING (user_id = auth.uid() OR public.is_admin());
+
+-- admin 全量管理（含改状态）；普通用户不直插，user_id 由提交 RPC 强制取自 auth.uid()。
+DROP POLICY IF EXISTS "feedback_admin_all" ON feedback;
+CREATE POLICY "feedback_admin_all" ON feedback
+  FOR ALL USING (public.is_admin()) WITH CHECK (public.is_admin());
+
+GRANT ALL ON TABLE feedback TO authenticated;
+
+COMMENT ON TABLE feedback IS '桌面端用户问题反馈，admin 在「反馈管理」页跟进处理';
+
+-- ============ 2. submit_feedback ============
+-- SECURITY DEFINER 强制 user_id = auth.uid()，避免客户端伪造提出者。
+CREATE OR REPLACE FUNCTION public.submit_feedback(
+  p_type TEXT,
+  p_title TEXT,
+  p_description TEXT DEFAULT NULL,
+  p_contact TEXT DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_id UUID;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'unauthorized: missing auth uid' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_title IS NULL OR btrim(p_title) = '' THEN
+    RAISE EXCEPTION 'invalid input: title is required' USING ERRCODE = '22004';
+  END IF;
+
+  INSERT INTO public.feedback (user_id, type, title, description, contact)
+  VALUES (
+    v_user_id,
+    COALESCE(NULLIF(btrim(COALESCE(p_type, '')), ''), '使用问题'),
+    btrim(p_title),
+    NULLIF(btrim(COALESCE(p_description, '')), ''),
+    NULLIF(btrim(COALESCE(p_contact, '')), '')
+  )
+  RETURNING id INTO v_id;
+
+  RETURN json_build_object('ok', true, 'id', v_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_feedback(text, text, text, text) TO authenticated;
+
+COMMENT ON FUNCTION public.submit_feedback(text, text, text, text)
+  IS '提交问题反馈，提出者强制取自 auth.uid()，仅登录用户可调用。';
+
+-- ============ 3. admin_list_feedback ============
+-- 返回 json { total, items: [...] }，JOIN profiles 出提出者姓名/邮箱，支持类型/状态/搜索 + 分页。
+CREATE OR REPLACE FUNCTION public.admin_list_feedback(
+  p_type TEXT DEFAULT NULL,
+  p_status TEXT DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM public.feedback f
+  WHERE
+    (p_type IS NULL OR p_type = '' OR f.type = p_type)
+    AND (p_status IS NULL OR p_status = '' OR f.status = p_status)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      f.title ILIKE '%' || p_search || '%' OR
+      f.description ILIKE '%' || p_search || '%' OR
+      f.contact ILIKE '%' || p_search || '%'
+    );
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      f.id,
+      f.user_id,
+      f.type,
+      f.title,
+      f.description,
+      f.contact,
+      f.status,
+      f.created_at,
+      p.display_name AS user_name,
+      p.email AS user_email
+    FROM public.feedback f
+    LEFT JOIN public.profiles p ON p.id = f.user_id
+    WHERE
+      (p_type IS NULL OR p_type = '' OR f.type = p_type)
+      AND (p_status IS NULL OR p_status = '' OR f.status = p_status)
+      AND (
+        p_search IS NULL OR p_search = '' OR
+        f.title ILIKE '%' || p_search || '%' OR
+        f.description ILIKE '%' || p_search || '%' OR
+        f.contact ILIKE '%' || p_search || '%'
+      )
+    ORDER BY f.created_at DESC, f.id DESC
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_feedback(text, text, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_feedback(text, text, text, integer, integer)
+  IS '后台反馈列表：聚合提出者姓名/邮箱，支持类型/状态/搜索筛选与分页（仅 admin 可调用）。';


### PR DESCRIPTION
## 变更内容
- 桌面端「问题反馈」弹窗接入 `submit_feedback` RPC（类型/标题/描述/联系方式）
- 后台新增「反馈管理」页：列表、类型/状态/搜索筛选、分页、状态切换
- 新增 `feedback` 表 + `submit_feedback` / `admin_list_feedback` RPC + RLS 策略
- 审计日志新增 `feedback.status` 动作分类

## 数据库迁移
- `migrations/0025_feedback.sql`

Closes #42