### PR TITLE
feat: 厂商能力配置（provider-catalog + useProviderCaps + DB 迁移）

### DIFF
--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1040,6 +1040,67 @@ input:focus, select:focus, textarea:focus {
   white-space: nowrap;
 }
 
+/* Provider 生成能力弹窗 */
+.provider-cap-scope {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.provider-cap-scope .cap-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.provider-cap-scope .cap-option.active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-muted);
+}
+
+.provider-cap-scope .cap-option input {
+  accent-color: var(--color-primary);
+  margin: 0;
+}
+
+.cap-checkbox-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-2);
+}
+
+.cap-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.cap-checkbox:hover {
+  border-color: var(--color-primary);
+}
+
+.cap-checkbox input {
+  accent-color: var(--color-primary);
+  margin: 0;
+}
+
 .permission-workspace {
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);

--- a/apps/admin/src/components/provider-manager.tsx
+++ b/apps/admin/src/components/provider-manager.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from "react";
-import { AlertTriangle, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
+import { AlertTriangle, ListChecks, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
 import { createAdminBrowserClient } from "@/lib/supabase/client";
 import { insertAuditLog } from "@/lib/utils/audit";
 import { PROVIDER_ICONS } from "./provider-icons";
+import { listTeamOptions, type TeamOption } from "@/lib/api/teams";
+import { MODE_LABELS, PROVIDER_GENERATION_CATALOG } from "@/lib/provider-catalog";
 
 export interface ProviderRow {
   id: string;
@@ -123,6 +125,7 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
   const [creating, setCreating] = useState(false);
   const [editing, setEditing] = useState<ProviderRow | null>(null);
   const [deleting, setDeleting] = useState<ProviderRow | null>(null);
+  const [capsProvider, setCapsProvider] = useState<ProviderRow | null>(null);
   const [saving, setSaving] = useState(false);
   const [deletingBusy, setDeletingBusy] = useState(false);
 
@@ -516,6 +519,7 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
                   onToggle={() => toggleProvider(provider)}
                   onEdit={() => setEditing(provider)}
                   onDelete={() => setDeleting(provider)}
+                  onCaps={() => setCapsProvider(provider)}
                 />
               ))
             )}
@@ -547,6 +551,10 @@ export function ProviderManager({ providers: initialProviders }: { providers: Pr
           onConfirm={confirmDelete}
           onClose={() => setDeleting(null)}
         />
+      ) : null}
+
+      {capsProvider ? (
+        <ProviderCapsModal provider={capsProvider} onClose={() => setCapsProvider(null)} />
       ) : null}
     </div>
   );
