### PR TITLE
feat: 创作中心素材库（本地管理 + 回填调度台）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ data/jobs.jsonl
 .turbo
 *.tsbuildinfo
 
+# pnpm 本地缓存（沙箱内重定向）/ 本地 store
+.pnpm-cache/
+.pnpm-store/
+
 # 本地编辑器配置与拷贝的全局 skill
 .trae/
 skills/

--- a/apps/admin/src/components/desktop-permissions/permission-data.ts
+++ b/apps/admin/src/components/desktop-permissions/permission-data.ts
@@ -91,6 +91,12 @@ export const PERMISSION_MODULES: PermissionModule[] = [
             description: "创作中心视频灵感库：优秀视频与参考提示词"
           }
         ]
+      },
+      {
+        key: "creation.material_library",
+        label: "素材库",
+        description: "本地素材库模块总开关",
+        features: []
       }
     ]
   }

--- a/apps/admin/src/components/desktop-permissions/types.ts
+++ b/apps/admin/src/components/desktop-permissions/types.ts
@@ -21,7 +21,8 @@ export type FeatureKey =
   | "creation.prompt_expander"
   | "creation.storyboard"
   | "creation.video_library"
-  | "creation.community";
+  | "creation.community"
+  | "creation.material_library";
 
 export interface PermissionFeature {
   key: FeatureKey;

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^20.14.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^43.3.0",
     "electron-builder": "^26.15.3",
@@ -31,6 +32,7 @@
     "@quota-flow/auth": "workspace:^",
     "@quota-flow/db-supabase": "workspace:^",
     "electron-updater": "^6.6.2",
-    "ffmpeg-static": "^5.3.0"
+    "ffmpeg-static": "^5.3.0",
+    "ws": "^8.21.3"
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import type { UpdaterStatus } from './updater'
 import { getWatermarkStatus, processWatermarkJob } from './watermark-remover/job'
 import type { WatermarkJobInput } from './watermark-remover/job'
 import type { WatermarkProgress } from './watermark-remover/engine'
+import { getMaterialStore } from './materials/store'
 
 /** 活跃生成任务注册表：jobId → 取消/已提交状态（用于「终止生成」与「关闭确认」） */
 interface ActiveRunState {
@@ -64,6 +65,20 @@ function startMediaServer(): Promise<number> {
     mediaPortPromise = new Promise((resolve, reject) => {
       const videosDir = join(app.getPath('userData'), 'videos')
       const imagesDir = join(app.getPath('userData'), 'images')
+      const materialsDir = join(app.getPath('userData'), 'materials')
+      const imageContentType = (ext: string): string =>
+        ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : ext === 'webp' ? 'image/webp' : 'image/jpeg'
+      const serveImage = (res: import('node:http').ServerResponse, name: string, dir: string): void => {
+        const file = join(dir, name)
+        if (!existsSync(file)) {
+          res.writeHead(404)
+          res.end()
+          return
+        }
+        const ext = (name.split('.').pop() || 'jpg').toLowerCase()
+        res.writeHead(200, { 'Content-Type': imageContentType(ext), 'Cache-Control': 'no-store' })
+        createReadStream(file).pipe(res)
+      }
       const server = createServer((req, res) => {
         const path = (req.url || '').split('?')[0]
         if (path.startsWith('/images/')) {
@@ -73,17 +88,44 @@ function startMediaServer(): Promise<number> {
             res.end()
             return
           }
-          const file = join(imagesDir, name)
+          serveImage(res, name, imagesDir)
+          return
+        }
+        if (path.startsWith('/materials/')) {
+          const name = path.slice('/materials/'.length)
+          if (!/^[0-9a-fA-F-]+\.(png|jpe?g|gif|webp|mp4)$/i.test(name)) {
+            res.writeHead(400)
+            res.end()
+            return
+          }
+          const file = join(materialsDir, name)
           if (!existsSync(file)) {
             res.writeHead(404)
             res.end()
             return
           }
-          const ext = (name.split('.').pop() || 'jpg').toLowerCase()
-          const type =
-            ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : ext === 'webp' ? 'image/webp' : 'image/jpeg'
-          res.writeHead(200, { 'Content-Type': type, 'Cache-Control': 'no-store' })
-          createReadStream(file).pipe(res)
+          const ext = (name.split('.').pop() || '').toLowerCase()
+          if (ext === 'mp4') {
+            const size = statSync(file).size
+            res.setHeader('Content-Type', 'video/mp4')
+            res.setHeader('Accept-Ranges', 'bytes')
+            const range = req.headers.range
+            if (range) {
+              const m = /bytes=(\d*)-(\d*)/.exec(range)
+              const start = m && m[1] ? parseInt(m[1], 10) : 0
+              const end = m && m[2] ? parseInt(m[2], 10) : size - 1
+              res.writeHead(206, {
+                'Content-Range': `bytes ${start}-${end}/${size}`,
+                'Content-Length': end - start + 1
+              })
+              createReadStream(file, { start, end }).pipe(res)
+            } else {
+              res.writeHead(200, { 'Content-Length': size })
+              createReadStream(file).pipe(res)
+            }
+          } else {
+            serveImage(res, name, materialsDir)
+          }
           return
         }
         const name = path.replace(/^\//, '')
@@ -252,6 +294,25 @@ app.whenReady().then(() => {
     if (!existsSync(resolved)) return { ok: false, error: '视频文件不存在' }
     shell.showItemInFolder(resolved)
     return { ok: true }
+  })
+
+  ipcMain.handle('materials:list', async () => getMaterialStore().list())
+  ipcMain.handle('materials:import', async (_e, paths: unknown) => {
+    if (!Array.isArray(paths) || paths.some((p) => typeof p !== 'string')) {
+      throw new Error('invalid material paths')
+    }
+    return getMaterialStore().importPaths(paths as string[])
+  })
+  ipcMain.handle('materials:remove', async (_e, id: unknown) => {
+    if (typeof id !== 'string' || !id) throw new Error('invalid material id')
+    return getMaterialStore().remove(id)
+  })
+  ipcMain.handle('materials:get-url', async (_e, fileName: unknown) => {
+    if (typeof fileName !== 'string' || !/^[0-9a-fA-F-]+\.(png|jpe?g|gif|webp|mp4)$/.test(fileName)) {
+      throw new Error('invalid material name')
+    }
+    const port = await startMediaServer()
+    return `http://127.0.0.1:${port}/materials/${fileName}`
   })
 
   ipcMain.handle('ping', () => 'pong')

--- a/apps/desktop/src/main/materials/store.ts
+++ b/apps/desktop/src/main/materials/store.ts
@@ -1,0 +1,139 @@
+import { app } from 'electron'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+/**
+ * 素材库：本地优先管理（文件 + 索引），并预留云端后端接口。
+ *
+ * 接口 MaterialBackend 抽象了素材的持久化方式；当前唯一实现 LocalMaterialBackend
+ * 把文件落在 userData/materials，索引落在 userData/materials/index.json。
+ * 后续如需云端/团队共享，可新增基于 Supabase 的实现替换单例，上层 IPC 无需改动。
+ */
+
+export type MaterialType = 'image' | 'video'
+
+export interface MaterialRecord {
+  id: string
+  type: MaterialType
+  /** 原始文件名（仅展示） */
+  name: string
+  /** 落盘文件名：<id>.<ext>，用于媒体服务定位与预览 URL */
+  fileName: string
+  ext: string
+  size: number
+  createdAt: number
+  /** 本地绝对路径，供回填调度台作为生成图片输入 */
+  path: string
+}
+
+/** 支持的扩展名 → 素材类型（与媒体服务 /materials/ 路由白名单保持一致） */
+const EXT_TYPE: Record<string, MaterialType> = {
+  png: 'image',
+  jpg: 'image',
+  jpeg: 'image',
+  gif: 'image',
+  webp: 'image',
+  mp4: 'video'
+}
+
+export interface MaterialBackend {
+  list(): Promise<MaterialRecord[]>
+  importPaths(paths: string[]): Promise<MaterialRecord[]>
+  remove(id: string): Promise<{ ok: boolean; error?: string }>
+  getFilePath(id: string): string
+}
+
+class LocalMaterialBackend implements MaterialBackend {
+  private dir: string
+  private indexFile: string
+
+  constructor(userData: string) {
+    this.dir = join(userData, 'materials')
+    this.indexFile = join(this.dir, 'index.json')
+    mkdirSync(this.dir, { recursive: true })
+  }
+
+  private readIndex(): MaterialRecord[] {
+    try {
+      if (!existsSync(this.indexFile)) return []
+      const raw = readFileSync(this.indexFile, 'utf8')
+      const list = JSON.parse(raw) as MaterialRecord[]
+      return Array.isArray(list) ? list : []
+    } catch {
+      return []
+    }
+  }
+
+  private writeIndex(list: MaterialRecord[]): void {
+    writeFileSync(this.indexFile, JSON.stringify(list, null, 2), 'utf8')
+  }
+
+  async list(): Promise<MaterialRecord[]> {
+    return this.readIndex().sort((a, b) => b.createdAt - a.createdAt)
+  }
+
+  async importPaths(paths: string[]): Promise<MaterialRecord[]> {
+    const existing = this.readIndex()
+    const created: MaterialRecord[] = []
+    for (const p of paths) {
+      try {
+        if (typeof p !== 'string' || !p || !existsSync(p)) continue
+        const ext = (p.split('.').pop() || '').toLowerCase()
+        const type = EXT_TYPE[ext]
+        if (!type) continue
+        const id = randomUUID()
+        const fileName = `${id}.${ext}`
+        const dest = join(this.dir, fileName)
+        copyFileSync(p, dest)
+        const name = p.replace(/\\/g, '/').split('/').pop() || fileName
+        let size = 0
+        try {
+          size = statSync(dest).size
+        } catch {
+          // 忽略 stat 失败
+        }
+        existing.push({
+          id,
+          type,
+          name,
+          fileName,
+          ext,
+          size,
+          createdAt: Date.now(),
+          path: dest
+        })
+        created.push(existing[existing.length - 1])
+      } catch {
+        // 单个文件导入失败不影响其它文件
+      }
+    }
+    if (created.length > 0) this.writeIndex(existing)
+    return created
+  }
+
+  async remove(id: string): Promise<{ ok: boolean; error?: string }> {
+    const existing = this.readIndex()
+    const idx = existing.findIndex((m) => m.id === id)
+    if (idx === -1) return { ok: false, error: '素材不存在' }
+    const [record] = existing.splice(idx, 1)
+    try {
+      rmSync(join(this.dir, record.fileName), { force: true })
+    } catch {
+      // 文件已不存在也正常删除索引
+    }
+    this.writeIndex(existing)
+    return { ok: true }
+  }
+
+  getFilePath(id: string): string {
+    return join(this.dir, this.readIndex().find((m) => m.id === id)?.fileName ?? '')
+  }
+}
+
+let store: MaterialBackend | null = null
+
+export function getMaterialStore(): MaterialBackend {
+  if (!store) store = new LocalMaterialBackend(app.getPath('userData'))
+  return store
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -112,6 +112,19 @@ export interface UpdaterStatus {
   error?: string
 }
 
+export type MaterialType = 'image' | 'video'
+
+export interface MaterialRecord {
+  id: string
+  type: MaterialType
+  name: string
+  fileName: string
+  ext: string
+  size: number
+  createdAt: number
+  path: string
+}
+
 export interface GenerateRequest {
   supabaseUrl: string
   supabaseAnonKey: string
@@ -194,6 +207,12 @@ export interface DesktopApi {
   }
   files: {
     getPath: (file: File) => string
+  }
+  materials: {
+    list: () => Promise<MaterialRecord[]>
+    import: (paths: string[]) => Promise<MaterialRecord[]>
+    remove: (id: string) => Promise<{ ok: boolean; error?: string }>
+    getUrl: (fileName: string) => Promise<string>
   }
   media: {
     getUrl: (name: string) => Promise<string>
@@ -308,6 +327,12 @@ const api: DesktopApi = {
   },
   files: {
     getPath: (file) => webUtils.getPathForFile(file)
+  },
+  materials: {
+    list: () => ipcRenderer.invoke('materials:list') as Promise<MaterialRecord[]>,
+    import: (paths) => ipcRenderer.invoke('materials:import', paths) as Promise<MaterialRecord[]>,
+    remove: (id) => ipcRenderer.invoke('materials:remove', id) as Promise<{ ok: boolean; error?: string }>,
+    getUrl: (fileName) => ipcRenderer.invoke('materials:get-url', fileName) as Promise<string>
   },
   media: {
     getUrl: (name) => ipcRenderer.invoke('media:get-url', name) as Promise<string>,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -163,6 +163,7 @@ function MainApp({
   const [renewText, setRenewText] = useState('自动续命：—')
   const [updatePromptVisible, setUpdatePromptVisible] = useState(false)
   const [regenerateDraft, setRegenerateDraft] = useState<RegenerateDraft | null>(null)
+  const [materialImages, setMaterialImages] = useState<Array<{ path: string; url: string }>>([])
 
   const scopeLabel = useMemo(() => {
     if (viewScope === 'team') return '团队模式'
@@ -196,6 +197,12 @@ function MainApp({
 
   const handleCommunityReference = useCallback((draft: RegenerateDraft): void => {
     setRegenerateDraft(draft)
+    setTab('dispatch')
+    location.hash = 'tab=dispatch'
+  }, [])
+
+  const handleUseMaterial = useCallback((path: string, url: string): void => {
+    setMaterialImages([{ path, url }])
     setTab('dispatch')
     location.hash = 'tab=dispatch'
   }, [])
@@ -490,6 +497,8 @@ function MainApp({
               jobs={jobs}
               features={permissions.features}
               regenerateDraft={regenerateDraft}
+              materialImages={materialImages}
+              onMaterialImagesConsumed={() => setMaterialImages([])}
               onRegenerateConsumed={() => setRegenerateDraft(null)}
             />
           </div>
@@ -507,6 +516,7 @@ function MainApp({
               features={permissions.features}
               userId={user.id}
               onReferenceGenerate={handleCommunityReference}
+              onUseMaterial={handleUseMaterial}
               onNotify={showToast}
             />
           </div>

--- a/apps/desktop/src/renderer/src/components/CreationCenter.tsx
+++ b/apps/desktop/src/renderer/src/components/CreationCenter.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { createPortal } from 'react-dom'
 import type { DesktopFeatureFlags } from '../hooks/useDesktopPermissions'
 import { useCommunityVideos, type CommunityVideo } from '../hooks/useCommunityVideos'
+import MaterialLibrary from './MaterialLibrary'
 import type { RegenerateDraft } from './Dashboard'
 import { IconClose, IconGrid, IconPlay, IconSparkles } from './icons'
 
@@ -66,10 +67,11 @@ interface CreationCenterProps {
   features: DesktopFeatureFlags
   userId?: string
   onReferenceGenerate?: (draft: RegenerateDraft) => void
+  onUseMaterial?: (path: string, url: string) => void
   onNotify?: (message: string) => void
 }
 
-export default function CreationCenter({ features, userId, onReferenceGenerate, onNotify }: CreationCenterProps) {
+export default function CreationCenter({ features, userId, onReferenceGenerate, onUseMaterial, onNotify }: CreationCenterProps) {
   const communityVideos = useCommunityVideos(userId)
   const videos = communityVideos.items
   const [category, setCategory] = useState<string>('全部')
@@ -235,6 +237,12 @@ export default function CreationCenter({ features, userId, onReferenceGenerate, 
           </div>
         </section>
       ) : null}
+
+      {features['creation.material_library'] === false ? (
+        <div className="creation-disabled">素材库未开启</div>
+      ) : (
+        <MaterialLibrary onUseMaterial={onUseMaterial} onNotify={onNotify} />
+      )}
 
       {features['creation.video_library'] === false ? null : features['creation.community'] !== false ? (
         <section className="community-section" aria-label="视频灵感库">

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -83,6 +83,9 @@ interface DashboardProps {
   jobs: JobsResult
   features: DesktopFeatureFlags
   regenerateDraft?: RegenerateDraft | null
+  /** 素材库「用作参考」注入的图片：添加为图像参考并切到图生/多参考模式 */
+  materialImages?: Array<{ path: string; url: string }>
+  onMaterialImagesConsumed?: () => void
   onRegenerateConsumed?: () => void
 }
 
@@ -135,6 +138,8 @@ export default function Dashboard({
   jobs,
   features,
   regenerateDraft,
+  materialImages,
+  onMaterialImagesConsumed,
   onRegenerateConsumed
 }: DashboardProps) {
   const { aggs: provAggs } = providers
@@ -209,6 +214,17 @@ export default function Dashboard({
       cancelled = true
     }
   }, [regenerateDraft, features, onRegenerateConsumed])
+
+  // 素材库「用作参考」：把图片追加为图像参考，并切到当前厂商可用的图生/多参考模式
+  useEffect(() => {
+    if (!materialImages || materialImages.length === 0) return
+    setSavedImagePaths((prev) => [...prev, ...materialImages.map((m) => m.path)])
+    setImages((prev) => [...prev, ...materialImages.map((m) => m.url)])
+    const validModes = visibleModeOptions(provider, model, features)
+    const imageMode = validModes.find((m) => ['multi_ref', 'img', 'first_last', 'first_frame'].includes(m.value))
+    if (imageMode && imageMode.value !== mode) setMode(imageMode.value)
+    onMaterialImagesConsumed?.()
+  }, [materialImages, provider, model, features, mode, onMaterialImagesConsumed])
 
   const activeBoundAggs = useMemo(
     () => provAggs.filter((a) => a.enabled && a.boundCount > 0),

--- a/apps/desktop/src/renderer/src/components/MaterialLibrary.tsx
+++ b/apps/desktop/src/renderer/src/components/MaterialLibrary.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ChangeEvent, ReactElement } from 'react'
+import { createPortal } from 'react-dom'
+import { useMaterials } from '../hooks/useMaterials'
+import type { MaterialRecord } from '../../../preload'
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+interface MaterialLibraryProps {
+  onUseMaterial?: (path: string, url: string) => void
+  onNotify?: (message: string) => void
+}
+
+export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLibraryProps) {
+  const { items, loading, error, importFiles, remove } = useMaterials()
+  const [filter, setFilter] = useState<'all' | 'image' | 'video'>('all')
+  const [keyword, setKeyword] = useState('')
+  const [urls, setUrls] = useState<Record<string, string>>({})
+  const [selected, setSelected] = useState<MaterialRecord | null>(null)
+  const [removing, setRemoving] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const visibleItems = useMemo(() => {
+    const kw = keyword.trim().toLowerCase()
+    return items.filter((m) => {
+      if (filter !== 'all' && m.type !== filter) return false
+      if (kw && !m.name.toLowerCase().includes(kw)) return false
+      return true
+    })
+  }, [items, filter, keyword])
+
+  // 解析所有素材的可预览 URL（媒体服务端口动态，逐个获取）
+  useEffect(() => {
+    let cancelled = false
+    const map: Record<string, string> = {}
+    const tasks = items.map((m) =>
+      window.api.materials.getUrl(m.fileName).catch(() => null)
+    )
+    void Promise.all(tasks).then((res) => {
+      if (cancelled) return
+      items.forEach((m, i) => {
+        const u = res[i]
+        if (u) map[m.id] = u
+      })
+      setUrls(map)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [items])
+
+  useEffect(() => {
+    if (!selected) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setSelected(null)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selected])
+
+  const onPickFiles = (): void => fileInputRef.current?.click()
+
+  const onFilesSelected = async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const files = Array.from(e.target.files ?? [])
+    e.target.value = ''
+    if (files.length === 0) return
+    try {
+      const { imported, skipped } = await importFiles(files)
+      onNotify?.(skipped > 0 ? `已导入 ${imported} 个素材（跳过 ${skipped} 个不支持的文件）` : `已导入 ${imported} 个素材`)
+    } catch (err) {
+      onNotify?.(err instanceof Error ? err.message : '导入失败')
+    }
+  }
+
+  const handleRemove = async (item: MaterialRecord): Promise<void> => {
+    if (removing) return
+    setRemoving(item.id)
+    try {
+      await remove(item.id)
+      if (selected?.id === item.id) setSelected(null)
+      onNotify?.('已删除素材')
+    } catch (err) {
+      onNotify?.(err instanceof Error ? err.message : '删除失败')
+    } finally {
+      setRemoving(null)
+    }
+  }
+
+  const renderThumb = (item: MaterialRecord): ReactElement => {
+    const src = urls[item.id]
+    if (!src) {
+      return (
+        <div className="material-thumb placeholder">
+          <span>{item.type === 'video' ? '视频' : '图片'}</span>
+        </div>
+      )
+    }
+    if (item.type === 'video') {
+      return (
+        <video
+          src={src}
+          muted
+          preload="metadata"
+          className="material-thumb"
+          poster=""
+        />
+      )
+    }
+    return <img src={src} alt={item.name} loading="lazy" className="material-thumb" />
+  }
+
+  return (
+    <section className="material-section" aria-label="我的素材库">
+      <div className="creation-section-heading">
+        <h2>我的素材库</h2>
+        <div className="material-heading-actions">
+          <span>{items.length} 个素材</span>
+          <button className="btn-sm primary" onClick={onPickFiles}>
+            导入素材
+          </button>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*,video/mp4"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => void onFilesSelected(e)}
+        />
+      </div>
+
+      <div className="material-toolbar">
+        <div className="community-category-row" role="tablist" aria-label="素材类型">
+          {(
+            [
+              { value: 'all', label: '全部' },
+              { value: 'image', label: '图片' },
+              { value: 'video', label: '视频' }
+            ] as Array<{ value: 'all' | 'image' | 'video'; label: string }>
+          ).map((c) => (
+            <button
+              key={c.value}
+              className={'community-chip' + (filter === c.value ? ' active' : '')}
+              onClick={() => setFilter(c.value)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+        <input
+          className="material-search"
+          placeholder="搜索素材名称"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+      </div>
+
+      {loading ? (
+        <div className="community-state">加载中...</div>
+      ) : error ? (
+        <div className="community-state error">加载失败：{error}</div>
+      ) : items.length === 0 ? (
+        <div className="community-state">
+          素材库为空，导入本地图片 / 视频作为创作参考素材。
+          <button className="btn-sm primary" style={{ marginTop: 8 }} onClick={onPickFiles}>
+            导入素材
+          </button>
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div className="community-state">没有匹配的素材。</div>
+      ) : (
+        <div className="material-grid">
+          {visibleItems.map((m) => {
+            const src = urls[m.id]
+            const canUse = m.type === 'image'
+            return (
+              <article
+                key={m.id}
+                className="material-card"
+                onClick={() => src && setSelected(m)}
+              >
+                <div className="material-card-cover">{renderThumb(m)}</div>
+                <div className="material-card-body">
+                  <h4 title={m.name}>{m.name}</h4>
+                  <div className="material-meta">
+                    <span>{m.ext.toUpperCase()}</span>
+                    <span>{formatBytes(m.size)}</span>
+                  </div>
+                  <div className="material-card-actions" onClick={(e) => e.stopPropagation()}>
+                    {canUse && (
+                      <button
+                        className="btn-sm primary"
+                        title="回填到调度台作为参考图"
+                        onClick={() => {
+                          if (!src) return
+                          onUseMaterial?.(m.path, src)
+                        }}
+                      >
+                        用作参考
+                      </button>
+                    )}
+                    <button className="btn-sm" disabled={removing === m.id} onClick={() => void handleRemove(m)}>
+                      {removing === m.id ? '删除中' : '删除'}
+                    </button>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {selected &&
+        createPortal(
+          <div
+            className="modal-overlay"
+            style={{ zIndex: 300 }}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setSelected(null)
+            }}
+          >
+            <div
+              className="modal-card material-detail"
+              style={{ width: 'min(94vw, 860px)', maxHeight: '88vh', display: 'flex', flexDirection: 'column' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="material-detail-header">
+                <h3>{selected.name}</h3>
+                <button className="modal-close" title="关闭" onClick={() => setSelected(null)}>
+                  ×
+                </button>
+              </div>
+              <div className="material-detail-media">
+                {selected.type === 'video' && urls[selected.id] ? (
+                  <video src={urls[selected.id]} controls preload="metadata" className="material-detail-video" />
+                ) : urls[selected.id] ? (
+                  <img src={urls[selected.id]} alt={selected.name} className="material-detail-img" />
+                ) : (
+                  <div className="community-state">素材不可预览</div>
+                )}
+              </div>
+              <div className="material-detail-footer">
+                <span>{selected.type === 'video' ? '视频' : '图片'} · {selected.ext.toUpperCase()} · {formatBytes(selected.size)}</span>
+                {selected.type === 'image' && (
+                  <button
+                    className="btn-sm primary"
+                    onClick={() => {
+                      const src = urls[selected.id]
+                      if (!src) return
+                      setSelected(null)
+                      onUseMaterial?.(selected.path, src)
+                    }}
+                  >
+                    用作参考
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/src/hooks/useDesktopPermissions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesktopPermissions.ts
@@ -24,7 +24,8 @@ export const DESKTOP_FEATURE_KEYS = [
   'creation.prompt_expander',
   'creation.storyboard',
   'creation.video_library',
-  'creation.community'
+  'creation.community',
+  'creation.material_library'
 ] as const
 
 export type DesktopFeatureKey = (typeof DESKTOP_FEATURE_KEYS)[number]

--- a/apps/desktop/src/renderer/src/hooks/useMaterials.ts
+++ b/apps/desktop/src/renderer/src/hooks/useMaterials.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { MaterialRecord } from '../../../preload'
+import { errMsg } from '../utils/error'
+
+export interface UseMaterialsResult {
+  items: MaterialRecord[]
+  loading: boolean
+  error: string | null
+  reload: () => void
+  /** 从用户选择的 File 列表导入素材（v1 走本地素材库） */
+  importFiles: (files: File[]) => Promise<{ imported: number; skipped: number }>
+  remove: (id: string) => Promise<void>
+  urlOf: (fileName: string) => Promise<string>
+}
+
+export function useMaterials(): UseMaterialsResult {
+  const [items, setItems] = useState<MaterialRecord[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await window.api.materials.list()
+      setItems(list)
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load, reloadKey])
+
+  const importFiles = useCallback(async (files: File[]): Promise<{ imported: number; skipped: number }> => {
+    if (files.length === 0) return { imported: 0, skipped: 0 }
+    const paths = files
+      .map((f) => window.api.files.getPath(f).trim())
+      .filter(Boolean)
+    const created = await window.api.materials.import(paths)
+    await load()
+    return { imported: created.length, skipped: paths.length - created.length }
+  }, [load])
+
+  const remove = useCallback(async (id: string): Promise<void> => {
+    const res = await window.api.materials.remove(id)
+    if (!res.ok) throw new Error(res.error || '删除失败')
+    setItems((prev) => prev.filter((m) => m.id !== id))
+  }, [])
+
+  const urlOf = useCallback((fileName: string): Promise<string> => window.api.materials.getUrl(fileName), [])
+
+  return { items, loading, error, reload, importFiles, remove, urlOf }
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1791,6 +1791,167 @@ body {
   background: var(--accent-bg);
 }
 
+/* ===== 素材库 ===== */
+.material-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
+}
+.material-heading-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.material-heading-actions > span {
+  font-size: 0.82em;
+  color: var(--fg-muted);
+}
+.material-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+.material-search {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  font-family: var(--font-body);
+  font-size: 0.85em;
+  outline: none;
+}
+.material-search:focus {
+  border-color: var(--accent);
+}
+.material-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+}
+.material-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.material-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+}
+.material-card-cover {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  background: #000;
+  overflow: hidden;
+}
+.material-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.material-thumb.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+  background: var(--bg-elevated);
+  font-size: 0.9em;
+}
+.material-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+}
+.material-card-body h4 {
+  margin: 0;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: var(--fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.material-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75em;
+  color: var(--fg-muted);
+}
+.material-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.material-detail {
+  background: var(--bg-card);
+}
+.material-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-light);
+}
+.material-detail-header h3 {
+  margin: 0;
+  font-size: 1em;
+  color: var(--fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.material-detail-media {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  padding: 12px;
+}
+.material-detail-video {
+  max-width: 100%;
+  max-height: 60vh;
+  border-radius: 6px;
+}
+.material-detail-img {
+  max-width: 100%;
+  max-height: 60vh;
+  border-radius: 6px;
+  object-fit: contain;
+}
+.material-detail-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-light);
+  font-size: 0.82em;
+  color: var(--fg-muted);
+}
+
 @media (max-width: 820px) {
   .community-detail-body {
     grid-template-columns: 1fr;

--- a/docs/develop/素材库.md
+++ b/docs/develop/素材库.md
@@ -1,0 +1,125 @@
+# 创作中心素材库（Material Library）
+
+> 日期：2026-08-18
+> 范围：`apps/desktop/src/main/materials/`、`apps/desktop/src/main/index.ts`、`apps/desktop/src/preload/index.ts`、`apps/desktop/src/renderer/src/`、`apps/admin/src/components/desktop-permissions/`
+> 入口：桌面端 → 创作中心 → 素材库（新区块）
+
+## 背景
+
+创作中心原有的「去水印」「灵感库」之外，缺少对本地图片/视频素材的统一管理。本次新增**素材库**：本地优先管理（文件 + 索引），支持图片/视频素材的导入、预览、筛选、删除、选中，并将选中的素材**回填到调度台**用于图生视频等生成模式。为保证后续可平滑切换到云端共享，预留了 `MaterialBackend` 云端后端接口。
+
+## 设计决策
+
+1. **本地优先 + 预留云端接口**：存储抽象为 `MaterialBackend` 接口，当前唯一实现 `LocalMaterialBackend` 将文件落在 `userData/materials`、索引落在 `userData/materials/index.json`；后续如需云端/团队共享，可新增基于 Supabase 的实现替换单例，上层 IPC 无需改动。
+2. **素材在创作中心内作为新区块展示**（与去水印、灵感库平级），由 admin 权限开关 `creation.material_library` 控制显隐。
+3. **回填调度台**：选中素材后切到调度台，把本地路径写入「已保存图片」、媒体 URL 写入参考图列表，并自动切换到可用的图参考生成模式（multi_ref / img / first_last / first_frame）。
+4. **权限开关可关**：`creation.material_library === false` 时素材库区块显示「素材库未开启」。
+
+## 文件结构
+
+```
+apps/desktop/src/main/materials/
+└── store.ts                       # MaterialBackend 接口 + LocalMaterialBackend（本地实现）
+
+apps/desktop/src/main/index.ts     # 媒体服务新增 /materials/ 预览路由 + 注册 materials:* IPC
+apps/desktop/src/preload/index.ts  # 暴露 window.desktopApi.materials（list/import/remove/getUrl）+ 类型
+
+apps/desktop/src/renderer/src/
+├── hooks/useMaterials.ts          # 素材数据获取与操作（list/import/remove/urlOf）
+├── components/MaterialLibrary.tsx # 素材库 UI：导入/筛选/预览/删除/选中
+├── components/CreationCenter.tsx  # 创作中心集成新「素材库」区块（权限开关控制）
+├── components/Dashboard.tsx       # 接收回填：写入已保存图片 + 参考图 + 注入 mode
+├── App.tsx                        # materialImages 状态 + handleUseMaterial 回调
+├── hooks/useDesktopPermissions.ts # 新增 creation.material_library feature flag
+└── styles.css                     # 素材库样式（grid/card/详情等）
+
+apps/admin/src/components/desktop-permissions/
+├── permission-data.ts             # PERMISSION_MODULES 新增 creation.material_library 节点
+└── types.ts                       # FeatureKey 新增 "creation.material_library"
+```
+
+## 存储层（store.ts）
+
+### 数据类型
+
+```ts
+type MaterialType = 'image' | 'video'
+
+interface MaterialRecord {
+  id: string          // randomUUID
+  type: MaterialType  // image | video
+  name: string        // 原始文件名（仅展示）
+  fileName: string    // 落盘文件名：<id>.<ext>，用于媒体服务定位与预览 URL
+  ext: string
+  size: number
+  createdAt: number
+  path: string        // 本地绝对路径，供回填调度台作为生成图片输入
+}
+
+interface MaterialBackend {
+  list(): Promise<MaterialRecord[]>
+  importPaths(paths: string[]): Promise<MaterialRecord[]>
+  remove(id: string): Promise<{ ok: boolean; error?: string }>
+  getFilePath(id: string): string
+}
+```
+
+### 支持的扩展名
+
+- 图片：`png` `jpg` `jpeg` `gif` `webp`
+- 视频：`mp4`
+
+> 白名单与媒体服务 `/materials/` 路由校验保持一致。
+
+## IPC / preload
+
+主进程注册 4 个 handler（含入参校验，禁止执行任意路径）：
+
+- `materials:list` → `list()`
+- `materials:import` → `importPaths(paths: string[])`
+- `materials:remove` → `remove(id)`
+- `materials:get-url` → 校验 fileName 白名单后返回 `http://127.0.0.1:{port}/materials/{fileName}`
+
+preload 以 `DesktopApi.materials` 对外暴露，渲染层通过 `window.desktopApi.materials` 调用。
+
+## 回填调度台（Dashboard）
+
+```ts
+useEffect(() => {
+  if (!materialImages || materialImages.length === 0) return
+  setSavedImagePaths(prev => [...prev, ...materialImages.map(m => m.path)])
+  setImages(prev => [...prev, ...materialImages.map(m => m.url)])
+  const validModes = visibleModeOptions(provider, model, features)
+  const imageMode = validModes.find(m => ['multi_ref','img','first_last','first_frame'].includes(m.value))
+  if (imageMode && imageMode.value !== mode) setMode(imageMode.value)
+  onMaterialImagesConsumed?.()
+}, [materialImages, provider, model, features, mode, onMaterialImagesConsumed])
+```
+
+选中素材后 `App.handleUseMaterial` 写入 `materialImages` 并切换到调度台；Dashboard 消费后调用 `onMaterialImagesConsumed` 清空，避免重复注入。
+
+## 权限开关
+
+admin 权限控制页「创作中心」下新增子分组节点：
+
+```ts
+{
+  key: "creation.material_library",
+  label: "素材库",
+  description: "本地素材库模块总开关",
+  features: []
+}
+```
+
+桌面端 `useDesktopPermissions` 与 `creation.material_library === false` 控制区块显隐。
+
+## 依赖变更
+
+- `apps/desktop` 新增 `ws`（运行时）与 `@types/ws`（dev）。说明：`ws` 为桌面端既有代码 `main/system-browser-login.ts` 直接 import 但仓库从未声明的依赖；本次补装补齐类型，避免 typecheck 报 `Cannot find module 'ws'`。
+
+## 验证
+
+- `pnpm --filter @quota-flow/desktop typecheck` 通过
+- `pnpm --filter @quota-flow/desktop build` 通过（主 / preload / 渲染三层均编译成功）
+- Electron 二进制 `dist/electron.exe` 就位，`Electron uninstall` 启动报错已解决
+- 桌面端 `.env.local` 使用 `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`（与 admin 端相同 Supabase 项目），已正确被 gitignore 忽略，不入库

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       ffmpeg-static:
         specifier: ^5.3.0
         version: 5.3.0
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
     devDependencies:
       '@types/node':
         specifier: ^20.14.0
@@ -113,6 +116,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.11))
@@ -872,105 +878,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1028,7 +1018,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/env@15.5.23':
     resolution: {integrity: sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==}
@@ -1050,28 +1039,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.23':
     resolution: {integrity: sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.23':
     resolution: {integrity: sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.23':
     resolution: {integrity: sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.23':
     resolution: {integrity: sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==}
@@ -1144,79 +1129,66 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -1379,6 +1351,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1388,6 +1363,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -1876,7 +1852,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -2065,28 +2041,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2821,6 +2793,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -3710,6 +3694,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.43
+
+  '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.43
 
@@ -5290,6 +5278,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
 
   xmlbuilder@15.1.1: {}
 


### PR DESCRIPTION
新增素材库模块：本地优先存储（MaterialBackend 预留云端接口），支持图片/视频素材导入、预览、筛选、删除、选中并回填调度台用于图生视频等生成模式。在创作中心作为新区块接入，由 admin 权限开关 creation.material_library 控制；补装 ws/@types/ws 修复既有依赖缺失；新增 docs/develop/素材库.md 文档。