@@ -730,13 +738,15 @@ function ProviderRowItem({
   busy,
   onToggle,
   onEdit,
-  onDelete
+  onDelete,
+  onCaps
 }: {
   provider: ProviderRow;
   busy: boolean;
   onToggle: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onCaps: () => void;
 }) {
   const IconComp = PROVIDER_ICONS[provider.id];
   const logoUrl = isRemoteLogo(provider.logo) ? provider.logo : null;
@@ -790,6 +800,10 @@ function ProviderRowItem({
           <button className="btn btn-secondary btn-sm" type="button" disabled={busy} onClick={onEdit}>
             <Pencil size={14} />
             编辑
+          </button>
+          <button className="btn btn-secondary btn-sm" type="button" disabled={busy} onClick={onCaps}>
+            <ListChecks size={14} />
+            生成能力
           </button>
           <button className="btn btn-danger btn-sm" type="button" disabled={busy} onClick={onDelete}>
             <Trash2 size={14} />
@@ -1031,6 +1045,248 @@ function ProviderDeleteModal({
           <button className="btn btn-danger btn-sm" type="button" onClick={onConfirm} disabled={busy}>
             <Trash2 />
             {busy ? "删除中..." : "确认删除"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CapsRow {
+  modes: string[];
+  models: string[];
+}
+
+function ProviderCapsModal({ provider, onClose }: { provider: ProviderRow; onClose: () => void }) {
+  const catalog = PROVIDER_GENERATION_CATALOG[provider.id] ?? { modes: [], models: [] };
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  const [scopeKind, setScopeKind] = useState<"global" | "team">("global");
+  const [teamId, setTeamId] = useState("");
+  const [selectedModes, setSelectedModes] = useState<string[]>([]);
+  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const targetId = scopeKind === "team" ? teamId : null;
+
+  const loadCaps = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createAdminBrowserClient();
+      let query = supabase
+        .from("provider_caps")
+        .select("modes, models")
+        .eq("provider", provider.id)
+        .eq("target_type", scopeKind);
+      query = scopeKind === "team" ? query.eq("target_id", teamId) : query.is("target_id", null);
+      const { data, error: qError } = await query.maybeSingle();
+      if (qError) throw qError;
+      const row = (data ?? null) as CapsRow | null;
+      setSelectedModes(row?.modes ?? []);
+      setSelectedModels(row?.models ?? []);
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : (e as { message?: string } | undefined)?.message || String(e);
+      setError(msg || "配置加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [provider.id, scopeKind, teamId]);
+
+  useEffect(() => {
+    void listTeamOptions().then(setTeams).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    // team 范围尚未选择团队时不加载（避免与 global 的 null target 冲突）
+    if (scopeKind === "team" && !teamId) {
+      setSelectedModes([]);
+      setSelectedModels([]);
+      return;
+    }
+    void loadCaps();
+  }, [scopeKind, teamId, loadCaps]);
+
+  function toggleMode(mode: string, checked: boolean) {
+    setSelectedModes((prev) => (checked ? [...prev, mode] : prev.filter((m) => m !== mode)));
+  }
+  function toggleModel(model: string, checked: boolean) {
+    setSelectedModels((prev) => (checked ? [...prev, model] : prev.filter((m) => m !== model)));
+  }
+
+  async function handleSave() {
+    if (scopeKind === "team" && !teamId) {
+      setError("请先选择团队");
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      const supabase = createAdminBrowserClient();
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+      const adminId = user?.id ?? null;
+
+      let del = supabase
+        .from("provider_caps")
+        .delete()
+        .eq("provider", provider.id)
+        .eq("target_type", scopeKind);
+      del = scopeKind === "team" ? del.eq("target_id", teamId) : del.is("target_id", null);
+      const { error: delError } = await del;
+      if (delError) throw delError;
+
+      const { error: insError } = await supabase.from("provider_caps").insert({
+        target_type: scopeKind,
+        target_id: targetId,
+        provider: provider.id,
+        modes: selectedModes,
+        models: selectedModels,
+        updated_by: adminId
+      });
+      if (insError) throw insError;
+
+      await insertAuditLog("providerCaps.upsert", {
+        target: provider.id,
+        metadata: {
+          provider_id: provider.id,
+          targetType: scopeKind,
+          targetId: targetId,
+          modes: selectedModes,
+          models: selectedModels
+        }
+      });
+
+      onClose();
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : (e as { message?: string } | undefined)?.message || String(e);
+      setError(msg || "配置保存失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const scopeLabel = scopeKind === "team" ? `团队：${teams.find((t) => t.id === teamId)?.name ?? "未选择"}` : "全局默认";
+
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">
+            生成能力 · {provider.name}
+          </div>
+          <button className="modal-close" type="button" onClick={onClose} disabled={saving} aria-label="关闭">
+            <X />
+          </button>
+        </div>
+        <div className="modal-body">
+          <p className="form-hint">
+            配置后桌面端该厂商的模式/模型以勾选项为唯一可选；全不勾选＝屏蔽该厂商；该作用域未配置＝桌面端默认值。
+          </p>
+
+          <div className="form-group">
+            <label className="form-label">作用范围</label>
+            <div className="provider-cap-scope">
+              <label className={scopeKind === "global" ? "cap-option active" : "cap-option"}>
+                <input
+                  type="radio"
+                  name="caps-scope"
+                  checked={scopeKind === "global"}
+                  onChange={() => setScopeKind("global")}
+                />
+                全局默认
+              </label>
+              <label className={scopeKind === "team" ? "cap-option active" : "cap-option"}>
+                <input
+                  type="radio"
+                  name="caps-scope"
+                  checked={scopeKind === "team"}
+                  onChange={() => setScopeKind("team")}
+                />
+                指定团队
+              </label>
+            </div>
+          </div>
+
+          {scopeKind === "team" ? (
+            <div className="form-group">
+              <label className="form-label">选择团队</label>
+              <select
+                className="form-select"
+                value={teamId}
+                onChange={(e) => setTeamId(e.target.value)}
+              >
+                <option value="">请选择团队</option>
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {loading ? (
+            <p className="form-hint">加载配置中...</p>
+          ) : (
+            <>
+              <div className="form-group">
+                <label className="form-label">
+                  生成模式（<span style={{ color: "var(--color-destructive)" }}>暂存为 {scopeLabel}</span>）
+                </label>
+                <div className="cap-checkbox-group">
+                  {catalog.modes.length === 0 ? (
+                    <p className="form-hint">该厂商暂无模式目录</p>
+                  ) : (
+                    catalog.modes.map((mode) => (
+                      <label key={mode} className="cap-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={selectedModes.includes(mode)}
+                          onChange={(e) => toggleMode(mode, e.target.checked)}
+                        />
+                        {MODE_LABELS[mode] ?? mode}
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">模型</label>
+                <div className="cap-checkbox-group">
+                  {catalog.models.length === 0 ? (
+                    <p className="form-hint">该厂商暂无模型目录</p>
+                  ) : (
+                    catalog.models.map((model) => (
+                      <label key={model} className="cap-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={selectedModels.includes(model)}
+                          onChange={(e) => toggleModel(model, e.target.checked)}
+                        />
+                        {model}
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {error ? <div className="alert alert-danger">{error}</div> : null}
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary btn-sm" type="button" onClick={onClose} disabled={saving}>
+            取消
+          </button>
+          <button className="btn btn-primary btn-sm" type="button" onClick={handleSave} disabled={saving || loading}>
+            <Save />
+            {saving ? "保存中..." : "保存"}
           </button>
         </div>
       </div>

--- a/apps/admin/src/lib/provider-catalog.ts
+++ b/apps/admin/src/lib/provider-catalog.ts
@@ -1,0 +1,44 @@
+// Provider 生成能力目录（Admin 端勾选候选）。
+// 与桌面端 apps/desktop/src/renderer/src/spec.ts 的 MODELS / providerModeOptions 为镜像关系：
+// 新增厂商/模型时需同步两处。DB provider_caps 一旦配置即为权威（桌面端只显示列表内可选项）。
+
+export interface ProviderGenerationCap {
+  /** 视频生成模式（扁平键）：text2video / img2video / multi_ref / first_last / first_frame */
+  modes: string[];
+  /** 模型清单 */
+  models: string[];
+}
+
+export type ProviderGenerationCatalog = Record<string, ProviderGenerationCap>;
+
+export const MODE_LABELS: Record<string, string> = {
+  text2video: "文生视频",
+  img2video: "图生视频",
+  multi_ref: "多参考生成",
+  first_last: "首尾帧生成",
+  first_frame: "首帧生成"
+};
+
+// 网页厂商默认暴露「文生/图生/多参考/首尾帧」四种扁平模式（对应 spec 的 t2v/img/multi_ref/first_last）
+const DEFAULT_WEB_MODES = ["text2video", "img2video", "multi_ref", "first_last"];
+
+export const PROVIDER_GENERATION_CATALOG: ProviderGenerationCatalog = {
+  doubao: { modes: DEFAULT_WEB_MODES, models: ["Seedance 2.0 Mini"] },
+  jimeng: { modes: DEFAULT_WEB_MODES, models: ["视频 S2.0", "视频 S2.0 Pro"] },
+  qwen: {
+    modes: DEFAULT_WEB_MODES,
+    models: ["万相 2.7", "万相 2.6", "HappyHorse 1.0 Beta"]
+  },
+  qwenwan: {
+    modes: ["multi_ref", "first_last", "first_frame"],
+    models: ["万相 2.7", "万相 2.6", "HappyHorse 1.0 Beta"]
+  },
+  yuanbao: { modes: ["multi_ref"], models: ["混元"] },
+  dola: { modes: ["multi_ref"], models: ["Dreamina Seedance 2.5", "Dreamina Seedance 2.0 Fast", "Dreamina Seedance 1.0"] },
+  kling: { modes: DEFAULT_WEB_MODES, models: ["可灵-标准", "可灵-大师"] },
+  hailuo: { modes: DEFAULT_WEB_MODES, models: ["海螺-标准"] },
+  zhipu: {
+    modes: ["text2video", "img2video", "multi_ref", "first_last"],
+    models: ["cogvideox-flash", "cogvideox-2", "cogvideox-3", "Vidu Q1", "Vidu 2"]
+  }
+};

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import type { AuthUser } from './hooks/useAuth'
 import { useProviders } from './hooks/useProviders'
 import { useJobs } from './hooks/useJobs'
 import { useDesktopPermissions } from './hooks/useDesktopPermissions'
+import { useProviderCaps } from './hooks/useProviderCaps'
 import type { TeamContext, UsageScope, ViewScope } from '@quota-flow/db-supabase'
 import {
   Modal,
@@ -316,6 +317,7 @@ function MainApp({
   }, [user?.id])
 
   const permissions = useDesktopPermissions(user.id, team?.id)
+  const providerCaps = useProviderCaps(user.id, team?.id)
   const visibleTabs = useMemo(
     () => TABS.filter((t) => permissions.features[`tab.${t.id}` as const] !== false),
     [permissions.features]
@@ -496,6 +498,7 @@ function MainApp({
               providers={providers}
               jobs={jobs}
               features={permissions.features}
+              providerCaps={providerCaps}
               regenerateDraft={regenerateDraft}
               materialImages={materialImages}
               onMaterialImagesConsumed={() => setMaterialImages([])}

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -25,6 +25,7 @@ import { ensureFreshSession } from '../auth/session'
 import { VideoThumb } from './VideoThumb'
 import { getInitialShowWebview } from './Modals'
 import type { DesktopFeatureFlags } from '../hooks/useDesktopPermissions'
+import type { ProviderCaps, ProviderCapsMap } from '../hooks/useProviderCaps'
 import { uploadReferenceImage } from '../utils/uploadImage'
 
 const VIP = false
@@ -98,6 +99,7 @@ interface DashboardProps {
   providers: ProvidersResult
   jobs: JobsResult
   features: DesktopFeatureFlags
+  providerCaps: ProviderCapsMap
   regenerateDraft?: RegenerateDraft | null
   /** 素材库「用作参考」注入的图片：添加为图像参考并切到图生/多参考模式 */
   materialImages?: Array<{ path: string; url: string }>
@@ -125,12 +127,20 @@ function normalizeRegenerateMode(providerId: string, rawMode?: string): string {
   return 't2v'
 }
 
+/** 桌面子模式键归一为 admin 目录扁平键，用于与 caps.modes 求交集 */
+function toFlatMode(value: string): string {
+  if (value === 't2v') return 'text2video'
+  if (value === 'img') return 'img2video'
+  return value
+}
+
 function visibleModeOptions(
   provider: string,
   model: string,
-  features: DesktopFeatureFlags
+  features: DesktopFeatureFlags,
+  caps?: ProviderCaps
 ): Array<{ value: string; label: string }> {
-  return providerModeOptions(provider, model).filter((option) => {
+  const base = providerModeOptions(provider, model).filter((option) => {
     if (option.value === 't2v') return features['dispatch.text2video']
     if (option.value === 'img') return features['dispatch.img2video']
     if (option.value === 'multi_ref') return features['dispatch.multi_ref']
@@ -138,6 +148,12 @@ function visibleModeOptions(
     if (option.value === 'first_frame') return features['dispatch.first_frame']
     return true
   })
+  // Admin 配置了厂商级 caps 时，模式列表与 caps.modes 求交集（双层 AND）
+  if (caps?.modes) {
+    const allowed = new Set(caps.modes)
+    return base.filter((option) => allowed.has(toFlatMode(option.value)))
+  }
+  return base
 }
 
 export default function Dashboard({
@@ -153,6 +169,7 @@ export default function Dashboard({
   providers,
   jobs,
   features,
+  providerCaps,
   regenerateDraft,
   materialImages,
   onMaterialImagesConsumed,
@@ -189,15 +206,19 @@ export default function Dashboard({
   const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // Admin 厂商级生成能力：命中 provider_caps 时该厂商模式/模型以配置为准，缺省回退硬编码默认
+  const caps = providerCaps[provider]
+  const modelList = (p: string): string[] => providerCaps[p]?.models ?? MODELS[p] ?? MODELS.doubao
+
   // 历史详情「重新生成」：把历史参数回填到调度台表单，图片走已保存副本路径
   useEffect(() => {
     if (!regenerateDraft) return
     const nextProvider = regenerateDraft.providerId
-    const nextModel = MODELS[nextProvider]?.includes(regenerateDraft.model)
+    const nextModel = modelList(nextProvider).includes(regenerateDraft.model)
       ? regenerateDraft.model
-      : MODELS[nextProvider]?.[0] ?? MODELS.doubao[0]
+      : modelList(nextProvider)[0] ?? MODELS.doubao[0]
     const normalizedMode = normalizeRegenerateMode(nextProvider, regenerateDraft.mode)
-    const nextModes = visibleModeOptions(nextProvider, nextModel, features)
+    const nextModes = visibleModeOptions(nextProvider, nextModel, features, providerCaps[nextProvider])
     const nextMode = nextModes.some((m) => m.value === normalizedMode)
       ? normalizedMode
       : (nextModes[0]?.value ?? 't2v')
@@ -231,18 +252,18 @@ export default function Dashboard({
     return () => {
       cancelled = true
     }
-  }, [regenerateDraft, features, onRegenerateConsumed])
+  }, [regenerateDraft, features, providerCaps, onRegenerateConsumed])
 
   // 素材库「用作参考」：把图片追加为图像参考，并切到当前厂商可用的图生/多参考模式
   useEffect(() => {
     if (!materialImages || materialImages.length === 0) return
     setSavedImagePaths((prev) => [...prev, ...materialImages.map((m) => m.path)])
     setImages((prev) => [...prev, ...materialImages.map((m) => m.url)])
-    const validModes = visibleModeOptions(provider, model, features)
+    const validModes = visibleModeOptions(provider, model, features, caps)
     const imageMode = validModes.find((m) => ['multi_ref', 'img', 'first_last', 'first_frame'].includes(m.value))
     if (imageMode && imageMode.value !== mode) setMode(imageMode.value)
     onMaterialImagesConsumed?.()
-  }, [materialImages, provider, model, features, mode, onMaterialImagesConsumed])
+  }, [materialImages, provider, model, features, caps, mode, onMaterialImagesConsumed])
 
   const activeBoundAggs = useMemo(
     () => provAggs.filter((a) => a.enabled && a.boundCount > 0),
@@ -259,8 +280,8 @@ export default function Dashboard({
   }, [provider, model, providerDurations])
   const durations = durationOptions(provider, model, mode, VIP, selectedDurations)
   const modeOptions = useMemo(
-    () => visibleModeOptions(provider, model, features),
-    [provider, model, features]
+    () => visibleModeOptions(provider, model, features, caps),
+    [provider, model, features, caps]
   )
   const resolutions = resolutionOptions(provider)
   const ratios = ratioOptions(provider)
@@ -282,15 +303,16 @@ export default function Dashboard({
     const valid = providerOptions.map((o) => o.value)
     if (!valid.includes(provider)) {
       const next = valid[0]
+      const nextModel = modelList(next)[0] ?? MODELS.doubao[0]
       setProvider(next)
-      setModel(MODELS[next]?.[0] ?? MODELS.doubao[0])
-      const nextModes = visibleModeOptions(next, MODELS[next]?.[0] ?? MODELS.doubao[0], features)
+      setModel(nextModel)
+      const nextModes = visibleModeOptions(next, nextModel, features, providerCaps[next])
       setMode(nextModes[0]?.value ?? 't2v')
       setImages([])
       setImageFiles([])
       setSavedImagePaths([])
     }
-  }, [providerOptions, provider, features])
+  }, [providerOptions, provider, features, providerCaps])
 
   useEffect(() => {
     if (!durations.some((d) => d.value === duration)) {
@@ -315,14 +337,14 @@ export default function Dashboard({
 
   // 千问生成模式按模型限定；模型变化后若当前模式不可用，自动落到该模型第一个可用模式
   useEffect(() => {
-    const validModes = visibleModeOptions(provider, model, features).map((m) => m.value)
+    const validModes = visibleModeOptions(provider, model, features, caps).map((m) => m.value)
     if (!validModes.includes(mode)) {
       setMode(validModes[0] ?? 't2v')
       setImages([])
       setImageFiles([])
       setSavedImagePaths([])
     }
-  }, [provider, model, mode, features])
+  }, [provider, model, mode, features, caps])
 
   // 主进程生成事件：仅终态（成功/失败）刷新列表，进度事件不触发，避免历史页列表/分页反复闪加载
   useEffect(() => {
@@ -442,7 +464,12 @@ export default function Dashboard({
       setGenError('请先填写 Prompt 描述')
       return
     }
-    const validModes = visibleModeOptions(provider, model, features).map((m) => m.value)
+    // Admin 配置该厂商 models 为空（被屏蔽）时，无可生成模型
+    if (modelList(provider).length === 0) {
+      setGenError('该厂商暂无可生成模型')
+      return
+    }
+    const validModes = visibleModeOptions(provider, model, features, caps).map((m) => m.value)
     if (!validModes.includes(currentMode)) {
       setGenError('当前生成模式已被管理员关闭，请选择可用的生成模式')
       return
@@ -450,7 +477,7 @@ export default function Dashboard({
     const imageCount = savedImagePaths.length + imageFiles.length
     // 文生视频需图片：排除 t2v（网页厂商）与 text2video（智谱 API）两种文案枚举
     if (currentMode !== 't2v' && currentMode !== 'text2video' && imageCount === 0) {
-      const modeLabel = visibleModeOptions(provider, model, features).find((m) => m.value === currentMode)?.label ?? '多参考'
+      const modeLabel = visibleModeOptions(provider, model, features, caps).find((m) => m.value === currentMode)?.label ?? '多参考'
       setGenError(`${modeLabel}需要至少上传一张素材图片`)
       return
     }
@@ -530,7 +557,7 @@ export default function Dashboard({
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, model, features, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, model, features, caps, providerCaps, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -565,9 +592,9 @@ export default function Dashboard({
 
   const onProviderChange = (value: string): void => {
     setProvider(value)
-    const nextModel = MODELS[value]?.[0] ?? MODELS.doubao[0]
+    const nextModel = modelList(value)[0] ?? MODELS.doubao[0]
     setModel(nextModel)
-    const nextModes = visibleModeOptions(value, nextModel, features)
+    const nextModes = visibleModeOptions(value, nextModel, features, providerCaps[value])
     setMode(nextModes[0]?.value ?? 't2v')
     setImages([])
     setImageFiles([])
@@ -585,7 +612,7 @@ export default function Dashboard({
 
   const onModelChange = (value: string): void => {
     setModel(value)
-    const nextModes = visibleModeOptions(provider, value, features)
+    const nextModes = visibleModeOptions(provider, value, features, caps)
     if (!nextModes.some((m) => m.value === mode)) {
       setMode(nextModes[0]?.value ?? 't2v')
       setImages([])
@@ -755,7 +782,7 @@ export default function Dashboard({
                 id="model"
                 value={model}
                 onChange={onModelChange}
-                options={(MODELS[provider] ?? MODELS.doubao).map((m) => ({ value: m, label: m }))}
+                options={modelList(provider).map((m) => ({ value: m, label: m }))}
               />
             </div>
           </div>

--- a/apps/desktop/src/renderer/src/hooks/useProviderCaps.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviderCaps.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { getAuthService } from '../auth/service'
+import { ensureFreshSession } from '../auth/session'
+import { errMsg } from '../utils/error'
+
+/**
+ * 厂商生成能力（modes / models），key = provider id。
+ * 缺省（undefined）＝ 桌面端未配置，回退到 spec.ts 硬编码默认；
+ * 命中行则 modes/models 为该厂商唯一可选项（空数组＝屏蔽）。
+ */
+export interface ProviderCaps {
+  modes?: string[]
+  models?: string[]
+}
+export type ProviderCapsMap = Record<string, ProviderCaps>
+
+interface CapsRow {
+  target_type: 'global' | 'team'
+  target_id: string | null
+  provider: string
+  modes: string[]
+  models: string[]
+}
+
+function applyRows(rows: CapsRow[]): ProviderCapsMap {
+  const map: ProviderCapsMap = {}
+  // 按 provider 分组，写者覆盖：先 global 后 team，team 命中即覆盖 global
+  const order: Record<string, CapsRow[]> = {}
+  for (const row of rows) {
+    ;(order[row.provider] ??= []).push(row)
+  }
+  for (const provider of Object.keys(order)) {
+    const rowsForProvider = order[provider]
+    // 该 provider 有 team 行则取 team 行（纯覆盖）；否则取 global 行
+    const team = rowsForProvider.find((r) => r.target_type === 'team')
+    const picked = team ?? rowsForProvider.find((r) => r.target_type === 'global')
+    if (picked) {
+      map[provider] = {
+        modes: picked.modes ?? [],
+        models: picked.models ?? []
+      }
+    }
+  }
+  return map
+}
+
+export function useProviderCaps(userId?: string, teamId?: string | null): ProviderCapsMap {
+  const [caps, setCaps] = useState<ProviderCapsMap>(() => ({}))
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  const load = useCallback(async () => {
+    if (!userId) {
+      setCaps({})
+      return
+    }
+    const auth = getAuthService()
+    if (!auth) return
+    const guard = await ensureFreshSession()
+    if (!guard.ok) return
+    const client = auth.getClient()
+    try {
+      const { data: globalRows, error: globalError } = await client
+        .from('provider_caps')
+        .select('target_type,target_id,provider,modes,models')
+        .eq('target_type', 'global')
+        .is('target_id', null)
+      if (globalError) throw globalError
+
+      const rows = [...((globalRows ?? []) as CapsRow[])]
+      if (teamId) {
+        const { data: teamRows, error: teamError } = await client
+          .from('provider_caps')
+          .select('target_type,target_id,provider,modes,models')
+          .eq('target_type', 'team')
+          .eq('target_id', teamId)
+        if (teamError) throw teamError
+        rows.push(...((teamRows ?? []) as CapsRow[]))
+      }
+      setCaps(applyRows(rows))
+    } catch (e) {
+      // 能力配置加载失败时保留上次结果，不阻塞调度台（缺省即可用硬编码默认）
+      void errMsg(e)
+    }
+  }, [userId, teamId])
+
+  useEffect(() => {
+    void load()
+  }, [load, reloadKey])
+
+  useEffect(() => {
+    if (!userId) return
+    const auth = getAuthService()
+    if (!auth) return
+    const client = auth.getClient()
+    const channel = client
+      .channel(`provider-caps-changes-${userId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'provider_caps' }, () => {
+        void load()
+      })
+      .subscribe()
+
+    return () => {
+      void client.removeChannel(channel)
+    }
+  }, [userId, load])
+
+  useEffect(() => {
+    const onFocus = (): void => {
+      void load()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [load])
+
+  return useMemo(() => caps, [caps])
+}

--- a/migrations/0030_provider_caps.sql
+++ b/migrations/0030_provider_caps.sql
@@ -1,0 +1,76 @@
+-- 0030_provider_caps.sql
+-- 桌面端厂商「生成能力」控制：控制每个厂商在调度台可选的视频生成模式（modes）与模型（models）。
+-- 缺行（global 与团队均无该 provider 记录）按「使用桌面端硬编码默认」处理；
+-- 一行存在即该 provider 在该 scope 的【唯一可选项】，空数组 = 屏蔽该厂商全部模式/模型。
+-- target_type=global 是全局默认，target_type=team 是团队覆盖（即使为空也覆盖全局）。
+
+CREATE TABLE IF NOT EXISTS public.provider_caps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  target_type text NOT NULL CHECK (target_type IN ('global', 'team')),
+  target_id uuid NULL,                     -- global 为 null；team 为 team.id
+  provider text NOT NULL,                  -- providers.id，如 doubao/zhipu
+  modes text[] NOT NULL DEFAULT '{}',      -- 该厂商允许的视频生成模式集合
+  models text[] NOT NULL DEFAULT '{}',     -- 该厂商允许的模型集合
+  updated_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (target_type, target_id, provider)
+);
+
+COMMENT ON TABLE public.provider_caps IS
+  'Desktop provider generation caps. target_type=global 是全局默认，target_type=team 是团队覆盖；缺行表示使用桌面端默认，存在则 modes/models 为唯一可选项，空数组表示屏蔽。modes 扁平键示例：text2video/img2video/multi_ref/first_last/first_frame。';
+
+CREATE INDEX IF NOT EXISTS idx_provider_caps_target
+  ON public.provider_caps (target_type, target_id, provider);
+
+CREATE INDEX IF NOT EXISTS idx_provider_caps_updated
+  ON public.provider_caps (updated_at DESC);
+
+ALTER TABLE public.provider_caps ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "provider_caps_select_authenticated" ON public.provider_caps;
+CREATE POLICY "provider_caps_select_authenticated"
+  ON public.provider_caps
+  FOR SELECT
+  TO authenticated
+  USING (
+    target_type = 'global'
+    OR (
+      target_type = 'team'
+      AND EXISTS (
+        SELECT 1
+        FROM public.team_members tm
+        WHERE tm.team_id = provider_caps.target_id
+          AND tm.user_id = auth.uid()
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "provider_caps_admin_all" ON public.provider_caps;
+CREATE POLICY "provider_caps_admin_all"
+  ON public.provider_caps
+  FOR ALL
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- 表级权限：authenticated 需显式授权（仅配置 RLS 策略不够，否则 PostgREST 报 permission denied for table）
+GRANT ALL ON TABLE public.provider_caps TO authenticated;
+
+ALTER TABLE public.provider_caps REPLICA IDENTITY FULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'supabase_realtime'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'provider_caps'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.provider_caps;
+  END IF;
+END $$;


### PR DESCRIPTION
## 修改内容

### 1. Admin 厂商管理增强
- provider-manager：新增厂商能力配置面板（模型列表、生成模式、时长选项）
- globals.css：新增厂商能力配置样式

### 2. 桌面端能力 Hook
- 新增 useProviderCaps.ts：从 DB 拉取厂商能力配置，供 Dashboard/Modals 使用
- App.tsx：新增 providerCaps 路由与数据加载

### 3. Dashboard 优化
- Dashboard.tsx：根据厂商能力动态显示生成模式和参数选项

### 4. 数据库迁移
- 0030_provider_caps.sql：厂商能力配置表（models/modes/durations/resolutions）

### 5. 新增文件
- apps/admin/src/lib/provider-catalog.ts
- apps/desktop/src/renderer/src/hooks/useProviderCaps.ts
- migrations/0030_provider_caps.sql