### PR TITLE
feat: 火山方舟 API 接入（免费视频模型额度对接）

### DIFF
--- a/apps/admin/src/lib/provider-catalog.ts
+++ b/apps/admin/src/lib/provider-catalog.ts
@@ -40,5 +40,13 @@ export const PROVIDER_GENERATION_CATALOG: ProviderGenerationCatalog = {
   zhipu: {
     modes: ["text2video", "img2video", "multi_ref", "first_last"],
     models: ["cogvideox-flash", "cogvideox-2", "cogvideox-3", "Vidu Q1", "Vidu 2"]
+  },
+  volcengine: {
+    modes: ["text2video", "img2video"],
+    models: [
+      "doubao-seedance-1-0-pro-250528",
+      "doubao-seedance-1-5-pro-251215",
+      "doubao-seedance-1-0-pro-fast-251015"
+    ]
   }
 };

--- a/apps/desktop/src/main/api-branch.ts
+++ b/apps/desktop/src/main/api-branch.ts
@@ -12,9 +12,15 @@
 
 import type { GenerateInput } from './dispatch'
 import { decodeZhipuPayload } from './providers'
-import { fetchZhipuQuota, zhipuGenerateWithKey } from '@quota-flow/providers'
-import type { ZhipuGenerateOptions } from '@quota-flow/providers'
-import { ipcMain } from 'electron'
+import {
+  decodeVolcenginePayload,
+  fetchZhipuQuota,
+  zhipuGenerateWithKey,
+  volcengineFreeVideoModels,
+  volcengineGenerateWithKey
+} from '@quota-flow/providers'
+import type { VolcengineFreeVideoModel, ZhipuGenerateOptions } from '@quota-flow/providers'
+import { ipcMain, safeStorage } from 'electron'
 
 /** 解密后的 API 厂商凭证（各厂商子集可不同；这里统一宽松字段） */
 export interface ApiCredential {
@@ -53,8 +59,12 @@ export interface ApiGenerationBranch {
   supportedDurations(model?: string): number[]
   /** 真实剩余额度（按次资源包）；无法查询返回 null */
   remaining?(creds: ApiCredential, model: string): Promise<number | null>
-  /** 展示用模型目录（「查看模型」弹窗） */
-  catalog(): ApiModelInfo[]
+  /** 展示用模型目录（「查看模型」弹窗）；perModelFreeQuota 为每账号免费 token 额度叠加层（火山方舟） */
+  catalog(
+    perModelFreeQuota?: Record<string, { remaining?: number; total?: number }>,
+    /** 火山方舟：该账号绑定时实时抓到的免费视频模型（优先于固定目录） */
+    captured?: VolcengineFreeVideoModel[]
+  ): ApiModelInfo[]
   generate(input: GenerateInput, creds: ApiCredential, params: ApiGenerateParams): Promise<ApiGenerateOutcome>
 }
 
@@ -70,6 +80,10 @@ export interface ApiModelInfo {
   size: string | null
   /** 该模型支持生成模式 */
   modes: Array<{ value: string; label: string }>
+  /** 是否已开通该模型（火山方舟未开通模型提示开通；默认 true） */
+  activated?: boolean
+  /** 【每账号】免费 token 额度（火山方舟免费视频模型）：剩余/总数，未抓到为 undefined */
+  freeQuota?: { remaining?: number; total?: number }
 }
 
 const ZHIPU_MODEL_COST: Record<string, number> = {
@@ -191,7 +205,7 @@ export function makeZhipuBranch(): ApiGenerationBranch {
         return null
       }
     },
-    catalog() {
+    catalog(_perModelFreeQuota?: Record<string, { remaining?: number; total?: number }>) {
       return ZHIPU_CATALOG_ORDER.map((model) => ({
         model,
         priceLabel: ZHIPU_MODEL_PRICE[model],
@@ -262,7 +276,89 @@ export function makeZhipuBranch(): ApiGenerationBranch {
 
 /** 已注册的 API 生成分支（key = providerId） */
 export const API_BRANCHES: Record<string, ApiGenerationBranch> = {
-  zhipu: makeZhipuBranch()
+  zhipu: makeZhipuBranch(),
+  volcengine: makeVolcengineBranch()
+}
+
+/** 火山方舟免费视频模型默认时长（未收录固定时长走通用档） */
+const VOLC_ENGINE_MODEL_DURATIONS = [5, 10]
+/** 火山免费视频模型统一支持文生 + 图生（Seedance 均有免费推理额度） */
+const VOLC_ENGINE_MODEL_MODES: Array<{ value: string; label: string }> = [
+  { value: 'text2video', label: '文生视频' },
+  { value: 'img2video', label: '图生视频' }
+]
+
+function makeVolcengineBranch(): ApiGenerationBranch {
+  const freeModels = volcengineFreeVideoModels()
+  return {
+    id: 'volcengine',
+    displayName: '火山方舟',
+    unitName: '次',
+    parseCredentials(decrypted) {
+      try {
+        const { apiKey, consoleJwt } = decodeVolcenginePayload(decrypted)
+        if (!apiKey) return null
+        return { apiKey, consoleJwt: consoleJwt ?? null }
+      } catch {
+        return null
+      }
+    },
+    cost() {
+      // 本轮火山方舟接入的均为免费视频模型，cost=0
+      return 0
+    },
+    supportedDurations() {
+      return VOLC_ENGINE_MODEL_DURATIONS
+    },
+    async remaining() {
+      // 免费 token 额度按账号、且无公开 API 可读；实时额度走本地账本，此处返回 null 表示未知。
+      return null
+    },
+    catalog(perModelFreeQuota, captured?: VolcengineFreeVideoModel[]) {
+      // 优先使用该账号绑定时实时抓到的免费模型目录；未抓到则回退内置固定目录
+      const base = Array.isArray(captured) && captured.length > 0 ? captured : freeModels
+      // 内置目录按 id 的默认免费额度，作为兜底：账号负载里存的旧模型缺 freeQuota 时，仍能展示具体 token 量
+      const defaultQuota = new Map(freeModels.map((m) => [m.id, m.freeQuota]))
+      return base.map((m) => ({
+        model: m.id,
+        priceLabel: m.price,
+        cost: 0,
+        durations: VOLC_ENGINE_MODEL_DURATIONS,
+        size: null,
+        modes: VOLC_ENGINE_MODEL_MODES,
+        activated: m.activated,
+        freeQuota: perModelFreeQuota?.[m.id] ?? m.freeQuota ?? defaultQuota.get(m.id)
+      }))
+    },
+    async generate(input, creds, params) {
+      if (params.mode !== 'text2video' && params.mode !== 'img2video') {
+        return { ok: false, error: '火山方舟当前仅支持文生视频 / 图生视频' }
+      }
+      const images = (params.images ?? []).filter((u) => /^https?:\/\//i.test(u))
+      // 图生视频需公网图片 URL（已由调度台上传 Supabase 取 https 地址）
+      const r = await volcengineGenerateWithKey(
+        creds.apiKey,
+        {
+          mode: params.mode,
+          model: params.model,
+          prompt: params.prompt,
+          images,
+          durationSec: params.durationSec,
+          audio: (input.audio === 'off' ? 'off' : 'on') as 'on' | 'off',
+          ratio: input.ratio,
+          resolution: input.resolution
+        },
+        params.onProgress
+      )
+      return {
+        ok: r.ok,
+        videoUrl: r.videoUrl,
+        coverImageUrl: r.coverImageUrl,
+        traceId: r.traceId,
+        error: r.error
+      }
+    }
+  }
 }
 
 let apiIpcRegistered = false
@@ -272,9 +368,25 @@ export function registerApiIpc(): void {
   if (apiIpcRegistered) return
   apiIpcRegistered = true
 
-  ipcMain.handle('provider:api-models', async (_e, providerId: string) => {
+  ipcMain.handle('provider:api-models', async (_e, providerId: string, encrypted?: string) => {
     const branch = API_BRANCHES[providerId]
     if (!branch) return { ok: false, error: '不支持的 API 厂商' }
-    return { ok: true, models: branch.catalog() }
+    // 火山方舟：解密该账号负载里的每模型免费 token 额度 + 实时抓到的模型目录，叠加到目录上展示
+    let perModelFreeQuota: Record<string, { remaining?: number; total?: number }> | undefined
+    let captured: VolcengineFreeVideoModel[] | undefined
+    if (providerId === 'volcengine' && typeof encrypted === 'string' && encrypted) {
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
+        const { models } = decodeVolcenginePayload(plain)
+        captured = models
+        if (Array.isArray(models)) {
+          perModelFreeQuota = {}
+          for (const m of models) {
+            if (m?.id && m.freeQuota) perModelFreeQuota[m.id] = m.freeQuota
+          }
+        }
+      } catch {}
+    }
+    return { ok: true, models: branch.catalog(perModelFreeQuota, captured) }
   })
 }

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -50,6 +50,8 @@ export interface QuotaUpdatedPayload {
   ledger: QuotaLedgerRow
   /** API 型厂商（智谱）生成成功后触发：渲染层据此重新拉取该账号真实额度 */
   zhipuRefreshKeyId?: string
+  /** 火山方舟生成成功后触发：渲染层据此静默同步该账号免费模型真实剩余额度 */
+  volcRefreshKeyId?: string
 }
 
 const UA =
@@ -760,8 +762,8 @@ async function runApiBranch(
     data: { resultUrl, cost, localPath, accountId: cand.id }
   })
 
-  // 智谱本地账本不做原子扣减（真实额度在平台资源包），仅记录 costAmount 展示；
-  // 生成完成后下发 zhipuRefreshKeyId，渲染层据此重新拉取该账号真实余额。
+  // API 型厂商本地账本不做原子扣减（真实额度在平台）；生成完成后下发热点字段，
+  // 渲染层据此重新拉取/同步该账号真实额度：智谱走 fetch-quota，火山走开通管理页静默同步。
   onQuotaUpdated?.({
     userId: input.userId,
     ledger: {
@@ -778,7 +780,7 @@ async function runApiBranch(
       reserved: 0,
       refreshed_at: new Date().toISOString()
     },
-    zhipuRefreshKeyId: cand.id
+    ...(providerId === 'volcengine' ? { volcRefreshKeyId: cand.id } : { zhipuRefreshKeyId: cand.id })
   })
   return { ok: true, jobId: job.id }
 }

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -1,9 +1,20 @@
 import { createHash } from 'crypto'
-import { app, BrowserWindow, ipcMain, safeStorage, session } from 'electron'
+import { app, BrowserWindow, ipcMain, safeStorage, session, shell } from 'electron'
 import type { Cookie } from 'electron'
 import { appendFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { fetchZhipuQuota, testZhipuApiKey } from '@quota-flow/providers'
+import {
+  fetchZhipuQuota,
+  testZhipuApiKey,
+  fetchVolcengineQuota,
+  testVolcengineApiKey,
+  volcengineAccountFingerprint,
+  decodeVolcenginePayload,
+  jwtExpiryMs,
+  captureVolcengineFreeVideoModels,
+  VOLCENGINE_FREE_NAME_TO_ID
+} from '@quota-flow/providers'
+import type { VolcengineFreeVideoModel } from '@quota-flow/providers'
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
@@ -105,6 +116,7 @@ function zhipuConsolePartitionFor(keyId?: string): string {
 }
 function partitionFor(providerId: string, keyId?: string): string {
   if (providerId === 'zhipu') return zhipuConsolePartitionFor(keyId)
+  if (providerId === 'volcengine') return volcConsolePartitionFor(keyId)
   const base = 'persist:qf-p:' + providerId
   return keyId ? `${base}:${keyId}` : base
 }
@@ -672,12 +684,15 @@ async function openProviderSite(
   keyId: string,
   encryptedKey?: string
 ): Promise<{ ok: boolean; error?: string }> {
-  // 智谱（bigmodel）：打开该账号控制台，使用按账号隔离的分区（persist:qf-zhipu-console:<keyId>）免重复登录且不串号
+  // 智谱（bigmodel）/ 火山方舟（volcengine）：打开该账号控制台，使用按账号隔离的分区免重复登录且不串号
   let url: string | undefined
   let partition: string
   let injectableEncrypted: string | undefined
   if (providerId === 'zhipu') {
     url = ZHIPU_CONSOLE_URL
+    partition = partitionFor(providerId, keyId)
+  } else if (providerId === 'volcengine') {
+    url = VOLC_CONSOLE_URL
     partition = partitionFor(providerId, keyId)
   } else {
     const site = providerSite(providerId)
@@ -1011,6 +1026,33 @@ function zhipuConsoleSession(keyId?: string): Electron.Session {
   return session.fromPartition(zhipuConsolePartitionFor(keyId))
 }
 
+// 火山方舟控制台会话捕获：与智谱同套路（打开控制台、注入拦截器捕获 Bearer JWT），
+// 但分区、URL、注入全局名各自独立，避免与智谱会话互串。
+// 火山控制台请求带 AK/SK 签名头与会话 cookie，主进程无法重放；先在捕获窗口页内注入 hook 取回令牌，
+// 后续额度探测（方案 §6）在捕获分区页内同源执行。
+const VOLC_CONSOLE_URL = 'https://console.volcengine.com/ark/region:cn-beijing/apikey'
+// 火山「开通管理→视觉模型」页：免费视频模型额度/开通状态所在页（额度同步抓取用；tab=ComputerVision 为视觉模型分类）
+const VOLC_OPEN_MANAGEMENT_URL =
+  'https://console.volcengine.com/ark/region:cn-beijing/openManagement?tab=ComputerVision'
+const VOLC_CONSOLE_PARTITION = 'persist:qf-volc-console'
+/** 火山控制台分区按账号隔离：persist:qf-volc-console[:keyId]，避免多账号串会话 */
+function volcConsolePartitionFor(keyId?: string): string {
+  return keyId ? `${VOLC_CONSOLE_PARTITION}:${keyId}` : VOLC_CONSOLE_PARTITION
+}
+function volcEngineConsoleSession(keyId?: string): Electron.Session {
+  return session.fromPartition(volcConsolePartitionFor(keyId))
+}
+/** 火山同步诊断日志（userData/volc-sync.log）：排查静默抓取为何未命中控制台免费模型 */
+function logVolcSync(line: string): void {
+  try {
+    appendFileSync(join(app.getPath('userData'), 'volc-sync.log'), `[${new Date().toISOString()}] ${line}\n`)
+  } catch {
+    // ignore
+  }
+}
+/** 静默续期窗口最多等待时长（毫秒） */
+const VOLC_QUIET_RENEW_TIMEOUT_MS = 25000
+
 /** 静默续期窗口最多等待时长（毫秒）；超时仍未捕获到新 JWT，视为控制台登录态已失效 */
 const ZHIPU_QUIET_RENEW_TIMEOUT_MS = 25000
 
@@ -1272,6 +1314,766 @@ export async function captureZhipuConsoleSession(opts?: {
   })
 }
 
+/**
+ * 火山方舟控制台会话捕获 / 静默续期（与智谱 captureZhipuConsoleSession 同套路，独立分区/URL/全局名）。
+ * @param opts.quiet true: 隐藏窗口静默重捕获（续期用，保留登录态 cookie）；缺省: 首次绑定交互式捕获。
+ */
+export async function captureVolcEngineConsoleSession(opts?: {
+  quiet?: boolean
+  keyId?: string
+  oldConsoleJwt?: string | null
+  /** 会话窗口初始加载的 URL；缺省为 API Key 管理页。传开通管理页可静默抓取最新免费额度（sync） */
+  targetUrl?: string
+  /** true 表示「额度同步」模式：静默轮询时同时读取 __VF_MODELS__ 并返回最新 models；缺省为仅绑定/续期的会话捕获 */
+  syncModels?: boolean
+}): Promise<{ ok: boolean; consoleJwt?: string; accountId?: string; models?: VolcengineFreeVideoModel[]; source?: 'console' | 'fallback'; error?: string }> {
+  const quiet = !!opts?.quiet
+  const syncModels = !!opts?.syncModels
+  const optKeyId = opts?.keyId
+  const winKey = `${quiet ? 'volc-console-quiet' : 'volc-console'}:${optKeyId ?? 'shared'}`
+  const oldConsoleJwt = opts?.oldConsoleJwt
+  const existing = loginWindows.get(winKey)
+  if (existing && !existing.isDestroyed()) {
+    existing.focus()
+    return { ok: false, error: quiet ? '会话续期进行中' : '火山方舟控制台窗口已打开' }
+  }
+
+  // 首次绑定需清空登录态存储避免残留；静默续期必须保留 cookie
+  if (!quiet) {
+    try {
+      await volcEngineConsoleSession(optKeyId).clearStorageData()
+    } catch {}
+  }
+  const ses = volcEngineConsoleSession(optKeyId)
+
+  const win = new BrowserWindow({
+    width: 1120,
+    height: 800,
+    minWidth: 900,
+    minHeight: 600,
+    show: !quiet,
+    paintWhenInitiallyHidden: true,
+    autoHideMenuBar: true,
+    title: quiet ? '火山方舟控制台 - Quota-Flow' : 'Quota-Flow · 火山方舟控制台',
+    backgroundColor: '#ffffff',
+    webPreferences: {
+      partition: volcConsolePartitionFor(optKeyId),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+  ses.setUserAgent(CHROME_UA)
+  win.webContents.setUserAgent(CHROME_UA)
+  // 拦截非 http(s) 协议跳转（如 bytedance:// 深链），避免触发 Windows 系统级「获取打开此链接的应用」弹窗。
+  // 火山控制台第三方登录（抖音/头条/穿山甲等）才会走这类深链，绑定流程推荐使用手机号/账号登录，完全走 http(s)。
+  const BLOCKED_PROTO_RE = /^(?!https?:)[a-z][a-z0-9+.-]*:/i
+  win.webContents.on('will-navigate', (ev, url) => {
+    if (BLOCKED_PROTO_RE.test(url)) {
+      ev.preventDefault()
+      void win.webContents
+        .executeJavaScript(
+          `(function(){try{window.__VF_BLOCKED=window.__VF_BLOCKED||[];window.__VF_BLOCKED.push(${JSON.stringify(url)});}catch(_){}})()`
+        )
+        .catch(() => {})
+    }
+  })
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (BLOCKED_PROTO_RE.test(url)) return { action: 'deny' }
+    return { action: 'allow' }
+  })
+  loginWindows.set(winKey, win)
+  void win.loadURL(opts?.targetUrl || VOLC_CONSOLE_URL).catch(() => {})
+
+  const INJECT = `(() => {
+    if (window.__QUOTA_FLOW_VOLC__) return;
+    window.__QUOTA_FLOW_VOLC__ = true;
+    window.__VF_CAPTURED__ = window.__VF_CAPTURED__ || null;
+    window.__VF_ACCOUNT__ = window.__VF_ACCOUNT__ || null;
+    // 账号标识写入 + 落 localStorage：volc 控制台从「开通管理」切到「API Key 管理」是整页跳转(非 SPA)，
+    // 页面全局 __VF_ACCOUNT__ 会被清空；持久化到同源 localStorage(按分区隔离)后，任何一次整页加载都能恢复。
+    const persistAccount = (id) => {
+      try { window.__VF_ACCOUNT__ = id; window.localStorage.setItem('qf:volc:account', String(id)); } catch (_) {}
+    };
+    try { const _a = window.localStorage.getItem('qf:volc:account'); if (_a && !window.__VF_ACCOUNT__) window.__VF_ACCOUNT__ = _a; } catch (_) {}
+    window.__VF_SUBMIT__ = false;
+    const JWT_RE = /(eyJ[A-Za-z0-9_-]{5,}\\.[A-Za-z0-9_-]{5,}\\.[A-Za-z0-9_-]{5,})/;
+    const store = (v) => {
+      if (typeof v === 'string' && v) {
+        const m = v.match(JWT_RE);
+        if (m) { window.__VF_CAPTURED__ = window.__VF_CAPTURED__ || m[0]; }
+      }
+    };
+    // 额度接口探测（方案 §6）：记录火山相关的 fetch/XHR 请求，便于运行期实抓额度接口
+    const isProbeUrl = (u) => u && /ark|openmanagement|quota|resource|package|project|apikey|account|user/i.test(u);
+    const probeLog = (method, u) => {
+      try { if (isProbeUrl(u)) console.log('[volc-console] ' + method + ' ' + String(u).slice(0, 300)); } catch (_) {}
+    };
+    // 账号标识探测（去重）：从控制台接口响应体里找稳定账号 id（uid/account_id/user_id 等），
+    // 同一火山账号的多个 API Key 共享同一账户，据此做账号级指纹去重。抓不到则回退 API Key 哈希。
+    const ACCOUNT_KEY_RE = /["']?(?:uid|userId|user_id|accountId|account_id|loginname|login_name|customer_id)["']?\\s*[:=]\\s*["']?(\\d{6,20})/i;
+    // 火山方舟账户 id 最可靠的真实载体是开通管理页资源的存储桶名：ark-auto-{accountId}-cn-beijing-default。
+    // （如 ListModelChargeItems 响应 FeaturedImage.BucketName = "ark-auto-2100466578-cn-..."）
+    // 这比 whitelist 里偶发的 JSON 字段（含 bot 预设模板静态 AccountId）更专属于「当前登录账号」，用于去重更稳。
+    const BUCKET_ACCOUNT_RE = /ark-(?:auto-)?(\\d{6,20})-cn-/i;
+    const extractAccount = (text) => {
+      if (typeof text !== 'string' || !text || window.__VF_ACCOUNT__) return;
+      // 优先 whitelist 字段；无则用存储桶名兜底（专属性区分账号）
+      const m = text.match(ACCOUNT_KEY_RE) || text.match(BUCKET_ACCOUNT_RE);
+      if (m && m[1]) persistAccount(m[1]);
+    };
+    // 开通管理页模型接口：网上承载「freeQuota / quota / activated / modelId」的响应体
+    // 直接解析出模型列表并入 window.__VF_MODELS_RAW__，避免依赖分页 DOM（wan 在第二页）。
+    window.__VF_MODELS_RAW__ = window.__VF_MODELS_RAW__ || [];
+    window.__VF_SAVED_RAW__ = window.__VF_SAVED_RAW__ || null;
+    const isModelJson = (text) => {
+      if (typeof text !== 'string' || text.length < 40) return false;
+      // 优先按「真实模型 id 内容」命中：模型列表/额度接口的响应体必然包含具体模型标识
+      // （wan2-1-14b、doubao-seedance-1-0-pro 等）。这比按 quota 字段名更可靠——火山接口
+      // 字段命名多变，但模型 id / 名称字符串是稳定的。
+      if (/wan2\s*-?\s*1\s*-?\s*14b|wan2-1-14b/i.test(text)) return true;
+      if (/doubao-seedance\s*-?\s*1-0-pro|doubao-seedance-1-0-pro/i.test(text)) return true;
+      if (/doubao-seedance/i.test(text) && /quota|token|额度|剩|免费/i.test(text)) return true;
+      if (/wan\s*-\s*1-14b|wan-1-14b/i.test(text)) return true;
+      // 兜底：仍是额度+模型名双条件
+      return (/freeQuota|free_quota|quota|token|额度/.test(text)) &&
+             (/wan|seedance|doubao|deepseek|模型|Model/i.test(text));
+    };
+    // 接口级模型额度捕获（正解）：直接解析火山开通管理页的 ListModelTokenLimit / ListModelRateLimit
+    // 响应体，拿到每个模型的真实免费额度与开通状态，彻底摆脱分页 DOM。响应可能分多次（翻页）返回，
+    // 这里按模型名累积合并，用窗口变量暴露给主进程回传。
+    window.__VF_TOKEN_LIMITS__ = window.__VF_TOKEN_LIMITS__ || {}; // modelName -> { tokenLimit, currentUsage }
+    window.__VF_HAS_RATE__ = window.__VF_HAS_RATE__ || false;      // 是否抓到模型全量列表
+    const ingestInterface = (url, text) => {
+      try {
+        if (typeof text !== 'string' || text.length < 30) return;
+        const j = JSON.parse(text);
+        const action = j && j.ResponseMetadata && j.ResponseMetadata.Action;
+        const res = j && j.Result;
+        if (action === 'ListModelTokenLimit' && res && Array.isArray(res.ModelTokenLimits)) {
+          for (const it of res.ModelTokenLimits) {
+            if (!it || typeof it.FoundationModelName !== 'string') continue;
+            const n = it.FoundationModelName.trim();
+            const tok = Number(it.TokenLimit) || 0;
+            window.__VF_TOKEN_LIMITS__[n] = { tokenLimit: tok, currentUsage: Number(it.CurrentUsage) || 0 };
+          }
+        } else if (action === 'ListModelRateLimit' && res && Array.isArray(res.Items)) {
+          window.__VF_HAS_RATE__ = true;
+        } else if (action === 'ListModelChargeItems') {
+          // 账号标识权威源：开通管理页模型列表的 FeaturedImage.BucketName 形如 ark-auto-{accountId}-cn-beijing-default，
+          // 这是「当前登录账号」的专有 id，比 bot 预设模板的静态 AccountId 可靠，拿来回填账号级指纹去重键。
+          const bm = (text).match(/ark-(?:auto-)?(\\d{6,20})-cn-/i);
+          if (bm && bm[1]) persistAccount(bm[1]);
+        }
+      } catch (_) {}
+    };
+    const tryParseModels = (url, text) => {
+      try {
+        const isModel = isModelJson(text);
+        if (!isModel) return;
+        const decis = /wan2\s*-?\s*1\s*-?\s*14b|doubao-seedance|wan-1-14b/i.test(text);
+        if (decis || !window.__VF_MODEL_BODY__ || text.length > window.__VF_MODEL_BODY__.length) {
+          const capped = text.length > 20000 ? text.slice(0, 20000) : text;
+          window.__VF_MODEL_BODY__ = capped;
+        }
+        const rec = { t: Date.now(), url: String(url || '').slice(0, 300), body: text.slice(0, 8000) };
+        window.__VF_MODELS_RAW__.push(rec);
+        if (window.__VF_MODELS_RAW__.length > 60) window.__VF_MODELS_RAW__.shift();
+        if (!window.__VF_SAVED_RAW__ || text.length > window.__VF_SAVED_RAW__.length) window.__VF_SAVED_RAW__ = text;
+      } catch (_) {}
+    };
+    const feedModels = (url, text) => { try { if (typeof text === 'string') tryParseModels(url, text); } catch (_) {} };
+    // 1) hook fetch
+    const origFetch = window.fetch;
+    if (origFetch) {
+      window.fetch = function (...args) {
+        try {
+          const url = typeof args[0] === 'string' ? args[0] : (args[0]?.url || '');
+          probeLog('fetch', url);
+          const init = args[1] || {};
+          const h = init.headers;
+          const getAuth = () => {
+            try {
+              if (h instanceof Headers) return h.get('authorization');
+              if (Array.isArray(h)) { const f = h.find((kv) => (kv[0] || '').toLowerCase() === 'authorization'); return f ? f[1] : undefined; }
+              if (h && typeof h === 'object') return h['authorization'] || h['Authorization'];
+            } catch (_) {}
+            return undefined;
+          };
+          const a = getAuth();
+          if (a) { store(String(a).replace(/^Bearer\\s+/i, '')); }
+        } catch (_) {}
+        const p = origFetch.apply(this, args);
+        try {
+          p.then((resp) => {
+            try { resp.clone().text().then((txt) => { extractAccount(txt); feedModels(url, txt); ingestInterface(url, txt); }); } catch (_) {}
+          }).catch(() => {});
+        } catch (_) {}
+        return p;
+      };
+    }
+    // 2) hook XMLHttpRequest（axios 底层）
+    const origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function (m, u, ...rest) {
+      try { window.__VF_XHR__ = { method: m, url: u }; } catch (_) {}
+      return origOpen.apply(this, [m, u, ...rest]);
+    };
+    const origSet = XMLHttpRequest.prototype.setRequestHeader;
+    XMLHttpRequest.prototype.setRequestHeader = function (k, v) {
+      try { if (String(k).toLowerCase() === 'authorization') store(String(v).replace(/^Bearer\\s+/i, '')); } catch (_) {}
+      return origSet.apply(this, arguments);
+    };
+    const origSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.send = function (...rest) {
+      try {
+        if (window.__VF_XHR__) {
+          const probeUrl = String(window.__VF_XHR__.url || '');
+          probeLog(window.__VF_XHR__.method, probeUrl);
+        }
+        if (typeof this.responseText !== 'undefined' && window.__VF_XHR__) {
+          const self = this;
+          const xUrl = String(window.__VF_XHR__.url || '');
+          try { this.addEventListener('load', function () { try { const t = self.responseText || ''; extractAccount(t); feedModels(xUrl, t); ingestInterface(xUrl, t); } catch (_) {} }); } catch (_) {}
+        }
+      } catch (_) {}
+      return origSend.apply(this, rest);
+    };
+    // 3) 兜底：定时扫描本地存储
+    const scanStorage = () => {
+      for (const name of ['localStorage', 'sessionStorage']) {
+        try {
+          const s = window[name];
+          if (!s) continue;
+          for (let i = 0; i < s.length; i++) {
+            const k = s.key(i);
+            if (!k) continue;
+            const v = s.getItem(k);
+            if (v && typeof v === 'string') { store(v); extractAccount(v); }
+          }
+        } catch (_) {}
+      }
+      // 账号标识还常以 query 形式出现在登录/管理页 URL（如 ?accountId=2100000825）
+      try { extractAccount(location.href); } catch (_) {}
+    };
+    window.__VF_SCAN__ = setInterval(scanStorage, 1500);
+    scanStorage();
+    // 3.5) 「绑定即抓模型」：扫描「开通管理→视觉模型」页 DOM，识别带免费推理额度文案的模型。
+    //      门禁是「有免费额度 + 开通状态」而非模型名前缀：页面同屏还混有图像（Seedream）与 3D
+    //      （Seed3D/Hyper3D/Hitem3D）模型且它们也有免费额度，故抓取层只负责如实上报「卡片名 + 额度 +
+    //      是否已开通」，是否属于「视频生成模型」由 providers 权威层按视频家族过滤（不依赖前缀）。
+    window.__VF_MODELS__ = window.__VF_MODELS__ || [];
+    // 「开通管理→视觉模型」卡片文本 =「模型名 + 未开通/已开通 + 厂商 + 免费推理额度 剩x / 共y token + 开通/退订」。
+    // 免费额度文本格式实测为「剩 x / 共 y token」（含剩/共前缀）；没有任何 free token 的模型（如 2.x 系列）不收录。
+    const volcQuotaRe = /(?:剩|剩余)\\s*([\\d,]+)\\s*\\/\\s*共?\\s*([\\d,]+)\\s*(?:token|Token|Tokens)?/i;
+    const volcStatusRe = /已开通|未开通|尚未开通|待开通|去开通/i;
+    const volcHasFreeRe = /免费推理额度|免费额度|剩\\s*[\\d,]+\\s*\\/\\s*共/i;
+    const scrapeFreeModels = () => {
+      try {
+        if (window.__VF_MODELS__.length >= 40) return; // 上限防抖（含图像/3D，宽收集后由类型层过滤）
+        const els = document.querySelectorAll('body *');
+        for (let i = 0; i < els.length; i++) {
+          const el = els[i];
+          const own = (el.textContent || '').replace(/\s+/g, ' ').trim();
+          // 护栏：去掉整段聚合容器（含多张卡片的整页/整块列表节点，own 文本很长）——它不是单张卡片，
+          //       进行下去会把其它卡片的免费额度文本当作本模型的额度，导致无免费额度的模型被误判成有。与模型名/版本无关。
+          if (own.length > 200) continue;
+          // 仅当该元素自带「开通状态」时视其为卡片信息承载层（避免对整页祖先重复处理）
+          const stM = own.match(volcStatusRe);
+          if (!stM) continue;
+          // 以卡片自身的状态文案判定是否已开通：未开通/尚未开通/待开通/去开通 → false；其余（已开通）→ true。
+          // 不能在祖先层探测不到「未开通」时留 undefined，否则合并层会沿用内置默认值，新开通模型永远停在「待开通」。
+          const isPendingStatus = /未开通|尚未开通|待开通|去开通/.test(stM[0] || '');
+          const name = own.slice(0, stM.index).trim().split(/\\s+/)[0] || '';
+          if (!name) continue;
+          // 该模型名是否为深描的别扭前段（多个合成词被拆出的残片，如只剩厂商名）——以非模型词作护栏，遇中文/纯厂商名时跳过
+          if (/[\\u4e00-\\u9fa5]/.test(name)) continue;
+          if (window.__VF_MODELS__.some((m) => m.name === name)) continue;
+          // 沿祖先向上寻找该模型的“卡片”：就近取首个同时含额度/开通状态信息的容器
+          let container = el;
+          let quota = null, notActivated = false, hasFree = false;
+          for (let depth = 0; container && depth < 8; container = container.parentElement, depth++) {
+            const t = (container.textContent || '').replace(/\\s+/g, ' ').trim();
+            const q = t.match(volcQuotaRe);
+            const na = /未开通|尚未开通|待开通|去开通/i.test(t);
+            if (q) quota = q;
+            if (volcHasFreeRe.test(t)) hasFree = true;
+            if (na) notActivated = true;
+            if (q || na) break; // 就近取实时信息层（继续向上会泛化到整页）
+          }
+          // 门禁：有免费推理额度才收录（无 free token 的模型如 2.x 系列不混入）
+          if (!quota || !hasFree) continue;
+          window.__VF_MODELS__.push({
+            name,
+            remaining: Number(quota[1].replace(/,/g, '')),
+            total: Number(quota[2].replace(/,/g, '')),
+            activated: isPendingStatus ? false : true
+          });
+        }
+      } catch (_) {}
+    };
+    window.__VF_SCAN2__ = setInterval(scrapeFreeModels, 2000);
+    scrapeFreeModels();
+    // 改版后开通管理页为「表格」布局（列：模型名/提供方、状态、免费推理额度、在线推理定价…）。
+    // 表格逐屏虚拟渲染，Wan/Seedance-1.0 等有额度模型常在列表深处：新增面向表格行的抓取，
+    // 采用「逐屏渐进滚动 + 每屏解析 [role=row]」：滚动到一屏就收录该屏有免费额度的行，再继续下一屏，
+    // 不直接跳到底（跳底会漏掉中间所有已刻录屏），保证 wan/lite/seedance1.0 全部收录。
+    const scrapeTableRows = () => {
+      try {
+        if (window.__VF_MODELS__.length >= 40) return;
+        const rows = document.querySelectorAll('[role=row], table tr');
+        for (let i = 0; i < rows.length; i++) {
+          const el = rows[i];
+          const t = (el.textContent || '').replace(/\s+/g, ' ').trim();
+          // 表头行（无模型名且多为中文列名），跳过
+          if (!t || t.length > 400 || /^模型名|^提供方|^状态$/.test(t)) continue;
+          const q = t.match(volcQuotaRe);
+          // 门禁：行内必须带「剩 x /共 y token」免费推理额度才收录（2.x 无免费额度的行不混入）
+          if (!q) continue;
+          // 取自提供方(中文)前的连续模型名 token：行首第一个无中文的连续串即模型名。
+          // 表格行常把模型名连写重复多次（如 Doubao-Seedance-1.5-pro …×3 且无空格），取最小重复周期去重。
+          const nm = t.match(/^[A-Za-z][A-Za-z0-9._-]*/);
+          let name = nm ? nm[0] : '';
+          if (name) {
+            const dup = name.match(/^(.+?)\\1+$/);
+            if (dup && dup[1].length > 1) name = dup[1];
+          }
+          if (!name || /[\\u4e00-\\u9fa5]/.test(name)) continue;
+          // 开通状态：行文本含「未开通/待开通/去开通」→ 未开通；否则视为已开通
+          const notActivated = /未开通|尚未开通|待开通|去开通/i.test(t);
+          if (window.__VF_MODELS__.some((m) => m.name === name)) continue;
+          window.__VF_MODELS__.push({
+            name,
+            remaining: Number(q[1].replace(/,/g, '')),
+            total: Number(q[2].replace(/,/g, '')),
+            activated: notActivated ? false : true
+          });
+        }
+      } catch (_) {}
+    };
+    let vfScreenIdx = 0;
+    // 额度同步模式：逐屏渐进滚动所有可滚动容器，一屏一屏往下，滚动一屏就解析该屏表格行。
+    // 每次滚一屏而非直接到底，避免跳底导致中间屏幕的模型行未渲染而漏收。
+    if (${syncModels ? 'true' : 'false'}) {
+      // 接口级额度同步：开通管理页视觉模型表是 Arco 分页（每页 10 条），wan 等免费模型在第二/末页。
+      // 真正额度在 ListModelTokenLimit 接口（分页返回），翻到哪页才请求哪页。故这里自动点「下一页」，
+      // 触发后续页面的额度接口请求，由 ingestInterface 累积到 window.__VF_TOKEN_LIMITS__。
+      // 点击按钮本身可能触发滑动/滚动，这里每轮点一次下一页（或用滚动作为兜底），点到无法前进即停。
+      window.__VF_AUTOSCROLL__ = setInterval(function () {
+        try {
+          // 1) Arco 分页「下一页」：定位分页容器 → 记录当前页码与 next 按钮；多事件派发高仿真点击触发翻页。
+          var nextBtn = null;
+          var pages = document.querySelectorAll('[class*="arco-pagination"],[class*="pagination"]');
+          for (var pi = 0; pi < pages.length && !nextBtn; pi++) {
+            var pitms = pages[pi].querySelectorAll('[class*="pagination-item"],[class*="pagination-list"] li');
+            for (var pj = 0; pj < pitms.length; pj++) {
+              var pel = pitms[pj];
+              var pc = String(pel.className || '');
+              var ptx = (pel.getAttribute('title') || '') + ' ' + (pel.getAttribute('aria-label') || '') + ' ' + (pel.textContent || '').replace(/\\s+/g, '');
+              // 当前页：class 含 current 或 active（兼容 -current / -active 两种命名），文本解析成页码
+              if (/pagination-item-(current|active)/.test(pc)) {
+                var pm = /(\\d+)/.exec((pel.textContent || '').trim());
+                if (pm && pm[1] !== String(window.__VF_PAGE__ || '')) window.__VF_PAGE__ = parseInt(pm[1], 10);
+              }
+              // next：class 含 next，或 title/aria/文本命中「下一页」
+              if (/next/i.test(pc) || /下一页|下一頁|next/i.test(ptx)) nextBtn = pel;
+            }
+          }
+          var hasMore = !!nextBtn && !/disabled|disabled/i.test(String(nextBtn.className || ''));
+          window.__VF_HASMORE__ = hasMore;
+          // 探针：在页面记录 next 按钮识别与翻页尝试，供主进程日志诊断（重复信息不刷屏）
+          var trace = window.__VF_PAGEDEBUG__ || [];
+          var nxInfo = nextBtn ? String(nextBtn.className || '').slice(0, 80) : 'none';
+          if (trace.length < 8 && (window.__VF_NX_LAST__ || '') !== nxInfo) {
+            trace.push('next[' + nxInfo + '] more=' + hasMore + ' pg=' + (window.__VF_PAGE__ || 0));
+            window.__VF_PAGEDEBUG__ = trace;
+            window.__VF_NX_LAST__ = nxInfo;
+          }
+          // 限速翻页：少隔 2.8s 才翻一次，避免连翻导致中间页额度接口被 abort（wan 在第二页，须等上页接口返回）
+          var npg = Date.now();
+          if (hasMore && (window.__VF_LASTPAGE_AT__ || 0) < npg - 2800) {
+            try {
+              nextBtn.scrollIntoView({ block: 'center' });
+              var tgt = nextBtn;
+              var inner = nextBtn.querySelector('[class*="icon"],a,button,span,[class*="next"]');
+              if (inner) tgt = inner;
+              ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click', 'touchend'].forEach(function (ev) {
+                tgt.dispatchEvent(new (window.MouseEvent || window.Event)(ev, { bubbles: true, cancelable: true, view: window, detail: 1 }));
+              });
+              if (tgt.click) tgt.click();
+              window.__VF_LASTPAGE_AT__ = npg;
+              window.__VF_CLICKNEXT__ = true;
+            } catch (_) {}
+          }
+          // 2) 兜底：仍滚动可滚动容器（兼容虚拟列表/非分页视图）
+          const scrollers = Array.from(document.querySelectorAll('*')).filter(function (el) {
+            return el.scrollHeight > el.clientHeight + 20;
+          });
+          for (const s of scrollers) {
+            const step = Math.max(s.clientHeight * 0.9, 120);
+            s.scrollTop = Math.min(s.scrollHeight, (s.scrollTop || 0) + step);
+            vfScreenIdx++;
+          }
+          window.__VF_SCREEN__ = vfScreenIdx;
+          // 3) 每轮都重新抓 DOM 行/卡片（兜底），以及同步一次接口状态变量
+          scrapeTableRows();
+          scrapeFreeModels();
+          window.__VF_INTERFACE_COUNT__ =
+            Object.keys(window.__VF_TOKEN_LIMITS__).length + (window.__VF_HAS_RATE__ ? 1 : 0);
+        } catch (_) {}
+      }, 900);
+    }
+    // 4) 可拖拽注入条（仅交互式首次绑定显示）
+    if (${quiet ? 'false' : 'true'}) {
+      const bar = document.createElement('div');
+      bar.id = 'qf-volc-bar';
+      bar.style.cssText = 'position:fixed;top:12px;left:12px;z-index:2147483647;display:flex;flex-direction:column;gap:6px;padding:8px 12px;border-radius:8px;background:rgba(20,20,22,.92);color:#fff;font:12.5px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;box-shadow:0 4px 16px rgba(0,0,0,.35);user-select:none;max-width:440px;';
+      bar.innerHTML =
+        '<div id="qf-volc-header" style="display:flex;align-items:center;gap:6px;font-weight:600;color:#fff;cursor:grab;font-size:12.5px;">' +
+        '<span id="qf-volc-grip" style="color:#9aa0a6;letter-spacing:1px;font-size:13px;">⋮⋮</span>' +
+        '<span>Quota-Flow · 火山方舟控制台</span>' +
+        '</div>' +
+        '<div style="color:#c9cdd4;font-size:12px;">请使用「手机号登录/账号登录」，进入「API Key 管理」复制 Key 后点击下方按钮即可（第三方登录已拦截，需在外部浏览器完成）</div>' +
+        '<button id="qf-volc-done" style="margin-top:2px;border:none;border-radius:6px;background:#22c55e;color:#fff;font:600 12.5px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:7px 12px;cursor:pointer;align-self:flex-start;">已获取 key 返回</button>';
+      document.body.appendChild(bar);
+      bar.querySelector('#qf-volc-done').addEventListener('click', () => { window.__VF_SUBMIT__ = true; window.__VF_STATE__ = window.__VF_CAPTURED__ ? 'ok' : 'empty'; });
+      let dragging = false, offX = 0, offY = 0;
+      const grip = document.getElementById('qf-volc-grip');
+      const header = document.getElementById('qf-volc-header');
+      const barEl = document.getElementById('qf-volc-bar');
+      const startDrag = (e) => { dragging = true; offX = e.clientX - barEl.offsetLeft; offY = e.clientY - barEl.offsetTop; barEl.style.cursor = 'grabbing'; e.preventDefault(); };
+      if (grip) grip.addEventListener('mousedown', startDrag);
+      if (header) header.addEventListener('mousedown', startDrag);
+      document.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        const x = Math.max(4, Math.min(window.innerWidth - barEl.offsetWidth - 4, e.clientX - offX));
+        const y = Math.max(4, Math.min(window.innerHeight - barEl.offsetHeight - 4, e.clientY - offY));
+        barEl.style.left = x + 'px'; barEl.style.top = y + 'px';
+      });
+      document.addEventListener('mouseup', () => { dragging = false; barEl.style.cursor = 'grab'; });
+    }
+  })()`
+
+  const inject = (): void => {
+    void win.webContents.executeJavaScript(INJECT).catch(() => {})
+  }
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(inject, 500)
+  })
+
+  return new Promise<{
+    ok: boolean
+    consoleJwt?: string
+    accountId?: string
+    models?: VolcengineFreeVideoModel[]
+    source?: 'console' | 'fallback'
+    error?: string
+  }>((resolve) => {
+    let finished = false
+    let renewTimeout: NodeJS.Timeout | null = null
+    // 额度同步：记开始时间 + 累积「最新一次抓到」的结果。开通管理页为虚拟列表，首屏只渲染顶部卡片（pro），
+    // 若首命中就返回，底部的 wan/lite 卡还没被自动滚动渲染出来 → 永远漏卡。故先累积、稳定后再返回。
+    const winStart = Date.now()
+    let syncLatest:
+      | { consoleJwt?: string; accountId?: string | null; models: VolcengineFreeVideoModel[]; signature: string }
+      | null = null
+    let syncStableCount = 0
+    const done = (result: {
+      ok: boolean
+      consoleJwt?: string
+      accountId?: string
+      models?: VolcengineFreeVideoModel[]
+      source?: 'console' | 'fallback'
+      error?: string
+    }): void => {
+      if (finished) return
+      finished = true
+      clearInterval(pollTimer)
+      if (renewTimeout) clearTimeout(renewTimeout)
+      if (!win.isDestroyed()) win.destroy()
+      loginWindows.delete(winKey)
+      resolve(result)
+    }
+    win.on('closed', () => {
+      clearInterval(pollTimer)
+      if (renewTimeout) clearTimeout(renewTimeout)
+      try {
+        void win.webContents
+          .executeJavaScript('clearInterval(window.__VF_SCAN__);clearInterval(window.__VF_SCAN2__)')
+          .catch(() => {})
+      } catch {}
+      if (loginWindows.get(winKey) === win) loginWindows.delete(winKey)
+      if (!finished) {
+        finished = true
+        resolve({ ok: false, error: '窗口已关闭' })
+      }
+    })
+
+    if (quiet) {
+      renewTimeout = setTimeout(() => {
+        if (syncModels) {
+          // 额度同步超时：说明未抓到开通管理页额度（登录态失效/页面未渲染/CSP 阻断）。以「成功但无新数据」返回，
+          // 由调用方保留旧 models，避免误把额度清空；仅在非同步场景把超时视为失败（续期需明确失败以便重试）。
+          if (!win.isDestroyed()) {
+            void win.webContents
+              .executeJavaScript(
+                `JSON.stringify({url: location.href, body:(document.body&&document.body.innerText||'').slice(0,600), login:/登录|扫码|二维码|手机号|密码/.test((document.body&&document.body.innerText||'')), vf:(window.__VF_MODELS__||[]).length, submit:!!window.__VF_SUBMIT__})`
+              )
+              .then((s) => logVolcSync(`SYNC_TIMEOUT page=${s}`))
+              .catch((e) => logVolcSync(`SYNC_TIMEOUT peek_err=${e}`))
+          }
+          done({ ok: true, source: 'fallback' })
+        } else {
+          done({ ok: false, error: '静默续期超时：控制台登录态可能已失效，请在厂商页手动刷新账号' })
+        }
+      }, VOLC_QUIET_RENEW_TIMEOUT_MS)
+    }
+
+    const pollTimer = setInterval(() => {
+      if (win.isDestroyed()) return
+      if (quiet) {
+        // 额度同步模式（静默）：无需注入条点击，等开通管理页抓到免费额度卡片后，累积最新 models，
+          // 直到抓取结果连续稳定（自动滚动已滚到底部、末端 wan/lite 卡也收录）或达到最大等待即可返回。
+        if (syncModels) {
+          // 页内心跳快照：无论是否抓到卡片，每轮都回吐一次页面状态，用于定位「为何 __VF_MODELS__ 为空」
+          //（登录墙？开通管理页未渲染？CSP 阻断注入？）。在线则记录，不阻塞主探测流程。
+          void win.webContents
+            .executeJavaScript(
+              `JSON.stringify({url: location.href, t:(document.body&&document.body.innerText||'').replace(/\\s+/g,' ').slice(0,400), login:/登录|扫码|二维码|手机号|密码/.test((document.body&&document.body.innerText||'')), vf:(window.__VF_MODELS__||[]).length, vfIds:(window.__VF_MODELS__||[]).map(m=>m.name).join(','), injected:!!window.__QUOTA_FLOW_VOLC__, submit:!!window.__VF_SUBMIT__, scroller:(function(){var n=0,b=0;try{var all=document.querySelectorAll('*');for(var i=0;i<all.length;i++){var e=all[i];if(e.scrollHeight>e.clientHeight+20){n++;if(e.scrollHeight>e.clientHeight*2)b++;}};return n+'/'+b;}catch(_){return 'err';}})(), cards:document.querySelectorAll('[class*=card],[class*=Card],[class*=item]').length,
+sample:(function(){
+  var out=[];
+  try{
+    var els=document.querySelectorAll('*');
+    for(var i=0;i<els.length&&out.length<3;i++){
+      var e=els[i];
+      var tt=(e.textContent||'').replace(/\\s+/g,' ').trim();
+      if(tt.length<260&&tt.length>4&&/token|tok|已开通|未开通|开通|剩余|剩|免费/.test(tt)){
+        // 近似卡片：文本短且含额度/开通关键词
+        out.push(tt.slice(0,160));
+      }
+    }
+  }catch(_){}
+  return out;
+})(), rows:(function(){
+  // 可视化模型（wan / doubao-seedance）在表格深处，逐屏滚动后应整行呈现（含状态列）。
+  // 这里专门输出含 wan/seedance 模型名的行全文（截取），以核对开通状态与额度字段格式。
+  var out=[];
+  try{
+    var cells=document.querySelectorAll('table tr, [role=row], [class*=Row]');
+    for(var i=0;i<cells.length;i++){
+      var c=cells[i];
+      var ct=(c.textContent||'').replace(/\s+/g,' ').trim();
+      if(ct.length<=6||!/[Ww]an|seedance|Seedance|doubao-seedance/.test(ct))continue;
+      if(out.length>=6)break;
+      out.push(ct.slice(0,220));
+    }
+  }catch(_){}
+  return out;
+})(), pag:(function(){
+  // 视觉模型表格为分页结构，wan 在第二页。抓分页控件（文本/容器/按钮）还原「下一页」等结构以便翻页。
+  var out=[];
+  try{
+    var t=document.body&&document.body.innerText||'';
+    // 形如「1 / 10 页」「共 2 页」「第 1 页」的总页数文本
+    var m=t.match(/[共第]?\\s*\\d+\\s*\\/\\s*\\d+\\s*[页共]?/g);
+    if(m){out.push('text:'+String(m).slice(0,80));}
+    var m2=t.match(/共\\s*\\d+\\s*页/g);
+    if(m2){out.push('共页:'+m2.slice(0,3).join(','));}
+  }catch(_){}
+  try{
+    // 页面唯一存在的分页容器：火山常用 antd pagination 或自研 li 结构
+    var conts=document.querySelectorAll('[class*=pagination],[class*=Pagination],[class*=page-list],[class*=PageList],[class*=pager] ,ul');
+    var seen=0;
+    for(var i=0;i<conts.length&&seen<2;i++){
+      var ct=(conts[i].textContent||'').replace(/\\s+/g,' ').trim();
+      var cl=String(conts[i].className||'').slice(0,80);
+      if(/[\\d/共页><]/.test(ct)&&ct.length<80){out.push('cont:'+cl+'|'+ct); seen++;}
+    }
+    var btns=document.querySelectorAll('a,button,[role=button]');
+    for(var i=0;i<btns.length;i++){
+      var b=btns[i];
+      var tx=(b.textContent||'').replace(/\\s+/g,' ').trim();
+      var al=(b.getAttribute&&b.getAttribute('aria-label'))||'';
+      var cl=String(b.className||'').slice(0,60);
+      if(/下一页|下一頁|next|>>|^>$/.test(tx)||/next|下一页/i.test(al)||/next|pagination/i.test(cl)){
+        var dis=b.hasAttribute&&b.hasAttribute('disabled')?'[dis]':'';
+        out.push('btn:'+cl+'|'+(al||tx).slice(0,24)+dis);
+        if(out.length>=8)break;
+      }
+    }
+  }catch(_){}
+  return out;
+})(), frames:(function(){
+  var out=[];
+  try{
+    var fs=document.querySelectorAll('iframe,frame');
+    for(var i=0;i<fs.length;i++){
+      var f=fs[i];
+      var fr={src:String(f.src||f.getAttribute('src')||'').slice(0,140)};
+      try{
+        var d=f.contentDocument;
+        fr.t=(d&&d.body&&d.body.innerText||'').replace(/\s+/g,' ').trim().slice(0,200);
+      }catch(_){fr.err='blocked';}
+      out.push(fr);
+    }
+  }catch(_){}
+  return out;
+})()})`
+            )
+            .then((s) => logVolcSync(`SYNC_HB ${Date.now() - winStart}ms page=${s}`))
+            .catch((e) => logVolcSync(`SYNC_HB_err ${e}`))
+          void win.webContents
+            .executeJavaScript('window.__VF_MODELS__ && (window.__VF_MODELS__.length > 0 || Object.keys(window.__VF_TOKEN_LIMITS__).length > 0 || window.__VF_HAS_RATE__) ? [window.__VF_CAPTURED__, window.__VF_ACCOUNT__ || null, window.__VF_MODELS__, window.__VF_SCREEN__ || 0, window.__VF_SAVED_RAW__ ? window.__VF_SAVED_RAW__.slice(0, 3000) : null, (window.__VF_MODELS_RAW__||[]).map(function(r){return r.url;}).filter(function(u,i,a){return a.indexOf(u)===i;}).slice(0,15), window.__VF_MODEL_BODY__ ? window.__VF_MODEL_BODY__.slice(0, 6000) : null, window.__VF_TOKEN_LIMITS__ || {}, window.__VF_HAS_RATE__ || false, window.__VF_PAGE__ || 0, window.__VF_HASMORE__ ? true : false, (window.__VF_PAGEDEBUG__ || []).join(";")] : null')
+            .then((val: unknown) => {
+              if (!val) return
+              const [jwt, accountId, rawModels, screenIdx, rawBody, rawUrls, modelBody, tokenLimits, hasRate, curPage, hasMore, pageDebug] = val as [
+                string | null,
+                string | null,
+                Array<{ name: string; remaining?: number; total?: number; activated?: boolean }>,
+                number,
+                string | null,
+                string[] | null,
+                string | null,
+                Record<string, { tokenLimit: number; currentUsage: number }>,
+                boolean,
+                number,
+                boolean,
+                string
+              ]
+              // 接口原始响应抓取：优先用接口 JSON 解析模型额度的开通状态，DOM 卡片只是兜底。
+              if (Array.isArray(rawUrls) && rawUrls.length > 0) {
+                logVolcSync(`SYNC_RAWURLS ${rawUrls.join(' | ')}`)
+              }
+              if (typeof modelBody === 'string' && modelBody.length > 80 && modelBody !== rawBody) {
+                logVolcSync(`SYNC_MODELBODY ${modelBody.slice(0, 6000)}`)
+              }
+              if (typeof rawBody === 'string' && rawBody.length > 80) {
+                logVolcSync(`SYNC_RAW sample=${rawBody.slice(0, 2200)}`)
+              }
+              // 接口级模型：ListModelTokenLimit 的 TokenLimit 即每个已开通模型的免费总额度。
+              // 换算为与目录一致的单位（火山 TokenLimit 单位是 token），remaining = TokenLimit - currentUsage。
+              const tokenNames = Object.keys(tokenLimits || {})
+              if (tokenNames.length > 0) {
+                logVolcSync(
+                  `SYNC_TOKENS ${tokenNames
+                    .map((n) => `${n}:${tokenLimits[n].tokenLimit}/used${tokenLimits[n].currentUsage}`)
+                    .join(' | ')}`
+                )
+                // 把接口真实额度 upsert 进 rawModels（副本），供下方 capture 合并，保证已开通模型不被
+                // 目录 fallback 显示「待开通」。随后继续走 capture/稳定收敛，不做 return。
+                for (const name of tokenNames) {
+                  const tl = tokenLimits[name]
+                  const existing = rawModels.find((m) => m.name === name)
+                  if (existing) {
+                    existing.remaining = Math.max(0, tl.tokenLimit - tl.currentUsage)
+                    existing.total = tl.tokenLimit
+                    existing.activated = true
+                  } else {
+                    rawModels.push({
+                      name,
+                      remaining: Math.max(0, tl.tokenLimit - tl.currentUsage),
+                      total: tl.tokenLimit,
+                      activated: true
+                    })
+                  }
+                }
+              }
+              const captured = captureVolcengineFreeVideoModels(rawModels)
+              if (captured.source !== 'console') return
+              // 与上一轮抓到的结果比较，用于判断是否已稳定（虚拟列表滚到底、不再新增/变化卡片）
+              const sig = captured.models
+                .map((m) => `${m.id}:${m.freeQuota?.remaining ?? '__'}:${m.activated ? 'T' : 'F'}`)
+                .join(',')
+              if (syncLatest && syncLatest.signature === sig) {
+                syncStableCount++
+              } else {
+                syncStableCount = 1
+                syncLatest = { consoleJwt: undefined, accountId, models: captured.models, signature: sig }
+                if (typeof jwt === 'string' && jwt) syncLatest.consoleJwt = jwt
+              }
+              console.log(`[volc-sync] 额度抓取中 ${captured.models.map((m) => m.id).join(',')} stable=${syncStableCount} screen=${screenIdx}`)
+              // 收敛：确保已渐进滚动足够多屏（到底部模型已渲染）后再按「连续稳定」返回。
+              // 首屏就有 3D 免费模型，若不要求滚屏会过早返回、漏掉深处 wan/seedance1.0。
+              const scrolledEnough = typeof screenIdx === 'number' && screenIdx >= 4
+              const morePages = !!hasMore
+              // 收敛：已尽力翻页（无下一页可点）且结果稳定 3 轮；或翻页/累积超 18s 兜底返回。
+              // 不再仅凭 8s 强收（会让停在第一页的稳定签名提前返回、漏掉第二页的 wan）。
+              if (
+                (scrolledEnough && syncStableCount >= 3 && !morePages) ||
+                (scrolledEnough && Date.now() - winStart >= 18000)
+              ) {
+                logVolcSync(
+                  `SYNC_HIT models=${sig.slice(0, 400)} raw=${rawModels.length} stable=${syncStableCount} screen=${screenIdx} page=${curPage} more=${hasMore ? true : false} pgdb=${pageDebug || ''}`
+                )
+                done({
+                  ok: true,
+                  consoleJwt: syncLatest.consoleJwt,
+                  accountId: typeof syncLatest.accountId === 'string' ? syncLatest.accountId : undefined,
+                  models: syncLatest.models,
+                  source: 'console'
+                })
+              }
+            })
+            .catch(() => {})
+          return
+        }
+        void win.webContents
+          .executeJavaScript('window.__VF_CAPTURED__ || null')
+          .then((jwt: unknown) => {
+            if (typeof jwt !== 'string' || !jwt) return
+            if (oldConsoleJwt && jwt === oldConsoleJwt.trim()) return
+            done({ ok: true, consoleJwt: jwt })
+          })
+          .catch(() => {})
+        return
+      }
+      void win.webContents
+        .executeJavaScript('window.__VF_SUBMIT__ ? [window.__VF_STATE__, window.__VF_CAPTURED__, (window.__VF_ACCOUNT__ || (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return null}})()), window.__VF_MODELS__ || [], (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return \'e\'}})() ] : null')
+        .then((val: unknown) => {
+          if (!val) return
+          const [state, jwt, accountId, rawModels, lsVal] = val as [
+            string,
+            string | null,
+            string | null,
+            Array<{ name: string; remaining?: number; total?: number }>,
+            string | null
+          ]
+          // 绑定诊断：accountId 可能来自页面全局 __VF_ACCOUNT__，或整页跳转后从 localStorage 恢复读取；
+          // 两者都空才能判定绑定时确未抓到账号 id（否则是链路其它环节丢的）
+          logVolcSync(
+            `CAPTURE_SUBMIT state=${state} accountId=${accountId ? 'YES' : 'NO'} ls=${(typeof lsVal === 'string' && lsVal) ? 'YES' : 'NO'}`
+          )
+          // 火山方舟控制台走 cookie 会话，通常不产生进入 Authorization 头的三段式 JWT（consoleJwt）。
+          // 故「已获取 key 返回」时不再把缺 JWT 视为失败：绑定只需 API Key，consoleJwt 作为可选增强，
+          // 捕获到则带回（供未来额度接口探测），捕获不到也未空返回值正常继续。
+          // 只有当既无 JWT 也无账号 id（连账号上下文都没抓到）才提示未完成，避免把已抓到的
+          // accountId/models 因 state=empty（无 JWT 的正常态）误丢弃，导致绑定拿不到账号级去重键。
+          if (state !== 'ok' && !accountId) {
+            done({ ok: false, error: '请在登录火山方舟控制台并复制 API Key 后点击返回' })
+            return
+          }
+          // 「绑定即抓模型」：把控制台页面抓到的免费 Seedance 条目规范化，回退内置目录。
+          const captured = captureVolcengineFreeVideoModels(rawModels)
+          const label = captured.models.map((m) => m.id).join(',') || '无'
+          if (captured.source === 'console') {
+            console.log(`[volc-caps] 免费视频模型清单（控制台抓取）：${label}`)
+          } else {
+            console.log(`[volc-caps] 免费视频模型清单（内置目录回退）：${label}; 抓取原始条目=${rawModels.length}`)
+          }
+          logVolcSync(
+            `CAPTURE_RETURN state=ok accountId=${typeof accountId === 'string' && accountId ? 'YES' : 'NO'}`
+          )
+          done({
+            ok: true,
+            consoleJwt: typeof jwt === 'string' && jwt ? jwt : undefined,
+            accountId: typeof accountId === 'string' && accountId ? accountId : undefined,
+            models: captured.models,
+            source: captured.source
+          })
+        })
+        .catch(() => {})
+    }, 700)
+  })
+}
+
 let registered = false
 
 export function initProviders(): void {
@@ -1294,7 +2096,16 @@ export function initProviders(): void {
         fingerprint =
           providerId === 'zhipu'
             ? await zhipuAccountFingerprint(plain)
-            : fingerprintFor(providerId, plain.trim())
+            : providerId === 'volcengine'
+              ? await volcengineAccountFingerprint(plain)
+              : fingerprintFor(providerId, plain.trim())
+        // 火山方舟去重诊断：确认 accountId 是否进链路、指纹是「账号级」还是退化成「Key 哈希」
+        if (providerId === 'volcengine') {
+          const { accountId } = decodeVolcenginePayload(plain)
+          logVolcSync(
+            `ENC_VOLC accountId=${accountId ? 'YES' : 'NO'} fp_level=${fingerprint ? (accountId ? 'account' : 'key-hash') : 'none'}`
+          )
+        }
       }
       return { encrypted, fingerprint }
     } catch {
@@ -1306,26 +2117,28 @@ export function initProviders(): void {
     return healthCheck(providerId, encrypted, typeof keyId === 'string' ? keyId : undefined)
   })
 
-  // API Key 型厂商（智谱）「测试」按钮：解密出 API Key 后调开放平台只读接口校验有效性，不产生费用
-  ipcMain.handle('provider:test-api-key', async (_e, _providerId: string, encrypted: string) => {
+  // API Key 型厂商「测试」按钮：解密出 API Key 后调对应开放平台只读接口校验有效性，不产生费用
+  ipcMain.handle('provider:test-api-key', async (_e, providerId: string, encrypted: string) => {
     try {
       const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
       const { apiKey } = decodeZhipuPayload(plain)
       if (!apiKey) return { ok: false, error: '未解析到 API Key' }
-      return await testZhipuApiKey(apiKey)
+      return providerId === 'volcengine' ? await testVolcengineApiKey(apiKey) : await testZhipuApiKey(apiKey)
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : 'API Key 校验失败' }
     }
   })
 
-  // API Key 型厂商（智谱）真实额度查询：解密后取 apiKey + consoleJwt，调控制台 biz 接口拿资源包余额
-  ipcMain.handle('provider:fetch-quota', async (_e, _providerId: string, encrypted: string) => {
+  // API Key 型厂商真实额度查询：解密后取 apiKey + consoleJwt，调对应控制台接口拿资源包余额
+  ipcMain.handle('provider:fetch-quota', async (_e, providerId: string, encrypted: string) => {
     if (!encrypted) return { ok: false, error: '缺少密钥' }
     try {
       const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
       const { apiKey, consoleJwt } = decodeZhipuPayload(plain)
       if (!apiKey) return { ok: false, error: '未解析到 API Key' }
-      return await fetchZhipuQuota(apiKey, consoleJwt ?? undefined)
+      return providerId === 'volcengine'
+        ? await fetchVolcengineQuota(apiKey, consoleJwt ?? undefined)
+        : await fetchZhipuQuota(apiKey, consoleJwt ?? undefined)
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : '额度查询失败' }
     }
@@ -1336,7 +2149,113 @@ export function initProviders(): void {
     return captureZhipuConsoleSession({ keyId: typeof keyId === 'string' && keyId ? keyId : undefined })
   })
 
-  // 智谱控制台会话状态：按账号 keyId 解密后视 JWT 的 exp 判定 alive / expiring / expired，供自动续期调度参考
+  // 火山方舟控制台会话捕获：按账号 keyId 弹出对应分区控制台登录窗口并捕获访问令牌（consoleJwt）
+  ipcMain.handle('provider:capture-volc-session', async (_e, keyId?: string) => {
+    // 绑定窗口初始落在「开通管理 → 视觉模型」页：该页首屏即调 ListModelChargeItems，其响应
+    // FeaturedImage.BucketName 形如 ark-auto-{accountId}-cn-beijing-default，是「当前登录账号」专有 id，
+    // 注入脚本据此写入 __VF_ACCOUNT__。这样「绑定第二把同账号 API Key」时就能拿到账号级去重键，命中
+    // 「更新已有/新建」提示（对齐智谱 customerId 策略），而不是退化到按 API Key 哈希。
+    // 用户在该页左侧导航切到「API Key 管理」复制 Key 属 SPA 内路由，__VF_ACCOUNT__ 得以保留。
+    return captureVolcEngineConsoleSession({
+      keyId: typeof keyId === 'string' && keyId ? keyId : undefined,
+      targetUrl: VOLC_OPEN_MANAGEMENT_URL
+    })
+  })
+
+  // 火山方舟控制台会话状态：视 JWT 的 exp 判定 alive / expiring / expired
+  ipcMain.handle(
+    'provider:volc-session-status',
+    async (_e, _providerId: string, keyId: string, encrypted: string) => {
+      if (!encrypted) return { hasSession: false }
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { consoleJwt } = decodeVolcenginePayload(plain)
+        if (!consoleJwt) return { hasSession: false }
+        const expMs = jwtExpiryMs(consoleJwt)
+        if (expMs === null) return { hasSession: true, status: 'alive', expMs: null, remainingMs: null }
+        const remainingMs = expMs - Date.now()
+        const status = remainingMs <= 0 ? 'expired' : remainingMs <= 10 * 60 * 1000 ? 'expiring' : 'alive'
+        return { hasSession: true, status, expMs, remainingMs }
+      } catch {
+        return { hasSession: false }
+      }
+    }
+  )
+
+  // 火山方舟控制台会话静默续期：隐藏窗口复用该账号分区登录态 cookie 重新捕获新 JWT，成功则重建加密负载
+  ipcMain.handle(
+    'provider:volc-renew-session',
+    async (_e, _providerId: string, keyId: string, encrypted: string) => {
+      if (!encrypted) return { ok: false, reason: 'no-secret', error: '缺少密钥' }
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { apiKey, consoleJwt, accountId } = decodeVolcenginePayload(plain)
+        if (!apiKey) return { ok: false, reason: 'no-key', error: '未解析到 API Key' }
+        const res = await captureVolcEngineConsoleSession({
+          quiet: true,
+          keyId: typeof keyId === 'string' && keyId ? keyId : undefined,
+          oldConsoleJwt: consoleJwt ?? null
+        })
+        if (!res.ok || !res.consoleJwt) {
+          return { ok: false, reason: 'capture-failed', error: res.error ?? '静默续期失败' }
+        }
+        const newJwt = res.consoleJwt
+        // 保留已知 accountId；静默续期若有新捕获的账号 id 则一并更新（保证去重键稳定）
+        const newAccountId = res.accountId ?? accountId ?? null
+        const newPlain = JSON.stringify({ v: 1, apiKey, consoleJwt: newJwt, accountId: newAccountId })
+        const newEncrypted = safeStorage.encryptString(newPlain).toString('base64')
+        const expMs = jwtExpiryMs(newJwt)
+        const remainingMs = expMs === null ? null : expMs - Date.now()
+        return { ok: true, encrypted: newEncrypted, expMs, remainingMs }
+      } catch (e) {
+        return { ok: false, reason: 'error', error: e instanceof Error ? e.message : '静默续期失败' }
+      }
+    }
+  )
+
+  // 火山方舟额度同步：后台打开「开通管理」页（复用该账号分区登录态），静默抓取最新免费模型额度/开通状态，
+  // 成功则重建加密负载（更新 models + 最新 consoleJwt/accountId）返回 newEncrypted，供渲染层落库并刷新展示。
+  ipcMain.handle(
+    'provider:volc-sync-models',
+    async (_e, _providerId: string, keyId: string, encrypted: string) => {
+      if (!encrypted) return { ok: false, reason: 'no-secret', error: '缺少密钥' }
+      logVolcSync(`SYNC_START key=${keyId}`)
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { apiKey, consoleJwt, accountId } = decodeVolcenginePayload(plain)
+        if (!apiKey) return { ok: false, reason: 'no-key', error: '未解析到 API Key' }
+        const res = await captureVolcEngineConsoleSession({
+          quiet: true,
+          syncModels: true,
+          keyId: typeof keyId === 'string' && keyId ? keyId : undefined,
+          oldConsoleJwt: consoleJwt ?? null,
+          targetUrl: VOLC_OPEN_MANAGEMENT_URL
+        })
+        // 成功且抓到了额度卡片 → 用最新 models + 最新 JWT 重建负载回库
+        if (res.ok && res.source === 'console' && Array.isArray(res.models) && res.models.length > 0) {
+          const newJwt = res.consoleJwt ?? consoleJwt ?? null
+          const newAccountId = res.accountId ?? accountId ?? null
+          const newPlain = JSON.stringify({ v: 1, apiKey, consoleJwt: newJwt, accountId: newAccountId, models: res.models })
+          const newEncrypted = safeStorage.encryptString(newPlain).toString('base64')
+          // 同步后回填账号级指纹（对齐智谱 customerId 策略）：一旦抓到该账号稳定 id，就重算指纹供渲染层落库，
+          // 让同账号多把 API Key 在库里共享同一 account_fingerprint，后续绑定即可命中「更新已有/新建」去重提示。
+          let newFingerprint: string | null = null
+          if (newAccountId) {
+            newFingerprint = await volcengineAccountFingerprint(newPlain)
+          }
+          console.log(`[volc-sync] 回写 models=${res.models.map((m) => m.id).join(',')} accountId=${newAccountId ?? 'NO'}`)
+          logVolcSync(`SYNC_BACKFILL key=${keyId} accountId=${newAccountId ? 'YES' : 'NO'} fp=${newFingerprint ? 'account' : (accountId ? 'account' : 'key-hash')}`)
+          logVolcSync(`SYNC_WRITEBACK key=${keyId} models=${res.models.map((m) => m.id).join(',')} accountId=${newAccountId ? 'YES' : 'NO'} fp=${newFingerprint ? 'account' : 'key-hash'}`)
+          return { ok: true, encrypted: newEncrypted, models: res.models, accountFingerprint: newFingerprint }
+        }
+        // 同步超时/未抓到（登录态失效或页面未就绪）：保留旧额度，不报错，交由调用方提示可稍后手动刷新
+        logVolcSync(`SYNC_PRESERVED key=${keyId} ok=${res.ok} source=${(res as { source?: string }).source ?? '?'}`)
+        return { ok: true, preserved: true }
+      } catch (e) {
+        return { ok: false, reason: 'error', error: e instanceof Error ? e.message : '额度同步失败' }
+      }
+    }
+  )
   ipcMain.handle(
     'provider:zhipu-session-status',
     async (_e, _providerId: string, keyId: string, encrypted: string) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -105,6 +105,8 @@ export interface QuotaUpdatedPayload {
   ledger: QuotaLedgerRow
   /** API 型厂商（智谱）生成成功后触发：据此重新拉取该账号真实额度 */
   zhipuRefreshKeyId?: string
+  /** 火山方舟生成成功后触发：据此静默同步该账号免费模型的真实剩余额度 */
+  volcRefreshKeyId?: string
 }
 
 /** 智谱平台资源包余额（fetch-quota 返回） */
@@ -125,6 +127,18 @@ export interface ApiModelInfo {
   durations: number[]
   size: string | null
   modes: Array<{ value: string; label: string }>
+  /** 是否已开通该模型（火山方舟未开通模型提示开通；默认 true） */
+  activated?: boolean
+  /** 【每账号】免费 token 额度（火山方舟免费视频模型）：剩余/总数；未抓到为 undefined */
+  freeQuota?: { remaining?: number; total?: number }
+}
+
+/** 火山方舟绑定时控制台抓到的免费视频模型（含每账号 token 额度），随加密负载持久化 */
+export interface VolcengineCapturedModel {
+  id: string
+  name?: string
+  price?: string
+  freeQuota?: { remaining?: number; total?: number }
 }
 
 /** 智谱控制台会话状态（依据 consoleJwt 的 JWT exp 判定），供自动续期调度参考 */
@@ -226,8 +240,9 @@ export interface DesktopApi {
     fetchQuota: (providerId: string, encrypted: string) => Promise<{ ok: boolean; quota?: ZhipuQuotaResult; error?: string }>
     /**
      * 查询 API 型厂商模型目录（「查看模型」弹窗）
+     * @param encrypted 可选：该账号加密负载（火山方舟用它读取每账号免费 token 额度）
      */
-    apiModels: (providerId: string) => Promise<{ ok: boolean; models?: ApiModelInfo[]; error?: string }>
+    apiModels: (providerId: string, encrypted?: string) => Promise<{ ok: boolean; models?: ApiModelInfo[]; error?: string }>
     /**
      * 捕获智谱控制台登录会话（consoleJwt），用于真实额度查询
      * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
@@ -246,6 +261,41 @@ export interface DesktopApi {
       encrypted?: string
       expMs?: number | null
       remainingMs?: number | null
+      reason?: string
+      error?: string
+    }>
+    /**
+     * 捕获火山方舟控制台登录会话（consoleJwt）与账号标识（accountId），用于真实额度查询与账号级去重
+     * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
+     */
+    captureVolcengineSession: (keyId?: string) => Promise<{ ok: boolean; consoleJwt?: string; accountId?: string; models?: VolcengineCapturedModel[]; source?: 'console' | 'fallback'; error?: string }>
+    /**
+     * 读取指定火山方舟账号的控制台会话状态（依据 consoleJwt 的 JWT exp 判定 alive / expiring / expired）
+     */
+    volcSessionStatus: (keyId: string, encrypted: string) => Promise<ZhipuSessionStatusResult>
+    /**
+     * 指定火山方舟账号控制台会话静默续期：隐藏窗口复用该账号分区登录态 cookie 重新捕获新 consoleJwt；
+     * 成功后返回重建后的新加密负载（encrypted），供调用方落库更新
+     */
+    volcRenewSession: (keyId: string, encrypted: string) => Promise<{
+      ok: boolean
+      encrypted?: string
+      expMs?: number | null
+      remainingMs?: number | null
+      reason?: string
+      error?: string
+    }>
+    /**
+     * 指定火山方舟账号额度同步：后台复用该账号分区登录态打开「开通管理」页，静默抓取最新免费模型
+     * 额度/开通状态；命中则返回重建后的新加密负载（encrypted）+ models，供调用方落库并刷新展示；
+     * 未抓到（登录态失效/页面未就绪）返回 {ok:true, preserved:true} 保留旧值。
+     */
+    volcSyncModels: (keyId: string, encrypted: string) => Promise<{
+      ok: boolean
+      encrypted?: string
+      models?: VolcengineCapturedModel[]
+      accountFingerprint?: string | null
+      preserved?: boolean
       reason?: string
       error?: string
     }>
@@ -354,8 +404,8 @@ const api: DesktopApi = {
       ipcRenderer.invoke('provider:test-api-key', providerId, encrypted) as Promise<{ ok: boolean; error?: string }>,
     fetchQuota: (providerId, encrypted) =>
       ipcRenderer.invoke('provider:fetch-quota', providerId, encrypted) as Promise<{ ok: boolean; quota?: ZhipuQuotaResult; error?: string }>,
-    apiModels: (providerId) =>
-      ipcRenderer.invoke('provider:api-models', providerId) as Promise<{ ok: boolean; models?: ApiModelInfo[]; error?: string }>,
+    apiModels: (providerId, encrypted) =>
+      ipcRenderer.invoke('provider:api-models', providerId, encrypted) as Promise<{ ok: boolean; models?: ApiModelInfo[]; error?: string }>,
     captureZhipuSession: (keyId) =>
       ipcRenderer.invoke('provider:capture-zhipu-session', keyId) as Promise<{ ok: boolean; consoleJwt?: string; error?: string }>,
     zhipuSessionStatus: (keyId, encrypted) =>
@@ -366,6 +416,35 @@ const api: DesktopApi = {
         encrypted?: string
         expMs?: number | null
         remainingMs?: number | null
+        reason?: string
+        error?: string
+      }>,
+    captureVolcengineSession: (keyId) =>
+      ipcRenderer.invoke('provider:capture-volc-session', keyId) as Promise<{
+        ok: boolean
+        consoleJwt?: string
+        accountId?: string
+        models?: VolcengineCapturedModel[]
+        source?: 'console' | 'fallback'
+        error?: string
+      }>,
+    volcSessionStatus: (keyId, encrypted) =>
+      ipcRenderer.invoke('provider:volc-session-status', 'volcengine', keyId, encrypted) as Promise<ZhipuSessionStatusResult>,
+    volcRenewSession: (keyId, encrypted) =>
+      ipcRenderer.invoke('provider:volc-renew-session', 'volcengine', keyId, encrypted) as Promise<{
+        ok: boolean
+        encrypted?: string
+        expMs?: number | null
+        remainingMs?: number | null
+        reason?: string
+        error?: string
+      }>,
+    volcSyncModels: (keyId, encrypted) =>
+      ipcRenderer.invoke('provider:volc-sync-models', 'volcengine', keyId, encrypted) as Promise<{
+        ok: boolean
+        encrypted?: string
+        models?: VolcengineCapturedModel[]
+        preserved?: boolean
         reason?: string
         error?: string
       }>

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -20,7 +20,7 @@ import { useAuth } from '../hooks/useAuth'
 import type { ProvidersResult } from '../hooks/useProviders'
 import type { JobsResult } from '../hooks/useJobs'
 import type { UsageScope, ViewScope } from '@quota-flow/db-supabase'
-import { getAuthService, getSupabaseConfig } from '../auth/service'
+import { getAuthService, getProviderService, getSupabaseConfig } from '../auth/service'
 import { ensureFreshSession } from '../auth/session'
 import { VideoThumb } from './VideoThumb'
 import { getInitialShowWebview } from './Modals'
@@ -208,7 +208,12 @@ export default function Dashboard({
 
   // Admin 厂商级生成能力：命中 provider_caps 时该厂商模式/模型以配置为准，缺省回退硬编码默认
   const caps = providerCaps[provider]
-  const modelList = (p: string): string[] => providerCaps[p]?.models ?? MODELS[p] ?? MODELS.doubao
+  // 火山方舟：调度台模型列表以「账号绑定时实际抓到的免费模型」为准（优先），未抓到才回退 provider_caps / spec 固定目录
+  const [volcModels, setVolcModels] = useState<string[] | null>(null)
+  const modelList = (p: string): string[] => {
+    if (p === 'volcengine' && volcModels && volcModels.length > 0) return volcModels
+    return providerCaps[p]?.models ?? MODELS[p] ?? MODELS.doubao
+  }
 
   // 历史详情「重新生成」：把历史参数回填到调度台表单，图片走已保存副本路径
   useEffect(() => {
@@ -269,6 +274,36 @@ export default function Dashboard({
     () => provAggs.filter((a) => a.enabled && a.boundCount > 0),
     [provAggs]
   )
+
+  // 火山方舟：调度台模型下拉 = 各已启用账号「绑定时所抓」全部免费模型的并集（动态，非固定文件/库定义）
+  useEffect(() => {
+    const svc = getProviderService()
+    if (!svc || !user) return
+    const agg = provAggs.find((a) => a.providerId === 'volcengine' && a.enabled)
+    if (!agg || agg.bindings.length === 0) {
+      if (volcModels === null) setVolcModels([])
+      return
+    }
+    const enabled = agg.bindings.filter((b) => b.enabled)
+    if (enabled.length === 0) return
+    let cancelled = false
+    void (async () => {
+      const union = new Set<string>()
+      for (const b of enabled) {
+        try {
+          const secret = await svc.getProviderKeySecret(user.id, b.keyId)
+          if (!secret) continue
+          const res = await window.api.providers.apiModels('volcengine', secret.encrypted_key)
+          if (res.ok && res.models) res.models.forEach((m) => m && m.model && union.add(m.model))
+        } catch {
+          // 单个账号抓取失败不影响整体目录
+        }
+      }
+      if (!cancelled) setVolcModels(Array.from(union))
+    })()
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id, provAggs, volcModels === null])
   const providerDurations = useMemo(() => {
     return new Map(provAggs.map((a) => [a.providerId, a.durations]))
   }, [provAggs])

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -8,6 +8,7 @@ import { ensureFreshSession } from '../auth/session'
 import { errMsg } from '../utils/error'
 import type { AuthUser } from '../hooks/useAuth'
 import type { TeamContext } from '@quota-flow/db-supabase'
+import type { VolcengineCapturedModel } from '../../../preload'
 import desktopPackage from '../../../../package.json'
 
 export interface UpdaterStatusView {
@@ -662,6 +663,10 @@ export function AddProviderModal({
   const [status, setStatus] = useState<'idle' | 'logging' | 'pick-account' | 'login-ok' | 'login-fail' | 'apikey-ok'>('idle')
   // 智谱控制台会话令牌：用户经「获取 API Key」捕获后暂存，保存时并入加密 payload 作为账号级去重依据
   const [consoleJwt, setConsoleJwt] = useState<string | null>(null)
+  // 火山方舟账号标识：从控制台接口捕获，保存时并入 payload 作为账号级去重依据
+  const [volcAccountId, setVolcAccountId] = useState<string | null>(null)
+  // 火山方舟绑定时控制台抓到的免费视频模型（含每账号 token 额度），随加密负载持久化供「查看模型」展示
+  const [volcModels, setVolcModels] = useState<VolcengineCapturedModel[] | null>(null)
   const [apiKey, setApiKey] = useState('')
   const [accountName, setAccountName] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -889,9 +894,13 @@ export function AddProviderModal({
     setStatus('logging')
     try {
       const trimmed = apiKey.trim()
-      // 智谱：如有已捕获的控制台会话，并入 `{v:1,apiKey,consoleJwt}` 结构化 payload，
-      // 供主进程解析出 customerId 生成「账号级」去重指纹（同账号不同 Key 去重）。
-      const raw = providerId === 'zhipu' && consoleJwt ? JSON.stringify({ v: 1, apiKey: trimmed, consoleJwt }) : trimmed
+      // 智谱 / 火山方舟：如有已捕获的控制台会话令牌(consoleJwt)或账号标识(volcAccountId)，并入结构化 payload，
+      // 供主进程生成「账号级」去重指纹（同账号不同 Key 去重）。
+      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine'
+      const raw =
+        isApiProvider && (consoleJwt || volcAccountId || (providerId === 'volcengine' && volcModels?.length))
+          ? JSON.stringify({ v: 1, apiKey: trimmed, consoleJwt, accountId: volcAccountId, models: providerId === 'volcengine' ? (volcModels ?? []) : undefined })
+          : trimmed
       const enc = await window.api.providers.encrypt(selected.providerId, raw)
       if (!enc.encrypted) {
         setStatus('idle')
@@ -935,20 +944,38 @@ export function AddProviderModal({
     }
   }
 
-  // 智谱「获取 API Key」：打开智谱控制台会话窗口以捕获 consoleJwt；用户在窗口内复制 API Key
+  // 智谱 / 火山方舟「获取 API Key」：打开对应控制台会话窗口以捕获 consoleJwt；用户在窗口内复制 API Key
   const openGetApiKey = async (): Promise<void> => {
     setError(null)
     setNotice(null)
     try {
-      // 智谱按账号绑定：先生成绑定 keyId（作为控制台分区与 DB 记录 id），确保登录态存入该账号自己的分区、多账号互不串号
+      // 按账号绑定：先生成绑定 keyId（作为控制台分区与 DB 记录 id），确保登录态存入该账号自己的分区、多账号互不串号
       let bindId = loginTempId
-      if (providerId === 'zhipu' && !bindId) {
+      if ((providerId === 'zhipu' || providerId === 'volcengine') && !bindId) {
         bindId = crypto.randomUUID()
         setLoginTempId(bindId)
       }
-      const res = await window.api.providers.captureZhipuSession(providerId === 'zhipu' ? bindId ?? undefined : undefined)
-      if (res.ok && res.consoleJwt) setConsoleJwt(res.consoleJwt)
-      if (!res.ok && res.error) setError(res.error)
+      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine'
+      // 火山方舟走独立的会话捕获入口（partition/注入与智谱隔离）
+      const volcRes = providerId === 'volcengine'
+        ? await window.api.providers.captureVolcengineSession(bindId ?? undefined)
+        : null
+      const finalRes: { ok: boolean; consoleJwt?: string; accountId?: string; models?: VolcengineCapturedModel[]; source?: 'console' | 'fallback'; error?: string } = volcRes
+        ?? (isApiProvider
+          ? await window.api.providers.captureZhipuSession(bindId ?? undefined)
+          : { ok: false, error: '该厂商不支持控制台会话捕获' })
+      if (finalRes.ok) {
+        if (finalRes.consoleJwt) setConsoleJwt(finalRes.consoleJwt)
+        if (finalRes.accountId) setVolcAccountId(finalRes.accountId)
+        // 「绑定即抓模型」：火山方舟在控制台页面抓到免费视频模型清单，提示用户并暂存随负载持久化
+        if (providerId === 'volcengine' && Array.isArray(finalRes.models) && finalRes.models.length > 0) {
+          const n = finalRes.models.length
+          setVolcModels(finalRes.models)
+          setNotice(finalRes.source === 'console' ? `已识别 ${n} 个免费视频模型（控制台抓取）` : `已识别 ${n} 个免费视频模型`)
+        }
+      } else if (finalRes.error) {
+        setError(finalRes.error)
+      }
     } catch (e) {
       setError(errMsg(e))
     }
@@ -1259,7 +1286,7 @@ export function AddProviderModal({
               <button className="btn-sm" onClick={() => void testApiKeyInput()} disabled={saving}>
                 测试 API Key
               </button>
-              {providerId === 'zhipu' && (
+              {(providerId === 'zhipu' || providerId === 'volcengine') && (
                 <button className="btn-sm primary" onClick={() => void openGetApiKey()} disabled={saving}>
                   获取 API Key
                 </button>

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { IconChevron, IconInfo, IconRefresh, ProviderIconMark } from './icons'
+import { IconChevron, IconClose, IconInfo, IconRefresh, ProviderIconMark } from './icons'
 import { AddProviderModal } from './Modals'
 import Pagination from './Pagination'
 import { EmptyState } from './EmptyState'
@@ -11,6 +11,128 @@ import type { UsageScope, ViewScope } from '@quota-flow/db-supabase'
 import type { ApiModelInfo } from '../../../preload'
 
 const PAGE_SIZE = 10
+
+/** 顶部额度汇总条
+ * - volcengine：聚合免费模型的额度（保持火山方舟原有展示，单位 tokens）
+ * - zhipu（及其他）：展示账号级共用额度（付费模型共用），单位按厂商配置
+ */
+function ModelsQuotaSummary({
+  providerId,
+  models,
+  quota,
+  unit = 'tokens',
+}: {
+  providerId: string
+  models: ApiModelInfo[]
+  quota: { available: boolean; total: number; remaining: number } | null
+  unit?: string
+}) {
+  if (providerId === 'volcengine') {
+    // 火山方舟：聚合免费模型额度
+    const freeModels = models.filter((m) => m.cost === 0 && m.freeQuota?.total)
+    const total = freeModels.reduce((sum, m) => sum + (m.freeQuota?.total ?? 0), 0)
+    const remaining = freeModels.reduce((sum, m) => sum + (m.freeQuota?.remaining ?? 0), 0)
+    if (total <= 0) return null
+    const pct = Math.min(100, Math.max(0, (remaining / total) * 100))
+    return (
+      <div className="models-summary">
+        <div className="models-summary-bar">
+          <div className="models-summary-bar-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <div className="models-summary-text">
+          <span className="models-summary-value">
+            {remaining.toLocaleString()} <span className="models-summary-unit">tokens</span>
+          </span>
+          <span className="models-summary-sep">/</span>
+          <span className="models-summary-total">{total.toLocaleString()}</span>
+        </div>
+      </div>
+    )
+  }
+  // 其他厂商（智谱等）：账号级共用额度
+  if (!quota || !quota.available) return null
+  const pct = Math.min(100, Math.max(0, (quota.remaining / Math.max(1, quota.total)) * 100))
+  return (
+    <div className="models-summary">
+      <div className="models-summary-bar">
+        <div className="models-summary-bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="models-summary-text">
+        <span className="models-summary-label">共用额度</span>
+        <span className="models-summary-value">
+          {quota.remaining.toLocaleString()} <span className="models-summary-unit">{unit}</span>
+        </span>
+        <span className="models-summary-sep">/</span>
+        <span className="models-summary-total">{quota.total.toLocaleString()}</span>
+      </div>
+    </div>
+  )
+}
+
+/** 单行模型用量
+ * - volcengine：免费模型显示自身免费额度（含待开通徽章），单位 tokens
+ * - zhipu 等：免费模型显示自身免费额度；付费模型显示账号级共用额度，单位按厂商配置
+ */
+function ModelQuotaCell({
+  providerId,
+  model,
+  sharedQuota,
+  unit = 'tokens',
+}: {
+  providerId: string
+  model: ApiModelInfo
+  sharedQuota: { available: boolean; total: number; remaining: number } | null
+  unit?: string
+}) {
+  const isFree = model.cost === 0
+  const freeQuota = model.freeQuota
+
+  if (providerId === 'volcengine') {
+    // 火山方舟：免费模型 + 待开通徽章
+    const activated = model.activated !== false
+    if (!activated) {
+      const quotaText = freeQuota?.total
+        ? `${typeof freeQuota.remaining === 'number' ? freeQuota.remaining.toLocaleString() : '—'} / ${freeQuota.total.toLocaleString()} tokens`
+        : '—'
+      return (
+        <span className="models-quota-cell" title="未开通该模型，需在火山方舟控制台开通后才会下发免费额度">
+          <span className="badge badge-pending">待开通</span>
+          <span className="models-quota-text models-quota-text--dim">{quotaText}</span>
+        </span>
+      )
+    }
+    if (freeQuota?.total) {
+      return (
+        <span className="models-quota-text">
+          {typeof freeQuota.remaining === 'number' ? freeQuota.remaining.toLocaleString() : '—'} / {freeQuota.total.toLocaleString()} tokens
+        </span>
+      )
+    }
+    return <span className="models-quota-text models-quota-text--dim">— token</span>
+  }
+
+  // 其他厂商（智谱等）
+  if (isFree) {
+    // 免费模型：显示自身额度
+    if (freeQuota?.total) {
+      return (
+        <span className="models-quota-text">
+          {typeof freeQuota.remaining === 'number' ? freeQuota.remaining.toLocaleString() : '—'} / {freeQuota.total.toLocaleString()} {unit}
+        </span>
+      )
+    }
+    return <span className="models-quota-text models-quota-text--dim">—</span>
+  }
+  // 付费模型：共用账号级额度
+  if (sharedQuota?.available) {
+    return (
+      <span className="models-quota-text" title="付费模型共用该额度">
+        共用{sharedQuota.remaining.toLocaleString()} / {sharedQuota.total.toLocaleString()} {unit}
+      </span>
+    )
+  }
+  return <span className="models-quota-text models-quota-text--dim">—</span>
+}
 
 function statusBadge(p: ProviderAgg): { cls: string; label: string } {
   if (!p.enabled) return { cls: 'badge-muted', label: '已停用' }
@@ -31,7 +153,7 @@ interface ProvidersProps {
 
 export default function Providers({ fresh, viewScope, usageScope, onBound, providers, canBind = true }: ProvidersProps) {
   const { user, team } = useAuth()
-  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, setKeyHealth } = providers
+  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, setKeyHealth, refreshVolcengineModelsOnce } = providers
   const [text, setText] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -44,11 +166,15 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
   const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null)
   // 「查看模型」弹窗
   const [models, setModels] = useState<ApiModelInfo[] | null>(null)
+  const [modelsLoading, setModelsLoading] = useState(false)
   const [modelsLabel, setModelsLabel] = useState('')
+  const [modelsProviderId, setModelsProviderId] = useState<string>('')
   // 弹窗顶部免费额度用量（该账号真实资源包余额；付费模型共用）
   const [modelsQuota, setModelsQuota] = useState<{ available: boolean; total: number; remaining: number } | null>(null)
   const [modelsUnit, setModelsUnit] = useState('次')
   const wasRefreshing = useRef(false)
+  // 「查看模型」弹窗同步令牌：关闭/重开时忽略过期的异步结果，避免同步完成后弹窗被重新打开
+  const modelsTokenRef = useRef(0)
 
   const showToast = (msg: string, ok = true) => {
     setToast({ msg, ok })
@@ -81,21 +207,56 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
     }
   }
 
-  // API Key 型厂商「查看模型」：拉取模型目录
+  // API Key 型厂商「查看模型」：拉取模型目录（火山方舟先静默同步最新免费模型额度/开通状态）
   const handleViewModels = async (providerId: string, keyId: string, accountName: string, unitName: string) => {
+    // 立即弹出弹窗并进入加载态，让火山方舟较慢的静默同步有可见反馈
+    const token = ++modelsTokenRef.current
+    setModels(null)
+    setModelsLabel(accountName)
+    setModelsProviderId(providerId)
+    setModelsQuota(zhipuQuotaOverrides[keyId] ?? null)
+    setModelsUnit(unitName)
+    setModelsLoading(true)
     try {
-      const res = await window.api.providers.apiModels(providerId)
+      let encrypted: string | undefined
+      // 火山方舟：取该账号密钥负载，供主进程读取每模型免费 token 额度
+      if (providerId === 'volcengine') {
+        const svc = getProviderService()
+        if (svc && user) {
+          const secret = await svc.getProviderKeySecret(user.id, keyId)
+          if (secret) encrypted = secret.encrypted_key
+          // 先静默同步该账号最新免费模型额度/开通状态；命中则用重建的加密负载展示最新值
+          const fresh = await refreshVolcengineModelsOnce(keyId)
+          if (fresh) encrypted = fresh
+        }
+      }
+      // 用户在同步期间已关闭弹窗，则丢弃本次结果
+      if (token !== modelsTokenRef.current) return
+      const res = await window.api.providers.apiModels(providerId, encrypted)
+      if (token !== modelsTokenRef.current) return
       if (res.ok && res.models) {
         setModels(res.models)
-        setModelsLabel(accountName)
-        setModelsQuota(zhipuQuotaOverrides[keyId] ?? null)
-        setModelsUnit(unitName)
       } else {
-        showToast(res.error || '无法加载模型目录', false)
+        if (token === modelsTokenRef.current) {
+          showToast(res.error || '无法加载模型目录', false)
+          setModels(null)
+        }
       }
     } catch (e) {
-      showToast(e instanceof Error ? e.message : String(e), false)
+      if (token === modelsTokenRef.current) {
+        showToast(e instanceof Error ? e.message : String(e), false)
+        setModels(null)
+      }
+    } finally {
+      if (token === modelsTokenRef.current) setModelsLoading(false)
     }
+  }
+
+  // 关闭「查看模型」弹窗：同时重置加载态，避免加载中无法关闭
+  const closeModels = () => {
+    modelsTokenRef.current++ // 使在途同步结果失效，防止完成后重新打开弹窗
+    setModels(null)
+    setModelsLoading(false)
   }
 
   useEffect(() => {
@@ -325,45 +486,61 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
         />
       )}
 
-      {models && (
-        <div className="modal-overlay" onClick={() => setModels(null)}>
-          <div className="modal" style={{ maxWidth: '560px' }} onClick={(e) => e.stopPropagation()}>
+      {(models || modelsLoading) && (
+        <div className="modal-overlay" onClick={closeModels}>
+          <div className="modal models-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
-              <h3>模型 · {modelsLabel}</h3>
-              <button className="btn-icon" onClick={() => setModels(null)} aria-label="关闭">×</button>
+              <h3>{modelsLabel}</h3>
+              <button className="modal-close" onClick={closeModels} aria-label="关闭">
+                <IconClose size={14} />
+              </button>
             </div>
             <div className="modal-body">
-              <div className="models-free-quota">
-                免费额度
-                {modelsQuota?.available
-                  ? ` ${modelsQuota.remaining} / ${modelsQuota.total} ${modelsUnit}`
-                  : ' —'}
-              </div>
-              <table className="models-table">
-                <thead>
-                  <tr>
-                    <th>模型</th>
-                    <th>用量</th>
-                    <th>价格</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {models.map((m) => (
-                    <tr key={m.model}>
-                      <td><strong>{m.model}</strong></td>
-                      <td>{m.cost === 0 ? '∞' : '—'}</td>
-                      <td>
-                        <span className={'badge ' + (m.cost === 0 ? 'badge-success' : 'badge-pending')}>
-                          {m.priceLabel}
-                        </span>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              {modelsLoading ? (
+                <div className="models-loading">
+                  <span
+                    className="spinner"
+                    style={{ width: 20, height: 20, border: '2px solid var(--border)', borderTopColor: 'var(--accent)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }}
+                  />
+                  <span>{modelsProviderId === 'volcengine' ? '正在同步最新免费额度，请稍候…' : '正在加载模型目录，请稍候…'}</span>
+                </div>
+              ) : models ? (
+                <>
+                  <ModelsQuotaSummary providerId={modelsProviderId} models={models} quota={modelsQuota} unit={modelsUnit} />
+                  <table className="models-table">
+                    <thead>
+                      <tr>
+                        <th>模型</th>
+                        <th>用量</th>
+                        <th>价格</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {models.map((m) => (
+                        <tr key={m.model}>
+                          <td className="models-cell-model">
+                            <code className="models-model-code">{m.model}</code>
+                          </td>
+                          <td className="models-cell-quota">
+                            <ModelQuotaCell providerId={modelsProviderId} model={m} sharedQuota={modelsQuota} unit={modelsUnit} />
+                          </td>
+                          <td>
+                            <span
+                              className={'badge ' + (m.cost === 0 ? (m.activated === false ? 'badge-pending' : 'badge-success') : 'badge-pending')}
+                              title={m.activated === false ? '未开通模型，需在火山方舟控制台开通' : undefined}
+                            >
+                              {m.priceLabel}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
+              ) : null}
             </div>
             <div className="modal-footer">
-              <button className="btn-sm primary" onClick={() => setModels(null)}>关闭</button>
+              <button className="btn-sm primary" onClick={closeModels}>关闭</button>
             </div>
           </div>
         </div>
@@ -575,7 +752,7 @@ function ProviderRow({
                         )}
                       </td>
                       <td>
-                        {!isApiKeyProvider || agg.providerId === 'zhipu' ? (
+                        {!isApiKeyProvider || agg.providerId === 'zhipu' || agg.providerId === 'volcengine' ? (
                           <>
                             <button
                               className="btn-sm"

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -180,6 +180,13 @@ export interface ProvidersResult {
     string,
     { hasSession: boolean; status?: 'alive' | 'expiring' | 'expired'; expMs?: number | null; remainingMs?: number | null }
   >
+  /** 火山方舟各账号控制台会话状态（keyId -> alive/expiring/expired），供态展示与自动续期联动 */
+  volcSessionStatuses: Record<
+    string,
+    { hasSession: boolean; status?: 'alive' | 'expiring' | 'expired'; expMs?: number | null; remainingMs?: number | null }
+  >
+  /** 火山方舟额度同步：后台静默抓取该账号最新免费模型额度/开通状态并落库；命中返回新加密负载，未抓到返回 false */
+  refreshVolcengineModelsOnce: (keyId: string) => Promise<string | false>
 }
 
 export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult {
@@ -318,6 +325,139 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     if (zhipuKeys.length === 0) return
     zhipuKeys.forEach((key) => void fetchZhipuQuotaOnce(key.id))
   }, [user?.id, keys, fetchZhipuQuotaOnce])
+
+  /* ================= 火山方舟（volcengine）：控制台会话状态与静默续期（仿智谱） ================= */
+
+  /** 全局续期进行中标记：控制台会话分区共享，同一时刻只允许一个火山账号续期 */
+  let volcRenewInFlight = false
+  /** keyId -> 该火山账号最近一次续期尝试时间戳（失败节流） */
+  const volcRenewAt = new Map<string, number>()
+  /** 火山各账号控制台会话状态（keyId -> alive/expiring/expired），供态展示与自动续期联动 */
+  const [volcSessionStatuses, setVolcSessionStatuses] = useState<
+    Record<string, { hasSession: boolean; status?: 'alive' | 'expiring' | 'expired'; expMs?: number | null; remainingMs?: number | null }>
+  >({})
+
+  // 单次拉取火山某账号真实额度并写入覆盖（额度接口待探测，接口可用后即生效）；当前查询失败回退本地账本
+  const fetchVolcengineQuotaOnce = useCallback(
+    async (keyId: string): Promise<number | null> => {
+      const svc = getProviderService()
+      if (!svc || !user) return null
+      try {
+        const secret = await svc.getProviderKeySecret(user.id, keyId)
+        if (!secret) return null
+        const res = await window.api.providers.fetchQuota('volcengine', secret.encrypted_key)
+        if (res.ok && res.quota) return res.quota.remaining
+        return null
+      } catch {
+        return null
+      }
+    },
+    [user]
+  )
+
+  // 对单个火山账号做一次静默续期：成功则用新加密负载落库并重拉真实额度；全局一次只续一个（共享会话分区）
+  const renewVolcSessionOnce = useCallback(
+    async (keyId: string, encrypted: string): Promise<boolean> => {
+      if (volcRenewInFlight) return false
+      volcRenewInFlight = true
+      volcRenewAt.set(keyId, Date.now())
+      try {
+        const res = await window.api.providers.volcRenewSession(keyId, encrypted)
+        if (!res.ok || !res.encrypted) return false
+        const svc = getProviderService()
+        if (svc && user) {
+          await svc.refreshProviderKey(user.id, keyId, {
+            encryptedKey: res.encrypted,
+            healthStatus: 'healthy'
+          })
+        }
+        setVolcSessionStatuses((prev) => ({
+          ...prev,
+          [keyId]: { hasSession: true, status: 'alive', expMs: res.expMs ?? null, remainingMs: res.remainingMs ?? null }
+        }))
+        await fetchVolcengineQuotaOnce(keyId)
+        return true
+      } catch {
+        return false
+      } finally {
+        volcRenewInFlight = false
+      }
+    },
+    [user, fetchVolcengineQuotaOnce]
+  )
+
+  // 火山方舟额度同步：后台复用该账号分区登录态静默抓取最新免费模型额度/开通状态并落库。
+  // 命中（抓到新 models）则用重建的加密负载更新 DB 并返回新 encrypted，供「查看模型」即时展示；
+  // 未抓到（登录态失效/页面未就绪）保留旧值返回 false，不打断调用方。
+  const refreshVolcengineModelsOnce = useCallback(
+    async (keyId: string): Promise<string | false> => {
+      const svc = getProviderService()
+      if (!svc || !user) return false
+      try {
+        const secret = await svc.getProviderKeySecret(user.id, keyId)
+        if (!secret) return false
+        const res = await window.api.providers.volcSyncModels(keyId, secret.encrypted_key)
+        if (!res.ok || res.preserved || !res.encrypted) return false
+        await svc.refreshProviderKey(user.id, keyId, {
+          encryptedKey: res.encrypted,
+          healthStatus: 'healthy',
+          // 同步回填账号级指纹：抓到的 accountId 稳定后重算指纹入库，同账号多 Key 共享，去重提示才命中
+          accountFingerprint: res.accountFingerprint ?? null
+        })
+        return res.encrypted
+      } catch {
+        return false
+      }
+    },
+    [user]
+  )
+
+  // 扫描所有火山账号的会话状态：命中 expiring / expired 且未到重试节流时，触发一次静默续期并停止本轮
+  const scanVolcSessions = useCallback(async (): Promise<void> => {
+    if (volcRenewInFlight) return
+    const svc = getProviderService()
+    if (!svc || !user) return
+    const now = Date.now()
+    for (const key of keys.filter((k) => k.provider_id === 'volcengine')) {
+      if (now - (volcRenewAt.get(key.id) ?? 0) < ZHIPU_RENEW_RETRY_MS) continue
+      let secret: { encrypted_key: string } | null = null
+      try {
+        secret = await svc.getProviderKeySecret(user.id, key.id)
+      } catch {
+        continue
+      }
+      if (!secret) continue
+      let state
+      try {
+        state = await window.api.providers.volcSessionStatus(key.id, secret.encrypted_key)
+      } catch {
+        continue
+      }
+      setVolcSessionStatuses((prev) => ({ ...prev, [key.id]: state }))
+      if (state.hasSession && (state.status === 'expiring' || state.status === 'expired')) {
+        await renewVolcSessionOnce(key.id, secret.encrypted_key)
+        return
+      }
+    }
+  }, [user, keys, renewVolcSessionOnce])
+
+  // 启动火山会话状态扫描：初始化立即扫一次，之后周期轮询；账号切换时重建
+  useEffect(() => {
+    if (!user) return
+    void scanVolcSessions()
+    const t = setInterval(() => {
+      void scanVolcSessions()
+    }, ZHIPU_SESSION_SCAN_MS)
+    return () => clearInterval(t)
+  }, [user?.id, scanVolcSessions])
+
+  // 初始化 / 刷新时主动拉取火山各账号真实额度
+  useEffect(() => {
+    if (!user || keys.length === 0) return
+    const volcKeys = keys.filter((k) => k.provider_id === 'volcengine')
+    if (volcKeys.length === 0) return
+    volcKeys.forEach((key) => void fetchVolcengineQuotaOnce(key.id))
+  }, [user?.id, keys, fetchVolcengineQuotaOnce])
 
   // 会话内覆盖某账号健康状态（API Key 测试成功/失败后即时反映，不落库）
   const setKeyHealth = useCallback((keyId: string, status: string) => {
@@ -494,6 +634,12 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
         void refreshZhipuQuota(payload.zhipuRefreshKeyId)
         return
       }
+      // 火山方舟生成完成：静默同步该账号免费模型真实剩余额度（开通管理页抓取），并刷新账本
+      if (payload.volcRefreshKeyId) {
+        void refreshVolcengineModelsOnce(payload.volcRefreshKeyId)
+        // 同步后重拉该账号真实额度，让页面剩余展示即时生效
+        void fetchVolcengineQuotaOnce(payload.volcRefreshKeyId)
+      }
       const ledger = payload.ledger
       setLedgers((prev) => {
         const idx = prev.findIndex((l) => l.id === ledger.id)
@@ -505,7 +651,7 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
         return [ledger, ...prev]
       })
     })
-  }, [user?.id, refreshZhipuQuota])
+  }, [user?.id, refreshZhipuQuota, refreshVolcengineModelsOnce, fetchVolcengineQuotaOnce])
 
   // 健康检查：与数据加载解耦，keys 就绪后独立运行（节流 + 并发限制，见 runHealthChecks）
   useEffect(() => {
@@ -696,6 +842,8 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     unbind,
     zhipuQuotaOverrides,
     setKeyHealth,
-    zhipuSessionStatuses
+    zhipuSessionStatuses,
+    volcSessionStatuses,
+    refreshVolcengineModelsOnce
   }
 }

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -9,7 +9,8 @@ export const PROVIDER_LABEL: Record<string, string> = {
   dola: 'Dola',
   kling: '可灵',
   hailuo: '海螺',
-  zhipu: '智谱（bigmodel）'
+  zhipu: '智谱（bigmodel）',
+  volcengine: '火山方舟'
 }
 
 export const MODELS: Record<string, string[]> = {
@@ -21,7 +22,8 @@ export const MODELS: Record<string, string[]> = {
   dola: ['Dreamina Seedance 2.5', 'Dreamina Seedance 2.0 Fast', 'Dreamina Seedance 1.0'],
   kling: ['可灵-标准', '可灵-大师'],
   hailuo: ['海螺-标准'],
-  zhipu: ['cogvideox-flash', 'cogvideox-2', 'cogvideox-3', 'Vidu Q1', 'Vidu 2']
+  zhipu: ['cogvideox-flash', 'cogvideox-2', 'cogvideox-3', 'Vidu Q1', 'Vidu 2'],
+  volcengine: ['doubao-seedance-1-0-pro-250528', 'doubao-seedance-1-5-pro-251215', 'doubao-seedance-1-0-pro-fast-251015', 'doubao-seedance-1-0-lite-t2v', 'doubao-seedance-1-0-lite-i2v']
 }
 
 /** 智谱模型展示价格（与主进程 api-branch 保持一致） */
@@ -47,6 +49,23 @@ export function zhipuModelDurations(model: string): number[] {
   return ZHIPU_MODEL_DURATIONS[model] ?? DEFAULT_SUPPORTED_DURATIONS
 }
 
+/** 火山方舟（volcengine）免费视频模型：有免费推理额度，Model ID 为平台固定目录（与 docs 实测一致） */
+export const VOLC_MODEL_PRICE: Record<string, string> = {
+  'doubao-seedance-1-0-pro-250528': '免费',
+  'doubao-seedance-1-5-pro-251215': '免费',
+  'doubao-seedance-1-0-pro-fast-251015': '免费',
+  'doubao-seedance-1-0-lite-t2v': '免费',
+  'doubao-seedance-1-0-lite-i2v': '免费'
+}
+
+/** 火山方舟各模型固定生成时长（秒）；以相机生产链路为准，未收录模型走默认档 */
+export const VOLC_MODEL_DURATIONS: Record<string, number[]> = {}
+
+/** 火山方舟按模型取有效时长；未收录回退默认档 */
+export function volcModelDurations(model: string): number[] {
+  return VOLC_MODEL_DURATIONS[model] ?? DEFAULT_SUPPORTED_DURATIONS
+}
+
 export interface DurationOption {
   value: number
   label: string
@@ -59,6 +78,13 @@ const DURATION_ORDER = [5, 10, 15] as const
 
 /** 千问视频生成模式按模型限定；本轮不再给 qwenwan 暴露文生/图生视频 */
 export function providerModeOptions(provider: string, model = ''): Array<{ value: string; label: string }> {
+  if (provider === 'volcengine') {
+    // 火山免费视频模型支持文生视频 + 图生视频（Seedance 均有免费额度）
+    return [
+      { value: 'text2video', label: '文生视频' },
+      { value: 'img2video', label: '图生视频' }
+    ]
+  }
   if (provider === 'zhipu') {
     switch (model) {
       case 'cogvideox-flash':
@@ -194,6 +220,13 @@ export function ratioOptions(provider: string): Array<{ value: string; label: st
 }
 
 export function uploadHint(provider: string, mode: string): string {
+  if (provider === 'volcengine') {
+    const map: Record<string, string> = {
+      img2video: '图生视频需上传 1 张首帧图片',
+      text2video: '文生视频无需上传素材'
+    }
+    return map[mode] ?? '文生视频无需上传素材'
+  }
   if (provider === 'zhipu') {
     const map: Record<string, string> = {
       img2video: '生视频需上传 1 张首帧图片',
@@ -225,6 +258,10 @@ export function computeCost(
   resolution: string
 ): CostResult {
   const d = DURATION_POINT[duration] ?? 0
+  if (provider === 'volcengine') {
+    const price = VOLC_MODEL_PRICE[model] ?? '免费'
+    return { text: price, who: model + ' · ' + duration + 's' }
+  }
   if (provider === 'zhipu') {
     const price = ZHIPU_MODEL_PRICE[model] ?? '免费'
     return { text: price, who: model + ' · ' + duration + 's' }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2877,38 +2877,194 @@ body {
   border-top: 1px solid var(--border-light);
 }
 
-/* 查看模型弹窗：顶部免费额度用量（付费模型共用） + 模型/用量/价格 */
-.models-free-quota {
-  display: inline-flex;
-  align-items: center;
-  margin-bottom: 12px;
-  padding: 4px 10px;
-  font-size: 12px;
-  color: var(--accent);
-  background: var(--accent-bg);
-  border-radius: var(--radius-md);
+/* 查看模型弹窗：顶部汇总卡 + 模型/用量/价格表 */
+.models-modal {
+  width: 620px;
+  max-width: 92vw;
 }
+.models-modal .modal-header h3 {
+  font-family: var(--font-display);
+  font-size: 1.12em;
+  font-weight: 600;
+}
+
+/* 顶部免费额度汇总 */
+.models-summary {
+  margin-bottom: 14px;
+}
+.models-summary-bar {
+  position: relative;
+  width: 100%;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--border-light);
+  overflow: hidden;
+}
+.models-summary-bar-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.4s ease;
+}
+.models-summary-text {
+  margin-top: 10px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.95em;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg);
+}
+.models-summary-value {
+  font-weight: 600;
+}
+.models-summary-unit {
+  color: var(--fg-muted);
+  font-size: 0.85em;
+  margin-left: 2px;
+}
+.models-summary-sep {
+  color: var(--fg-muted);
+  margin: 0 6px;
+}
+.models-summary-total {
+  color: var(--fg-muted);
+}
+
+/* 模型弹窗 —— 单行三列对齐 */
+.models-modal {
+  width: 620px;
+  max-width: 94vw;
+}
+
+/* 顶部汇总：细进度线 + 一行文字 */
+.models-summary {
+  margin: 4px 0 12px;
+}
+.models-summary-bar {
+  height: 3px;
+  background: var(--border-light);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.models-summary-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #34d399, #60a5fa);
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+.models-summary-text {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-top: 6px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  color: var(--fg-secondary);
+}
+.models-summary-label {
+  color: var(--fg-muted);
+  font-size: 0.82em;
+  margin-right: 4px;
+}
+.models-summary-value {
+  font-weight: 600;
+  color: var(--fg);
+}
+.models-summary-unit {
+  font-size: 0.82em;
+  color: var(--fg-muted);
+  margin-left: 2px;
+}
+.models-summary-sep {
+  color: var(--fg-muted);
+  margin: 0 2px;
+}
+.models-summary-total {
+  color: var(--fg-muted);
+}
+
+/* 表格：auto 宽度，单行对齐 */
 .models-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.92em;
-}
-.models-table th,
-.models-table td {
-  text-align: left;
-  padding: 7px 8px;
-  border-bottom: 1px solid var(--border-light);
+  font-size: 0.88em;
 }
 .models-table th {
+  text-align: left;
+  padding: 0 12px 8px;
   color: var(--fg-muted);
   font-weight: 600;
   font-size: 0.78em;
   text-transform: uppercase;
-  letter-spacing: 0.4px;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border-light);
+  white-space: nowrap;
+}
+.models-table th:nth-child(3) {
+  text-align: right;
+}
+.models-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.models-table tbody tr:last-child td {
+  border-bottom: none;
 }
 .models-table td:last-child {
   text-align: right;
+}
+
+/* 「查看模型」加载态：转圈 + 文案居中 */
+.models-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 150px;
+  color: var(--fg-muted);
+  font-size: 0.92em;
+}
+
+/* 单元格内部：单行，不用 flex，避免破坏表格布局 */
+.models-cell-model,
+.models-cell-quota {
+  vertical-align: middle;
+}
+.models-model-code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.85em;
+  color: var(--fg);
+  background: var(--bg-elevated);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+  line-height: 1.5;
+}
+
+/* 用量列：单行 */
+.models-quota-cell {
+  display: inline-block;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.models-quota-text {
+  color: var(--fg);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9em;
+  white-space: nowrap;
+}
+.models-quota-text--dim {
+  color: var(--fg-muted);
 }
 
 .about-box {

--- a/docs/厂商与API平台接入/火山方舟API Key绑定.md
+++ b/docs/厂商与API平台接入/火山方舟API Key绑定.md
@@ -1,0 +1,226 @@
+# 火山引擎（火山方舟）API Key 绑定实施计划
+
+> 范围：本轮只做 **火山方舟 API Key 绑定**（含 API Key 校验、控制台会话捕获、真实额度查询与展示、账号级去重）。
+> 模型目录 / 视频生成（调度台生成能力）**本轮不做**（用户已明确「模型先只接有免费额度的，先暂时不接」），仅预留扩展点。
+> 内部 id：`volcengine`；展示名：`火山方舟`。
+
+---
+
+## 1. 摘要
+
+复用智谱（bigmodel）的「API Key 型厂商」接入模式（见 `docs/厂商与API平台接入/智谱AI开放平台账号绑定.md`），把火山方舟作为第二个 API Key 型厂商接入：
+
+- 数据面：火山方舟视频生成 API 为 **Bearer Token 鉴权**（`Authorization: Bearer <ARK_API_KEY>`），与智谱相同，`test API Key` 可复用「明文哈希→只读接口校验」。
+- 额度面：火山方舟 **API Key 无法查真实免费额度/资源包**（需火山控制台登录会话 + 内部接口），因此绑定流程需额外捕获**控制台会话**，存档后用其查真实额度（与智谱 `consoleJwt` 同构）。
+- 会话会过期，本轮按 **C 级：自动续期** 设计（用户选定）——解析 JWT `exp`、临期/过期时用持久化分区 + 隐藏窗口**静默重捕获**新 JWT 并回写，无需用户手动操作；静默失败才回退本地账本并暴露「重新登录」入口。该机制做成**智谱/火山通用**，火山首期落地。
+- 本轮交付：绑定弹窗支持火山方舟、捕获控制台会话并**自动续期**、账号页展示真实剩余额度、账号级去重。
+
+---
+
+## 2. 现状分析（智谱模板，已确认）
+
+| 环节 | 智谱实现（含文件） | 火山要做的 |
+|---|---|---|
+| 加密存储 | `providers.ts` `decodeZhipuPayload`，格式 `{v:1,apiKey,consoleJwt}` + `safeStorage` | 新增 `decodeVolcenginePayload`，相同结构复用 `{v:1,apiKey,consoleJwt}` |
+| 明文→指纹 | `zhipuAccountFingerprint`（customerId → `sha256(zhipu\|...c)`, 否则 key 哈希） | 新增 `volcengineAccountFingerprint` |
+| 测试 Key | `testZhipuApiKey` 调 `GET /models` | 新增 `testVolcengineApiKey` 调火山只读接口 |
+| 查额度 | `fetchZhipuQuota`（biz 接口+资源包过滤） | 新增 `fetchVolcengineQuota`（火山控制台额度接口） |
+| 捕获会话 | `captureZhipuConsoleSession`（fetch+XHR hook 捕获 Bearer JWT） | 新增 `captureVolcengineConsoleSession`；并抽出**通用会话捕获内核**（可见/静默两模式），智谱/火山复用 |
+| 过期续期 | 现状**无**：`fetchZhipuQuota` 无 JWT 时退用 API Key→401，`fetchZhipuQuotaOnce` 返回 null→回退本地账本展示，需手动重绑 | 新增 C 级自动续期（见 §5.9） |
+| 绑定 UI | `Modals.tsx` AddProviderModal：zhipu 分支「获取 API Key」按钮、存 consoleJwt、去重 | 增加 volcengine 分支，复用同一骨架 |
+| 额度刷新 | `useProviders.ts` `refreshZhipuQuota` + 30s 重试窗口 | 新增 `refreshVolcengineQuota` |
+| 真实额度展示 | `Providers.tsx` L420 `isApiQuota` / L541、`Dashboard.tsx` L1021 | 条件扩展到 `volcengine` |
+| DB seed | `migrations/0027_add_zhipu_provider.sql` | 新增 `migrations/0031_add_volcengine_provider.sql` |
+
+导出链：`packages/providers/src/volcengine.ts`（新）→ `src/index.ts` 增加再导出；桌面端从 `@quota-flow/providers` 引入（主进程 `providers.ts` 已如此引入 zhipu 函数）。
+
+---
+
+## 3. 火山方舟接口调研结论（2026-08 官方文档核对）
+
+### 3.1 视频生成数据面 API（本轮只用于校验 Key，生成后续再接）
+- Host：`https://ark.cn-beijing.volces.com/api/v3`
+- 鉴权：`Authorization: Bearer <ARK_API_KEY>`（数据面 API Key 鉴权，与智谱 id 相同，非签名 v4）
+- 提交：`POST /contents/generations/tasks`，body `{ model, content:[{type,text|url}], parameters:{...} }` → 返回任务 `id`
+- 查询：`GET /contents/generations/tasks/{id}`，`status ∈ queued/running/cancelled/succeeded/failed/expired`，视频在 `content.video_url`
+
+### 3.2 校验 API Key（不产生费用）
+- 用只读/开销为零的请求区分「无效 key(401)」：推荐 `GET /api/v3/contents/generations/tasks/{不存在id}`——有效 key 返回 404（未找到任务），无效 key 返回 401。
+- 落地时先用 curl 实测确认该路径的 401/404 区分；若不可靠，再退化为控制台会话内校验（见 §5）。
+
+### 3.3 真实免费额度 / 资源包（需控制台会话，本轮交付之一）
+- 火山 API Key **无法**直接读取资源包/免费额度（同智谱 biz 域，属控制台内部 API）。
+- 额度展示入口：`https://console.volcengine.com/ark/region:cn-beijing/openManagement?…&tab=ComputerVision`（用户提供）及 API Key 管理页 `https://console.volcengine.com/ark/region:cn-beijing/apikey`。
+- **确切额度接口 / 请求头 / 响应字段需运行时抓包确认**（见 §6，为唯一开放性风险）。
+
+---
+
+## 4. 关键决策
+
+1. **内部 id = `volcengine`，展示名 = `火山方舟`**（用户选定）。
+2. **额度展示 = 控制台会话捕获**（用户选定：本轮就做控制台会话捕获，不退回「静态/账本」）。
+3. **模型目录/生成能力本轮不做**：不新增 `provider_caps` 记录、不注册完整 `api-branch` 生成分支。
+4. **额度查询优先「控制台同源内执行」**：火山控制台请求带 AK/SK 签名头（`Authorization`/`X-Auth-*`/`X-t-*signature`）且有会话 cookie 绑定，主进程盲发请求难以重放签名；改为在**捕获会话用的持久化分区 webview 页内**发起同源 `fetch` 查额度接口，把 JSON 传回主进程解析。这样签名与 cookie 自动带上，最稳。
+5. **去重维度**：优先取火山账号标识（uid / IAM / customer），取不到则回退 API Key 哈希。
+6. **会话过期策略 = C 级自动续期（通用机制）**：解析 JWT `exp` 感知过期；临期/过期触发**静默重捕获**（见 §5.9），静默窗口利用持久化分区已有登录态直接拿到新 JWT，覆盖回写 provider_keys。静默失败才回退本地账本 + 暴露「重新登录」。智谱与火山共用同一套「会话捕获/过期管理」内核，火山首期落地。
+
+---
+
+## 5. 实施步骤（决策完整，可按序执行）
+
+### 5.1 DB 迁移：`migrations/0031_add_volcengine_provider.sql`
+参照 `migrations/0027_add_zhipu_provider.sql`：
+- `INSERT INTO providers (id, name, logo, capabilities, auth_type, unit_name, default_daily_quota, equivalent_count_divisor)`
+- 值：`id='volcengine'`、`name='火山方舟'`、`logo`（取「火」字，同智谱「智」风格）、`auth_type='apikey'`、`capabilities` 本轮给**空 models 数组**（模型延后）、`unit_name='次'`、`default_daily_quota`/`equivalent_count_divisor` 参照 zhipu（50/1）。
+- `ON CONFLICT (id) DO UPDATE ...`（幂等，同 0027）。
+
+### 5.2 `packages/providers/src/volcengine.ts`（新增）
+复制智谱 zhipu.ts 的日志/脱敏/容错骨架，仅实现本轮所需函数：
+
+1. 常量：`VOLC_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"`、控制台地址、分区 `persist:qf-volc-console`。
+2. `decodeVolcenginePayload(decrypted): { apiKey; consoleJwt? }`——与 `decodeZhipuPayload` 同构（兼容纯 key 旧格式）。导出。
+3. `testVolcengineApiKey(apiKey): Promise<{ok; error?}>`——调用 §3.2 只读校验。导出。
+4. `fetchVolcengineQuota(apiKey, consoleJwt?): Promise<{ok:true; quota:VolcQuota}|{ok:false;error}>`
+   - 优先用 consoleJwt 查火山控制台额度接口；请求本身在**控制台同源**执行（参数携带「在页面内执行的脚本」或回传 URL+headers 供页内跑）。
+   - `VolcQuota` 结构对齐 zhipu：`{ available, total, remaining, expiresAt?, packageName?, expired?, accountId? }`。
+   - **注意**：由于额度接口未定（§6），先按「页内同源 fetch 指定接口 + 返回 raw，再由主进程按探测到的字段解析」封装，字段解析逻辑留探测后补齐。
+5. `volcengineAccountFingerprint(payload): Promise<string|null>`——有 consoleJwt 时先取账号标识，回退 key 哈希。导出。
+6. `export interface VolcengineQuota`。
+7. 会话过期工具（放同一文件或抽 `console-session.ts` 新文件，先放本文件、后续统一重排）：
+   - `jwtExpiryMs(jwt): number | null`——解码 `eyJ...` 中段(base64url)取 `exp`（秒→毫秒）；解析不了返回 null。
+   - 供主进程读取会话状态与过期时间。
+
+### 5.3 `packages/providers/src/index.ts`
+在文件顶部加 `export * from "./volcengine"`（并确认 zhipu 的再导出在源码中的正确位置，见「注意」）。
+
+> ⚠️ 注意：当前 `src/index.ts` **源码**未再导出 zhipu（仅在已构建的 `dist/index.*` 里有），易在下次 rebuild 时把桌面端 zhipu 导入打穿。落地时应先在 `src/index.ts` 补上 zhipu 再导出（保持 dist 与 src 一致），再放 volcengine。
+
+### 5.4 主进程 `apps/desktop/src/main/providers.ts`
+1. import：`testVolcengineApiKey`、`fetchVolcengineQuota`（来自 `@quota-flow/providers`）。
+2. `decodeVolcenginePayload` 导出（或复用 zhipu 同名结构，直接复用 `decodeZhipuPayload`——两厂商 payload 结构相同，可直接复用，避免重复）。
+3. `provider:encrypt`：在 `providerId === 'zhipu'` 分支旁加 `providerId === 'volcengine' ? await volcengineAccountFingerprint(plain):...`。
+4. `provider:test-api-key`：当前硬编码 `testZhipuApiKey`；改为按 `_providerId` 路由（zhipu→testZhipuApiKey，volcengine→testVolcengineApiKey）。
+5. `provider:fetch-quota`：同时按 `_providerId` 路由。
+6. 新增 `captureVolcengineConsoleSession()`（参照 `captureZhipuConsoleSession`）：
+   - 分区：`persist:qf-volc-console`；窗口 `paintWhenInitiallyHidden:true`、`contextIsolation:true`、`nodeIntegration:false`、**`sandbox:false`**；加载前 `clearStorageData()`（保留 HTTP 缓存）。
+   - 加载 `https://console.volcengine.com/ark/region:cn-beijing/apikey`。
+   - 注入 hook（用 `window.__QUOTA_FLOW_VOLC__` 去重）：hook `window.fetch` + `XMLHttpRequest.setRequestHeader/open/send`，捕获 `authorization`、`x-auth-ctoken`、`x-auth-session` 等头里的令牌；`store()` 时先剥离 `Bearer ` 前缀并尝试 JWT 正则；兜底扫描 localStorage/sessionStorage + 主进程 `session.cookies` 取 auth cookie。
+   - 注入条：标题「⋮⋮  Quota-Flow · 火山方舟控制台」，文案说明在「API Key 管理/开通管理」页操作，绿色按钮「已获取key返回」，可拖拽（复用智谱条样式与拖拽逻辑）。
+   - 轮询 `window.__VF_SUBMIT__`，拿到会话令牌后 `done({ok:true, consoleJwt})`。
+7. **抽通用会话捕获内核并支持静默模式（C 级自动续期的根基）**：把 `captureZhipuConsoleSession` 与火山版本重构为共用 `runConsoleCapture({ partition, url, inject, tokenKey, name, quiet })`：
+   - `quiet === true`：`new BrowserWindow({ show:false, paintWhenInitiallyHidden:true, webPreferences:{...} })`，**不注入可拖拽条**，仅注入 hook；轮询 `window.<capturedVar>` 直到捕获到令牌 或 超时（如 25s）自动销毁；成功/超时后 `done(...)`。因持久化分区保留登录 cookie，静默加载已登录分区会自然触发已鉴权请求、hook 自动捕获新 JWT。
+   - `quiet === false`：现有可见窗口 + 注入条 + 用户点击按钮返回（保持智谱/火山首绑交互不变）。
+8. **新增会话状态/续期 IPC**（C 级）：
+   - `provider:console-session-status({ providerId, encrypted })` → 主进程解码 payload，取 `consoleJwt`，用 `jwtExpiryMs` 算 `expMs`，返回 `{ hasConsoleJwt:boolean; expMs:number|null }`（无 consoleJwt → `hasConsoleJwt:false, expMs:null`）。
+   - `provider:renew-console-session({ providerId, encrypted })` → 解码 payload 分理出 `apiKey`，调 `runConsoleCapture(..., { quiet:true })` 静默拿新 `consoleJwt`；成功后返回 `{ ok:true, consoleJwt }`（渲染层据此重加密回写）；失败返回 `{ ok:false, error:'会话需重新登录' }`。
+9. `initProviders()`：注册 `provider:capture-volcengine-session`、`provider:console-session-status`、`provider:renew-console-session` IPC。
+
+### 5.5 `apps/desktop/src/preload/index.ts`
+在 `providers` 接口下新增三组（`encrypt`/`testApiKey`/`fetchQuota` 已接收 providerId，天然通用无需改）：
+- `captureVolcengineSession: () => Promise<{ ok: boolean; consoleJwt?: string; error?: string }>`。
+- `consoleSessionStatus: (providerId: string, encrypted: string) => Promise<{ hasConsoleJwt: boolean; expMs: number | null }>`。
+- `renewConsoleSession: (providerId: string, encrypted: string) => Promise<{ ok: boolean; consoleJwt?: string; error?: string }>`。
+
+### 5.6 渲染层 `apps/desktop/src/renderer/src/components/Modals.tsx`
+1. `saveApiKey`：`const raw = (providerId === 'zhipu' || providerId === 'volcengine') && consoleJwt ? JSON.stringify({v:1,apiKey:trimmed,consoleJwt}) : trimmed`。
+2. 新增 `openGetVolcEngineKey()`：调 `window.api.providers.captureVolcengineSession()`，`ok && consoleJwt` → `setConsoleJwt`。
+3. 按钮区（L1256）：`{(providerId === 'zhipu' || providerId === 'volcengine') && (<button ... onClick={providerId==='volcengine'?openGetVolcEngineKey:openGetApiKey}>获取 API Key</button>)}`。
+4. 复用既有去重/刷新已绑定流程，无需改。
+
+### 5.7 额度刷新 `apps/desktop/src/renderer/src/hooks/useProviders.ts`
+- 新增 `refreshVolcengineQuota`（镜像 `refreshZhipuQuota`：`window.api.providers.fetchQuota('volcengine', secret.encrypted_key)` + 30s 重试窗口 + 覆盖展示）。
+- 在初始化/账号切换时把 `volcengine` 账号一并纳入额度刷新。
+- **会话状态表（C 级续期驱动）**：新增 `sessionStates: Record<keyId, { hasConsoleJwt:boolean; expMs:number|null; state:'alive'|'expiring'|'expired'|'missing'|'renewing'|'renew_failed' }>`，与额度刷新联动。
+
+### 5.8 展示扩展
+- `spec.ts`：`PROVIDER_LABEL.volcengine = '火山方舟'`；`MODELS.volcengine` 本轮给空/注释（模型延后）。
+- `Providers.tsx`：L420 `isApiQuota` 与 L541 展示分支条件从 `providerId === 'zhipu'` 扩为同时支持 `volcengine`（展示真实剩余额度；额度单位/默认日额度/等效除数字段对 apikey 厂商隐藏，火山同 zhipu）；L422 附近对 `hasConsoleJwt` 为空的 apikey 账号显示「未捕获会话」提示，`renew_failed` 显示「会话需重新登录」+ 点击重取入口。
+- `Dashboard.tsx`：L1021 `isApiQuota` 同理扩展；本轮不做模型下拉/价格徽标（模型延后）。
+
+### 5.9 C 级：控制台会话过期自动续期设计（通用机制，火山首期落地）
+
+**目标**：额度来源的 `consoleJwt` 过期后无需用户手动操作，后台静默续期；只有静默续期也失败（控制台登录态整体失效）才回退账本并提示重新登录。
+
+**状态机**（每账号一个 `sessionStates[keyId].state`）：
+```
+missing ──首次捕获──▶ alive ──距 exp < 15min──▶ expiring ──到期──▶ (静默续期)
+alive/expiring ──静默续期成功──▶ alive(新 exp)
+expiring/expired ──静默续期失败──▶ renew_failed ──(手动「重新登录」)──▶ (可见窗口重捕获)→alive
+```
+
+**前端调度（`useProviders.ts`）**：
+1. 初始化/账号切换后，对每个 apikey 账号调 `consoleSessionStatus(providerId, encrypted_key)`，得到 `{hasConsoleJwt, expMs}`，写入 `sessionStates`：
+   - 无 consoleJwt → `missing`（仅提示「未捕获会话」，不自动续期）。
+   - 有 expMs：
+     - `expMs - now > 15min` → `alive`（本次不动作，交给定时器）。
+     - `0 < expMs - now ≤ 15min` → `expiring` → 本轮即触发续期。
+     - `expMs ≤ now` → `expired` → 本轮即触发续期。
+   - expMs 解析失败（非标准 JWT）→ 按 `alive` 对待，仅通过额度接口 401 兜底续期。
+2. **定时器**（如每 10 分钟）：遍历 apikey 账号，`expiring`/`expired` 的触发续期；顺带把 `alive` 但额度接口近期 401 的也触发。
+3. **续期动作 `renewSessionFor(keyId)`**：
+   - 置 `state='renewing'`；调 `renewConsoleSession(providerId, encrypted_key)`。
+   - 成功返回新 `consoleJwt` → 复用绑定写入路径（`provider:encrypt` 重生成 `{v:1,apiKey,consoleJwt}` → 更新 `provider_keys.encrypted_key`）→ 置 `alive`，随后立即 `fetchQuota` 刷新真实额度。
+   - 失败 → 置 `renew_failed`，`zhipuQuotaOverrides` 保持/清空（回退本地账本展示），下次定时器不再反复骚扰（频率上限，如 30min）。
+   - 并发防抖：同 keyId 续期进行中时，重复触发直接跳过。
+4. **生成后额度刷新**：`quota:updated` 事件仍走 `refreshZhipuQuota`/`refreshVolcengineQuota`；若此时返回 401，则视为会话过期，触发一次续期再查。
+
+**主进程**：`renewConsoleSession` = 解码 payload → `runConsoleCapture({..., quiet:true})` → 返回新 consoleJwt；成功与否都确保隐藏窗口销毁、定时器清理（复用智谱捕获的 done/closed 清理套路）。静默模式不使用 `clearStorageData()`（那是首绑时清登录态用的，续期必须保留 cookie）。
+
+**智谱迁移关系**：机制通用后，智谱的 `provider:fetch-quota`（已在 zhipu 实现 401 回退）可平滑接入同一续期循环；本轮先火山落地，智谱接入作为 §9 后续项，避免一次改动过大。
+
+---
+
+## 6. 控制台额度接口探测（核心开放风险，实施时实测定稿）
+
+火山控制台额度接口未公开、字段未知，**必须在接入时实抓**，步骤（与智谱 biz 抓包同套路）：
+
+1. 用 §5.4 的捕获会话窗口登录后，停留在「开通管理（ComputerVision）」/「API Key 管理」页。
+2. 在注入脚本里加**请求日志**：记录所有 `ark`/`openManagement`/`quota`/`resource`/`package` 相关 `fetch/XHR` 的 URL、method、关键请求头（脱敏）、以及响应体前缀，输出到主进程 console（`[volc-console]` 前缀）。
+3. 据此确定「返回资源包/免费额度剩余/总量」的那个接口，及其字段（如 `available`/`total`/`status`，确认是否有 `EXPIRED` 类似态需过滤）。
+4. 把该接口 URL + 字段映射固化进 `fetchVolcengineQuota`（页内同源执行，见 §4-4 决策，规避签名重放）。
+5. 同时从「账号信息/用户接口」找稳定账号标识（uid/IAM/customer）供去重；找不到则用 API Key 哈希回退。
+
+> 若「页内同源执行」路线遇 CSP 阻断 `executeJavaScript` 的 fetch，则把主进程 replay 作为备选（用捕获到的 headers 集合 + cookie 重放），或直接让捕获窗口在页内静默调额度接口并把结果回填 `window.__VF_QUOTA__` 供主进程轮询取回。
+
+---
+
+## 7. 假设与决策清单
+
+| # | 决策/假设 | 依据 |
+|---|---|---|
+| 1 | id=`volcengine`，名=`火山方舟` | 用户确认 |
+| 2 | 本轮=绑定+会话捕获+真实额度；模型/生成延后 | 用户确认 |
+| 3 | 数据面 Bearer 鉴权，testKey 用只读接口 | 官方文档核对 §3 |
+| 4 | 额度=控制台内部接口，需会话捕获 | 用户确认 + 智谱先例 |
+| 5 | 额度查询走控制台同源执行 | 火山签名头难重放（保守选稳） |
+| 6 | payload 复用 `{v:1,apiKey,consoleJwt}` 结构 | 与智谱兼容，减少代码 |
+| 7 | 去重优先账号标识、回退 key 哈希 | 智谱先例 |
+| 8 | volcengine 同 zhipu 在 apikey 下隐藏额度单位/默认日额度/等效除数 | 智谱先例 |
+| 9 | 会话过期 = C 级自动续期（解析 exp + 静默重捕获 + 回写），通用内核火山首期落地 | 用户选定 |
+| 10 | 静默续期失败才回退本地账本，并暴露「重新登录」 | 智谱现状补强 |
+
+---
+
+## 8. 验证步骤
+
+1. `pnpm --filter @quota-flow/providers build`（确保 dist 含 volcengine，且不再丢 zhipu 导出）+ 桌面端与 db 包 `typecheck`。
+2. 执行 `migrations/0031_add_volcengine_provider.sql`，`providers` 表出现 `volcengine` 行（apikey）。
+3. 完全退出并重启桌面应用（旧打包产物不热更）。在「绑定」弹窗选「火山方舟」：
+   - 输入火山方舟 API Key → 点「测试 API Key」：无效 key 报红、有效 key 绿提示。
+   - 点「获取 API Key」：打开火山控制台，登录后按钮返回，弹窗显示「已获取控制台会话」。
+   - 保存：账号出现在厂商列表，展开显示真实剩余额度（来自控制台额度接口），且绑定成功即刷新额度。
+4. 去重：同一火山账号用另一 API Key 再绑定 → 弹出「检测到相同账号，更新已有 / 仍要新建」确认（与智谱一致）。
+5. 观察主进程以 `[volc-console]` / `[volc-quota]` 前缀日志，确认捕获与额度解析路径正确。
+6. **自动续期（C 级）**：
+   - 进入「会话状态」：已捕获会话的火山账号 `state=alive` 且 `expMs` 有效。
+   - 临时把续期阈值临时调大/伪造一个已过期的 expMs 的 payload 存入该账号 → 观察定时器自动触发 `renewConsoleSession`，隐藏窗口静默捕获新 JWT 并回写 `provider_keys.encrypted_key`，期间无可见窗口闪现。
+   - 手动停用/清掉控制台登录态后再触发续期 → `state=renew_failed`，账号行显示「会话需重新登录」、额度回退本地账本，点击「重新登录」能打开可见窗口重捕获恢复。
+   - 观察并发防抖：同账号续期中重复触发被跳过，无重复开窗。
+
+---
+
+## 9. 后续（本轮不做，仅记录）
+
+- 智谱接入同一自动续期内核：`provider:fetch-quota` 已有 401 回退，接入 `renewConsoleSession` + 前端 `sessionStates` 循环即可，属增量小改。
+- 火山方舟模型目录（只接有免费额度的模型）：新增 `provider_caps` 记录 + `api-branch` 注册 `volcengine` 分支（提交 `POST /contents/generations/tasks`、轮询 `GET .../{id}`、取 `content.video_url`），同步 `spec.ts` 模式/时长/价格/提示词辅助提示、Dashboard 模型下拉与价格徽标。
+- 会话捕获/过期内核完成后，理论上可推广到元宝/千问等「登录 Cookie」型厂商（若其 cookie 同样会过期），作为远期统一会话管理。

--- a/docs/厂商与API平台接入/火山方舟免费视频模型额度对接.md
+++ b/docs/厂商与API平台接入/火山方舟免费视频模型额度对接.md
@@ -1,0 +1,181 @@
+# 火山方舟免费视频模型额度与调用参数对接
+
+> 目标：记录火山方舟（volcengine）「免费额度视频生成模型」的**额度来源**与**调用参数**（Model ID + 提交/查询 API），供桌面端接入实时查找。
+> 与 `火山方舟API Key绑定.md`（绑定/会话/去重）配套；本文聚焦**额度数据 + 调用方式**的内存。
+
+---
+
+## 0. 硬约束（必须遵守）
+
+**新账号绑定时，必须立即获取该账号「有免费额度的视频生成模型」的 Model ID 并入库。**
+- 因为免费额度是按**账号**（而非按 key）核算的；同一个火山账号绑定后，未开通/已开通的免费视频模型归属已定。
+- 绑定后额度展示、去重、后续生成校验都依赖这个 Model ID 列表，故**绑定流程内完成抓取**，而不是等用户手动去控制台翻。
+
+**Model ID 是平台固定值**，实测来源：
+1. 在线推理「预置推理接入点」表（仅已开通）。
+2. 官方《模型列表》文档（全量，含未开通）。
+
+---
+
+## 1. 现场实测数据（2026-08-19 登录火山方舟后台抓取）
+
+### 1.1 免费额度（开通管理 → 视觉模型 tab）
+
+| 模型 | 开通状态 | 免费额度 | Model ID | 免费额度来源 |
+|------|---------|---------|----------|------------|
+| Doubao-Seedance-**1.5-pro** | 已开通 | 2,000,000 / 2,000,000 token | `doubao-seedance-1-5-pro-251215` | 开通管理页 |
+| Doubao-Seedance-**1.0-pro** | 已开通 | 272,120 / 2,000,000 token | `doubao-seedance-1-0-pro-250528` | 开通管理页 |
+| Doubao-Seedance-1.0-pro-fast | 未开通 | 2,000,000 / 2,000,000 token | `doubao-seedance-1-0-pro-fast-251015` | 开通管理页 |
+| Doubao-Seedance-1.0-lite-t2v | 未开通 | 2,000,000 / 2,000,000 token | `doubao-seedance-1-0-lite-t2v-250428` | 开通管理页 |
+| Doubao-Seedance-1.0-lite-i2v | 未开通 | 2,000,000 / 2,000,000 token | `doubao-seedance-1-0-lite-i2v` | 开通管理页 |
+| **Wan2.1-14B** | 未开通 | 2,000,000 / 2,000,000 token | `wan2-1-14b-t2v` / `wan2-1-14b-i2v`（按 mode，基名入库为 `wan2-1-14b`） | 开通管理页 |
+
+**已有免费额度并已开通的两个：1.5-pro、1.0-pro**（其预置推理接入点也已自动创建，见 §1.2）。
+
+> ✅ 修订（2026-08-19 后半程）：`1.0-lite-t2v/i2v` 在开通管理页显示有免费额度，**应按「有免费额度的视频模型」接入**；其 Model ID 已从官方《创建视频生成任务》文档核实（lite-t2v 带 `-250428` 后缀），不再视为「文档未收录」。Wan2.1-14B 同样是有免费额度的视频模型，文生/图生走不同 Model ID（`wan2-1-14b-t2v` / `wan2-1-14b-i2v`）。
+
+### 1.2 当前无免费额度展示的视频模型（按真实额度判定，并非按版本排斥）
+
+> ⚠️ 原则：抓取完全**按卡片是否带「免费推理额度」判定**，不按模型名/版本排除。2.x 只是因为它在开通管理页**自己这张卡片上不带免费额度**才没被抓到（若某 2.x 卡片真显示出免费额度，会与其他模型一样被自动收录）。
+
+Seedance **2.x 系列**（2.5 / 2.0 / 2.0-fast / 2.0-mini）在开通管理页**自身卡片不显示免费额度**，属纯按量付费，且开通门槛为「余额>200 元或购买资源包」，因此当前实测不产生免费额度项。
+
+- `doubao-seedance-2-5-260628`
+- `doubao-seedance-2-0-260128`
+- `doubao-seedance-2-0-fast-260128`
+- `doubao-seedance-2-0-mini-260615`
+
+### 1.3 在线推理「预置推理接入点」表（已开通模型，含 Model ID + Endpoint ID）
+
+实测可看到已开通模型的预置接入点（Model ID 与 Endpoint ID 都展示）：
+
+| 接入模型 | Model ID | Endpoint ID（预置接入点） |
+|---------|----------|--------------------------|
+| Doubao-Seedance-1.0-pro | `doubao-seedance-1-0-pro-250528` | `ep-m-20251110092555-6zwrl` |
+| Doubao-Seed-2.1-pro | `doubao-seed-2-1-pro-260628` | `ep-m-20260806163500-vd8vt` |
+| …（其余为未收录/无关模型） | … | … |
+
+> 预置接入点可直接用 **Model ID** 调用（无需创建自定义接入点）；自定义接入点才用 Endpoint ID（`ep-*`）。视频生成走预置接入点 → 传 Model ID 即可。
+
+---
+
+## 2. 视频生成调用方式
+
+### 2.1 提交任务
+
+```
+POST https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks
+Authorization: Bearer <ARK_API_KEY>
+Content-Type: application/json
+```
+
+**Body 字段**（来自官方《创建视频生成任务》文档实录）：
+
+| 字段 | 说明 | 必选/默认 |
+|------|------|----------|
+| `model` | Model ID（如上 §1） | 必选 |
+| `content[]` | 输入内容列表（见下） | 必选 |
+| `omni_reference_task_type` | 任务类型引导 | 默认 `auto` |
+| `resolution` | 视频分辨率 | 可选 |
+| `ratio` | 视频宽高比 | 可选 |
+| `duration` | 视频时长（秒，整数） | 可选 |
+| `frames` | 视频帧数 | 可选 |
+| `generate_audio` | 生成有声视频 | 默认 `true` |
+| `watermark` | 视频水印 | 默认 `false` |
+| `output_format` | 输出格式 | 默认 `mp4` |
+| `seed` | 随机种子 | 默认 `-1` |
+| `camera_fixed` | 固定摄像头 | 默认 `false` |
+| `service_tier` | 服务等级 | 默认 `default` |
+
+**`content[]` 元素**：
+- 文生视频：`{ "type": "text", "text": "提示词" }`
+- 图生视频（追加）：`{ "type": "image_url", "image_url": { "url": "<公网图地址>" }, "role": "reference_image" }`
+- 多参考视频/音频：对应 `type` 为 `video_url`/`audio_url`，`role` 区分（`reference_video` / 首尾帧等）
+
+**返回**：`{ "id": "<任务id>" }`
+
+### 2.2 查询任务结果
+
+```
+GET https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks/{id}
+Authorization: Bearer <ARK_API_KEY>
+```
+
+响应 `status ∈ queued / running / cancelled / succeeded / failed / expired`；成功后视频地址在 `content.video_url`（`content` 数组里）。
+
+### 2.3 官方 SDK 参考（volcengine-python-sdk[ark]）
+
+```python
+from volcenginesdkarkruntime import Ark
+client = Ark(
+    base_url="https://ark.cn-beijing.volces.com/api/v3",
+    api_key=os.environ["ARK_API_KEY"],
+)
+create = client.content_generation.tasks.create(
+    model="doubao-seedance-1-0-pro-250528",
+    content=[{"type": "text", "text": "明亮多彩的果味饼干广告"}],
+)
+# 轮询：client.content_generation.tasks.retrieve(id=create.id)
+```
+
+---
+
+## 3. 新账号绑定时的抓取流程（实现要点）
+
+在桌面端「绑定火山方舟账号」时，`fetchVolcengineQuota` 之外，**新增一步「取该账号免费视频模型 Model ID 列表」**：
+
+1. 复用已捕获的控制台会话（见 `火山方舟API Key绑定.md` §5.4 的 `captureVolcEngineConsoleSession`）。
+2. 在控制台「开通管理 → 视觉模型」同源页面内抓取**带免费额度的视觉模型**：
+   - 解析方向：筛出**带「免费推理额度 剩X/Y token」文案**的模型；页面同屏混有图像 Seedream、3D Seed3D/Hyper3D/Hitem3D 等**也带免费额度**的项，故抓取层如实收集，由**权威层 `isVolcengineVideoFamilyName`（视频家族：Seedance || Wan）**过滤为视频模型。
+   - 对每项得 Model ID：内置固定映射（官方权威值）优先，未收录则按展示名规范化推导（Wan 家族按 mode 追加 `-t2v`/`-i2v`）。
+   - 过滤：跳过无免费额度的模型（2.x 纯计费）；非视频家族的免费模型（Seedream/3D）不入视频调度台。
+3. 结果落库（建议 `provider_caps` 或账号级扩展字段），与账号绑定一起保存，供额度展示与生成校验。
+
+> 若运行时抓取失败（CSP 阻断 / 字段变动），回退到内置固定清单（§1.1 的 1.0-pro / 1.5-pro，已证实有效），并在日志打 `[volc-caps]` 前缀标记回退。
+
+---
+
+## 4. 与现有实现的关系
+
+| 已有产物 | 状态 | 本方案追加 |
+|---------|------|-----------|
+| `volcengine.ts`（decode / test / 指纹 / quota） | 已实现 | quota 之外新增「免费模型列表」抓取 |
+| `captureVolcEngineConsoleSession` | 已实现 | 复用其会话 |
+| `0031_add_volcengine_provider.sql` | 已实现 | `capabilities.models` 目前为空，可用免费模型清单填充 |
+| `ProviderCaps`（provider_caps 表，智谱在用） | 已实现 | 火山方舟免费视频模型可复用同一张表登记 |
+
+---
+
+## 5. 验证
+
+1. 新绑定一个火山方舟账号 → 日志出现 `[volc-caps]`，账号明细展示 `doubao-seedance-1-0-pro`（或 1.5-pro）及其实时剩余额度。
+2. 未开通模型（如 1.0-pro-fast）也能在账本/待开通列表里看到 Model ID 与免费额度文案。
+3. 同一账号换 key 再绑：仍能正确识别为相同账号（账号级指纹），不重复创建免费模型记录。
+
+---
+
+## 6. 运行期额度同步（静默后台，不弹窗）
+
+> 需求：用户在火山控制台**新开通**某个有免费额度的模型后，桌面端要能同步到；生成视频后消费的额度也要实时同步。两者共用同一套静默同步链路。
+
+### 6.1 触发时机
+
+| 场景 | 触发点 | 效果 |
+|------|--------|------|
+| 新增开通/额度变动 | 打开某火山账号「查看模型」弹窗前 | 先同步再展示，弹窗即最新开通状态与剩余额度 |
+| 生成完成扣减 | 视频生成成功后下发 `volcRefreshKeyId` | 后台静默同步该账号免费模型最新剩余额度 |
+
+### 6.2 实现链路
+
+1. **主进程** `providers.ts`：`provider:volc-sync-models` IPC。
+   - `captureVolcEngineConsoleSession` 增加 `syncModels` + `targetUrl`（`VOLC_OPEN_MANAGEMENT_URL` = 控制台「开通管理」页）。
+   - 复用该账号 `persist:qf-volc:<keyId>` 分区登录态 cookie，以**隐藏窗口**加载开通管理页，静默抓取各免费模型的实时剩余额度/开通状态（DOM 卡片容器解析，见 §3）。
+   - 命中则用最新 `models` + 最新 `consoleJwt/accountId` **重建加密负载**返回 `{ ok, encrypted, models }`；未抓到（登录态失效/页面未就绪）返回 `{ ok:true, preserved:true }` 保留旧值、不报错。
+2. **preload** `index.ts`：暴露 `volcSyncModels(keyId, encrypted)`；`QuotaUpdatedPayload` 增加 `volcRefreshKeyId`。
+3. **渲染层** `useProviders.ts`：`refreshVolcengineModelsOnce(keyId)`。
+   - 读该账号密钥 → 调 `volcSyncModels` → 命中则 `refreshProviderKey` 落库并返回新 encrypted，未命中返回 `false`。
+   - `onQuotaUpdated`：收到 `volcRefreshKeyId` 时静默同步该账号并重拉真实额度。
+4. **厂商页** `Providers.tsx`：`handleViewModels` 对 volcengine 先调 `refreshVolcengineModelsOnce`，用重建后的 encrypted 加载模型目录，「查看模型」即最新值。
+5. **调度** `dispatch.ts`：`runApiBranch` 成功后按 providerId 下发，`volcengine` → `volcRefreshKeyId`（智谱仍走 `zhipuRefreshKeyId`）。
+
+> 同步为**尽力而为**：平台扣减有后端子时，单次抓取可能略滞后；「查看模型」每次重新触发同步即可逐步逼近最新值。超时/登录态失效默认保留旧额度，不做阻塞报错。

--- a/migrations/0031_add_volcengine_provider.sql
+++ b/migrations/0031_add_volcengine_provider.sql
@@ -1,0 +1,33 @@
+-- 0031_add_volcengine_provider.sql
+-- 火山方舟（火山引擎 ARK）账号绑定 seed：API Key 登录，非网页 cookie 登录。
+-- apikey 型厂商「额度单位 / 默认日额度 / 等效除数」不在 Admin 端手工填写，
+-- 额度由接入层自动核算；火山方舟本轮尚未探测到控制台真实额度接口（见方案 §6），先走每日账本 daily_total。
+-- 免费视频模型目录（2026-08-19 实测，有免费推理额度）：Seedance 1.0-pro / 1.5-pro / 1.0-pro-fast，
+--   Model ID 为平台固定值，写入 capabilities.models 作为厂商级权威清单（与桌面 spec.ts 的 MODELS.volcengine 镜像）。
+-- 说明：1.0-lite-t2v/i2v 虽在开通管理页显示免费额度，官方文档未收录 Model ID，本轮不接入。
+-- Idempotent：重复执行只更新 seed 字段，不重复插入。
+
+INSERT INTO providers (id, name, logo, capabilities, auth_type, unit_name, default_daily_quota, equivalent_count_divisor)
+VALUES
+  (
+    'volcengine',
+    '火山方舟',
+    '火',
+    '{"models":[
+      {"id":"doubao-seedance-1-0-pro-250528","modes":["text2video","img2video"],"free":true,"price":"免费"},
+      {"id":"doubao-seedance-1-5-pro-251215","modes":["text2video","img2video"],"free":true,"price":"免费"},
+      {"id":"doubao-seedance-1-0-pro-fast-251015","modes":["text2video","img2video"],"free":true,"price":"免费"}
+    ]}'::jsonb,
+    'apikey',
+    '次',
+    50,
+    1
+  )
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  logo = EXCLUDED.logo,
+  capabilities = EXCLUDED.capabilities,
+  auth_type = EXCLUDED.auth_type,
+  unit_name = EXCLUDED.unit_name,
+  default_daily_quota = EXCLUDED.default_daily_quota,
+  equivalent_count_divisor = EXCLUDED.equivalent_count_divisor;

--- a/migrations/0032_provider_caps_volcengine.sql
+++ b/migrations/0032_provider_caps_volcengine.sql
@@ -1,0 +1,28 @@
+-- 0032_provider_caps_volcengine.sql
+-- 火山方舟（volcengine）「生成能力」全局登记：把「绑定即抓模型」抓取到的免费视频模型
+-- 关联到 provider_caps（global 作用域），使调度台 / Dashboard 把火山方舟限定为这组免费模型与模式。
+-- 模型清单为平台固定值（2026-08-19 实测，见 docs/厂商与API平台接入/火山方舟免费视频模型额度对接.md），
+-- 与 spec.ts 的 MODELS.volcengine、providers.capabilities.models 三者保持一致（厂商级 Catalog）。
+-- provider_caps 语义：global 行存在即作为该 provider 的唯一可选项，空数组=屏蔽；此处给出免费模型白名单。
+-- 注意 target_id 为 NULL：Postgres UNIQUE 对 NULL 各自独立，不能依赖 ON CONFLICT 幂等，故用 存在则更 / 否则插。
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.provider_caps
+    WHERE target_type = 'global' AND target_id IS NULL AND provider = 'volcengine'
+  ) THEN
+    UPDATE public.provider_caps
+    SET modes = ARRAY['text2video','img2video'],
+        models = ARRAY['doubao-seedance-1-0-pro-250528','doubao-seedance-1-5-pro-251215','doubao-seedance-1-0-pro-fast-251015','doubao-seedance-1-0-lite-t2v','doubao-seedance-1-0-lite-i2v'],
+        updated_at = now()
+    WHERE target_type = 'global' AND target_id IS NULL AND provider = 'volcengine';
+  ELSE
+    INSERT INTO public.provider_caps (target_type, target_id, provider, modes, models)
+    VALUES (
+      'global', NULL, 'volcengine',
+      ARRAY['text2video','img2video'],
+      ARRAY['doubao-seedance-1-0-pro-250528','doubao-seedance-1-5-pro-251215','doubao-seedance-1-0-pro-fast-251015','doubao-seedance-1-0-lite-t2v','doubao-seedance-1-0-lite-i2v']
+    );
+  END IF;
+END $$;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,6 +4,11 @@ import { BaseProvider } from "@quota-flow/core";
 import { YuanbaoProvider } from "./yuanbao";
 import { QwenWanProvider } from "./qwen";
 
+// 导出 API 型厂商的凭据处理函数（decode/test/fetch-quota 等），供桌面端主进程直接复用。
+// 注意：保持在源码层再导出（不要只存在于已构建的 dist），否则 rebuild 会把这些导出打穿。
+export * from "./zhipu";
+export * from "./volcengine";
+
 export interface ProviderFactoryOptions {
 }
 

--- a/packages/providers/src/volcengine.ts
+++ b/packages/providers/src/volcengine.ts
@@ -1,0 +1,538 @@
+// 火山方舟（火山引擎 ARK）API Key 型厂商适配器
+//
+// 本轮只实现「绑定」所需的能力（API Key 校验、账号级指纹、会话工具、额度占位）：
+//   - 数据面为 Bearer Token 鉴权（Authorization: Bearer <ARK_API_KEY>），与智谱同为 API Key 型。
+//   - 火山方舟 API Key 无法直接读取资源包/免费额度（需火山控制台登录会话 + 内部接口，接口待探测，见
+//     docs/厂商与API平台接入/火山方舟API Key绑定.md §6）。因此真实额度展示「接口待探测」时以本地账本为准。
+//   - decodeVolcenginePayload 与智谱同构（兼容纯 key 旧格式）：{v:1,apiKey,consoleJwt}。
+//
+// 日志埋点统一前缀 [volc]（enabled 同 zhipu，受 QUOTA_DEBUG 控制）。
+
+import { createHash } from "node:crypto";
+
+export const VOLC_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3";
+/** 火山方舟控制台（API Key 管理页），用于绑定「获取 API Key」打开会话窗口捕获 consoleJwt */
+export const VOLC_CONSOLE_URL = "https://console.volcengine.com/ark/region:cn-beijing/apikey";
+
+/** 与智谱一致的支付/额度结构（字段为探测预留，运行时确认后固化字段映射） */
+export interface VolcengineQuota {
+  available: boolean
+  total: number
+  remaining: number
+  expiresAt?: string | null
+  packageName?: string | null
+  expired?: boolean
+  accountId?: unknown
+}
+
+/**
+ * 解火山方舟加密负载（兼容多种格式）：
+ * - 新版：{ v: 1; apiKey: string; consoleJwt?: string | null; accountId?: string | null; models?: VolcengineFreeVideoModel[] } JSON 字符串
+ * - 旧版：纯 API Key 字符串（非 `{` 开头）
+ */
+export function decodeVolcenginePayload(decrypted: string): {
+  apiKey: string
+  consoleJwt?: string | null
+  accountId?: string | null
+  models?: VolcengineFreeVideoModel[]
+} {
+  const trimmed = decrypted.trim()
+  if (!trimmed.startsWith("{")) return { apiKey: trimmed }
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      v?: number
+      apiKey?: string
+      consoleJwt?: string | null
+      accountId?: string | null
+      models?: VolcengineFreeVideoModel[]
+    }
+    const apiKey = parsed.apiKey?.trim() ?? ""
+    let consoleJwt = parsed.consoleJwt ?? null
+    let accountId = parsed.accountId ?? null
+    if (typeof consoleJwt === "string" && consoleJwt) {
+      try {
+        consoleJwt = decodeURIComponent(consoleJwt)
+      } catch {}
+    }
+    if (typeof accountId === "string") {
+      accountId = accountId.trim() || null
+    } else {
+      accountId = null
+    }
+    const models = Array.isArray(parsed.models) ? parsed.models.filter((m) => m && typeof m.id === "string") : undefined
+    return { apiKey, consoleJwt, accountId, models }
+  } catch {
+    return { apiKey: trimmed }
+  }
+}
+
+/** 从自定义状态 JWT 中解析 `exp`（毫秒）；非标准 JWT / 无 exp / 解析失败返回 null（据此不自动续期）。 */
+export function jwtExpiryMs(jwt?: string | null): number | null {
+  if (!jwt) return null
+  const m = /^([A-Za-z0-9_-]+)\.([A-Za-z0-9_-]+)\.([A-Za-z0-9_-]+)$/.exec(jwt.trim())
+  if (!m) return null
+  try {
+    const b64 = m[2].replace(/-/g, "+").replace(/_/g, "/")
+    const pad = b64.length % 4 ? "=".repeat(4 - (b64.length % 4)) : ""
+    const data = JSON.parse(Buffer.from(b64 + pad, "base64").toString("utf8")) as { exp?: number }
+    return typeof data.exp === "number" ? data.exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+function fingerprintFor(providerId: string, raw: string): string {
+  const norm = raw.trim()
+  return createHash("sha256")
+    .update(`${providerId}|${norm}`)
+    .digest("hex")
+}
+
+/**
+ * 火山方舟账号级指纹：优先用控制台会话解析出的稳定账号标识 accountId（同一账号多个 API Key 共享）。
+ * accountId 为空（未捕获会话 / 未抓到账号接口）时回退按 API Key 明文哈希。
+ * payload 为「加密前明文」，可能是 `{v:1,apiKey,consoleJwt,accountId}` 或纯 API Key。
+ */
+export async function volcengineAccountFingerprint(payload: string): Promise<string | null> {
+  const { apiKey, accountId } = decodeVolcenginePayload(payload)
+  if (!apiKey) return null
+  if (accountId) {
+    return fingerprintFor("volcengine", "volc-account:" + accountId)
+  }
+  // TODO: 若后续实抓到能返回稳定账号标识的控制台接口，优先解析 accountId 生成账号级指纹，与智谱 customerId 策略对齐。
+  return fingerprintFor("volcengine", apiKey)
+}
+
+/**
+ * 校验火山方舟 API Key 是否有效（不产生任何生成费用）：
+ * 请求一个不存在的只读任务查询端点，用状态码区分鉴权——无效 key 返回 401，有效 key 返回业务错误(404 等)。
+ * 仅把 401 视为"无效"，其余 HTTP 响应视为鉴权已通过（Key 有效）。
+ */
+export async function testVolcengineApiKey(
+  apiKey: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const key = (apiKey ?? "").trim()
+  if (!key) return { ok: false, error: "请先输入 API Key" }
+  try {
+    // 用一个不可能存在的任务 id 触发查询：有效 key 不会因此扣费，且能区分鉴权是否通过
+    const res = await fetch(`${VOLC_BASE_URL}/contents/generations/tasks/qf-invalid-key-check-nonexistent`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(15000),
+    })
+    if (res.status === 401) return { ok: false, error: "API Key 无效或已失效（身份验证失败）" }
+    if (res.status >= 200 && res.status < 600) return { ok: true }
+    return { ok: false, error: `校验失败（HTTP ${res.status}）` }
+  } catch {
+    return { ok: false, error: "校验失败（网络错误或超时）" }
+  }
+}
+
+/**
+ * 查询火山方舟真实额度（资源包/免费额度）。
+ * 火山 API Key 无法经数据面读取额度；需控制台会话 + 内部接口，而该接口字段尚未探测确认（见方案 §6），
+ * 故本轮先返回「待探测」结果，由上层回退到本地账本展示；待实抓确认后固化字段映射。
+ */
+export async function fetchVolcengineQuota(
+  apiKey: string,
+  consoleJwt?: string,
+): Promise<{ ok: true; quota: VolcengineQuota } | { ok: false; error: string }> {
+  if (!consoleJwt) {
+    return { ok: false, error: "火山方舟额度接口待探测：暂以本地账本为准" }
+  }
+  // 控制台会话已捕获，但额度接口尚未确认（未探测到 URL/字段），本轮不盲目请求未知端点。
+  return { ok: false, error: "火山方舟额度接口待探测：暂以本地账本为准" }
+}
+
+/**
+ * 火山方舟「免费视频生成模型」目录（厂商级、账号无关）。
+ * Model ID 为平台固定值（2026-08-19 实测，见 docs/厂商与API平台接入/火山方舟免费视频模型额度对接.md）。
+ * 新账号绑定时由上层调用以标识可用免费模型；建模密钥值固定、无需运行时抓取控制台。
+ * 说明：1.0-lite-t2v/i2v 官方文档未收录 Model ID，本轮不纳入。
+ */
+export interface VolcengineFreeVideoModel {
+  id: string
+  /** 控制台展示名（用于爬取归一化，与官方模型列表一致） */
+  name: string
+  modes: string[]
+  free: true
+  price: string
+  /** 该平台预留的免费推理额度提示（供 UI 展示） */
+  quotaHint: string
+  /** 【每账号】是否已开通该模型（1.0-pro-fast 等默认未开通，需到控制台开通后使用）；未抓到时取内置默认值 */
+  activated?: boolean
+  /** 【每账号】绑定控制台抓到的免费 token 额度（剩余/总数）；未抓到为 undefined */
+  freeQuota?: { remaining?: number; total?: number }
+}
+
+export function volcengineFreeVideoModels(): VolcengineFreeVideoModel[] {
+  return [
+    {
+      id: "doubao-seedance-1-0-pro-250528",
+      name: "Doubao-Seedance-1.0-pro",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（开通管理页）",
+      activated: true,
+      freeQuota: { remaining: 272120, total: 2000000 }
+    },
+    {
+      id: "doubao-seedance-1-5-pro-251215",
+      name: "Doubao-Seedance-1.5-pro",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（开通管理页）",
+      activated: true,
+      freeQuota: { remaining: 2000000, total: 2000000 }
+    },
+    {
+      id: "doubao-seedance-1-0-pro-fast-251015",
+      name: "Doubao-Seedance-1.0-pro-fast",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
+      activated: false,
+      freeQuota: { remaining: 2000000, total: 2000000 }
+    },
+    {
+      id: "doubao-seedance-1-0-lite-t2v",
+      name: "Doubao-Seedance-1.0-lite-t2v",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
+      activated: false,
+      freeQuota: { remaining: 2000000, total: 2000000 }
+    },
+    {
+      id: "doubao-seedance-1-0-lite-i2v",
+      name: "Doubao-Seedance-1.0-lite-i2v",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
+      activated: false,
+      freeQuota: { remaining: 2000000, total: 2000000 }
+    },
+    // Wan 家族：文生/图生走不同 Model ID（-t2v / -i2v），本目录存基名 wan2-1-14b，调用时由 resolveVolcengineModel 按 mode 追加
+    {
+      id: "wan2-1-14b",
+      name: "Wan2.1-14B",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（开通管理页）",
+      activated: false,
+      freeQuota: { remaining: 2000000, total: 2000000 }
+    }
+  ]
+}
+
+/** 控制台「开通管理→视觉模型」页抓到的免费 Seedance 条目（名 / Model ID / 剩余与总免费额度 / 是否已开通） */
+export interface VolcengineScrapedFreeModel {
+  name: string
+  id?: string
+  remaining?: number
+  total?: number
+  activated?: boolean
+}
+
+/** 展示名 → Model ID 固定映射（权威值，覆盖内置目录全部免费模型，含 lite 系列） */
+export const VOLCENGINE_FREE_NAME_TO_ID: Record<string, string> = Object.fromEntries(
+  volcengineFreeVideoModels().map((m) => [m.name, m.id]),
+)
+
+/** 展示名（带点号）→ 规范化 Model ID（小写 + `.`→`-`）；lite 系列名归一化即真实 Model ID，用于固定映射未收录的未知免费模型 */
+function normalizeVolcModelId(name: string): string {
+  return name.toLowerCase().replace(/\./g, "-")
+}
+
+/**
+ * 削减模型名里的畸形拼接/重复段：表格行常把同一模型名连写多次（如
+ * `wan2-1-14bwan2-1-14bwan2-1-14bwanai`），取最小重复周期去掉冗余重复，残余垃圾段留给后续解析丢弃。
+ * 正常名不含相邻自重复时原样返回。
+ */
+function reduceRepeatedModelName(name: string): string {
+  let cur = name || ""
+  for (let i = 0; i < 5; i++) {
+    const m = cur.match(/^(.+?)\1/)
+    if (!m || !m[1]) break
+    cur = m[1]
+  }
+  return cur
+}
+
+/**
+ * 把实抓/接口的模型名解析到「权威目录」的 Model ID。
+ * 三种命中路径，逐一尝试以自动归并重复与截断别名：
+ *  - 精确：展示名固定映射；或规范化后恰等于某个目录 id；
+ *  - 模糊：畸形拼接经去重归约后，与目录 id 存在包含/前缀关系（如
+ *    `doubao-seedance-1-5-pro` 缺 `-251215` 后缀、`doubao-seedance-1-0-pro-fa` 截断 `fast`）→ 归一到唯一 id；
+ *  - 未命中目录：规范化干净名作为「新免费模型」占位 id；畸形残留/含中文/超长一律返回 null 拒绝收录，
+ *    避免 DOM 残片被当成独立新模型混入列表。
+ */
+function resolveVolcScrapedId(rawName: string): string | null {
+  const raw = (rawName || "").trim()
+  if (!raw) return null
+  // 1) 展示名固定映射
+  const exact = VOLCENGINE_FREE_NAME_TO_ID[raw]
+  if (exact) return exact
+  const norm = reduceRepeatedModelName(normalizeVolcModelId(raw))
+  if (!norm) return null
+  // 2) 规范化后恰等于某个目录 id
+  for (const m of FREE_CATALOG) if (m.id === norm) return m.id
+  // 3) 与目录 id 存在包含/前缀关系，归一到不重复的 id
+  const hits = FREE_CATALOG.filter(
+    (m) => m.id === norm || m.id.includes(norm) || norm.includes(m.id),
+  ).map((m) => m.id)
+  if (hits.length === 1) return hits[0]
+  if (hits.length > 1) {
+    // 多命中（如 `doubao-seedance-1-0-pro` 同时作 …pro-250528 / …pro-fast-251015 前缀）：取短版本，稳定不漂移
+    return hits.slice().sort((a, b) => a.length - b.length)[0]
+  }
+  // 4) 未命中目录：仅收留「干净规范 id」作占位；畸形残留 / 中文 / 超长 / 带非法字符一律拒绝
+  if (/[\u4e00-\u9fa5]/.test(norm)) return null
+  if (norm.length > 64) return null
+  if (!/^[a-z0-9][a-z0-9._-]*[a-z0-9]$/.test(norm)) return null
+  return norm
+}
+
+/** 内置免费目录（作为爬取失败的权威兜底） */
+const FREE_CATALOG: VolcengineFreeVideoModel[] = volcengineFreeVideoModels()
+
+/**
+ * 火山方舟「视频生成」模型家族判定（权威层，依据控制台开通管理页的分类，不依赖抓取层的 DOM 前缀）：
+ *  - 视频生成家族：Seedance（doubao-seedance-*，如 1.0-pro / 1.5-pro / lite 系列）、Wan（Wan2.1-14B 等）；
+ *  - 图像生成家族 Seedream（doubao-seedream-*）、3D 生成家族（Seed3D/Hyper3D/Hitem3D 等）同样带免费推理额度，
+ *    但**不是视频模型**，须在权威层排除，以免混入视频调度台的模型下拉。
+ * 抓取层只如实上报「有免费额度」的所有模型，是否「视频生成模型」由本函数按家族知识过滤。
+ */
+export function isVolcengineVideoFamilyName(name: string): boolean {
+  const n = (name || "").toLowerCase()
+  return n.includes("seedance") || n.includes("wan")
+}
+
+/**
+ * 「绑定即抓模型」：把控制台实时抓到的免费模型规范化为目录（权威层）。
+ * - 收录页面上**所有**「有免费推理额度且属于视频家族」的模型（含 lite、Wan 系列），按页面顺序给出；
+ *   （页面同屏混有图像 Seedream、3D Seed3D/Hyper3D/Hitem3D 等免费模型，跑 videoFamily 过滤剔除）
+ * - id 优先级：内置固定映射（官方权威值）> 由展示名规范化推导（供未收录未知免费视频模型占位）；
+ *   （页面「开通管理」卡片只展示带点号的展示名，无可靠 Model ID，故不再信任页面抓到的 id）
+ * - token（剩余/总）与是否已开通由页面实抓回填；
+ * - 完全未抓到（无会话/未进开通页/CSP 阻断）时回退内置目录，由 caller 以 [volc-caps] 标记回退。
+ */
+export function captureVolcengineFreeVideoModels(
+  scraped: VolcengineScrapedFreeModel[] | null | undefined,
+): { models: VolcengineFreeVideoModel[]; source: "console" | "fallback" } {
+  const src = Array.isArray(scraped) ? scraped : []
+  const catalog = FREE_CATALOG.map((m) => ({ ...m }))
+  if (src.length === 0) {
+    return { models: catalog, source: "fallback" }
+  }
+  // 合并策略：目录（免费视频模型权威全集）+ 实抓模型，按「权威 Model ID」去重。
+  // - 抓取只负责如实上报「有免费额度的所有模型」，并可能因虚拟列表/滚动漏掉列表末尾卡片（如 Wan 在最底部）；
+  // - 因此以目录为权威骨架（保证 Wan、lite 等已知免费视频模型不因抓取漏卡而丢失），
+  //   抓到的实时额度 / 是否已开通优先覆盖对应 id；目录未收录的新免费模型由抓取补充。
+  // - 实抓名字先经 resolveVolcScrapedId 归一到目录 id：截断别名（缺版本后缀、fast 截断）与
+  //   畸形拼接串（如 wan2-1-14b×3+wanai）都会被折叠到正确条目，杜绝同一模型以残片形式重复出现。
+  const byId = new Map<string, VolcengineFreeVideoModel>()
+  for (const m of catalog) byId.set(m.id, m)
+  for (const s of src) {
+    const name = s.name?.trim() || ""
+    if (!name) continue
+    // 门禁：只收视频家族模型（剔除非视频的图像 Seedream / 3D Seed3D 等空闲免费模型）
+    if (!isVolcengineVideoFamilyName(name)) continue
+    // 归一化到权威 Model ID；畸形/无效名返回 null → 跳过，不引入重复或垃圾条目
+    const id = resolveVolcScrapedId(name)
+    if (!id) continue
+    // 实抓额度只在是「有限正数」时才覆盖目录默认值；NaN/undefined 会弄脏展示，回退目录默认
+    const hasQuota =
+      Number.isFinite(s.remaining) && Number.isFinite(s.total) && (s.total as number) > 0
+    const existing = byId.get(id)
+    if (existing) {
+      // 已收录于目录：保留目录权威 id/name/modes，仅覆盖实时额度与开通状态。
+      // activated 取「任一来源判为已开通」即开通（只升不降），避免先到的 DOM 误标覆盖接口后续抓到的 true。
+      if (hasQuota) existing.freeQuota = { remaining: s.remaining as number, total: s.total as number }
+      if (s.activated === true) existing.activated = true
+      continue
+    }
+    // 目录未收录的新免费模型：以规范化干净 id 占位
+    byId.set(id, {
+      id,
+      name,
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "免费",
+      quotaHint: "免费推理额度（开通管理页）",
+      freeQuota: hasQuota ? { remaining: s.remaining as number, total: s.total as number } : undefined,
+      activated: s.activated === true
+    })
+  }
+  const models = Array.from(byId.values())
+  if (models.length === 0) {
+    return { models: catalog, source: "fallback" }
+  }
+  return { models, source: "console" }
+}
+
+/**
+ * 火山方舟 Model ID 的 Mode 解析：Seedance 家族单 Model ID 同时覆盖文生/图生；
+ * Wan 家族（wan2-1-14b 等）文生/图生走不同 Model ID（-t2v / -i2v），按 mode 追加后缀。
+ */
+export function resolveVolcengineModel(model: string, mode: "text2video" | "img2video"): string {
+  const m = (model || "").trim()
+  if (/^wan\b/i.test(m) || /^wan[-.\d]/i.test(m)) {
+    return mode === "img2video" ? `${m}-i2v` : `${m}-t2v`
+  }
+  return m
+}
+
+export interface VolcengineGenerateOptions {
+  mode: "text2video" | "img2video"
+  model: string
+  prompt?: string
+  /** 单图：图生视频首帧（公网 https URL）；多图按需透传 */
+  images?: string[]
+  /** 视频时长（秒，整数）；免费模型固定 6s 时由调用方消化 */
+  durationSec?: number
+  /** 是否生成有声视频 */
+  audio?: "on" | "off"
+  ratio?: string
+  resolution?: string
+}
+
+export interface VolcengineGenerateResult {
+  ok: boolean
+  videoUrl?: string
+  coverImageUrl?: string
+  traceId?: string
+  model: string
+  error?: string
+}
+
+/**
+ * 火山方舟（数据面）视频生成：提交任务 → 轮询 → 解析视频 URL。
+ *   提交 POST {base}/contents/generations/tasks，Bearer <ARK_API_KEY> 鉴权，返回 {id}。
+ *   轮询 GET  {base}/contents/generations/tasks/{id}，status ∈ queued/running/cancelled/succeeded/failed/expired；
+ *   成功终态视频地址在 content[].video_url，封面在 content[].poster_url。
+ * onProgress 用于桌面调度台实时推送过程提示。
+ */
+export async function volcengineGenerateWithKey(
+  apiKey: string,
+  opts: VolcengineGenerateOptions,
+  onProgress?: (message: string) => void,
+): Promise<VolcengineGenerateResult> {
+  const key = (apiKey ?? "").trim()
+  if (!key) return { ok: false, model: opts.model, error: "火山方舟 API Key 缺失" }
+  const content: Array<Record<string, unknown>> = [
+    { type: "text", text: opts.prompt?.trim() || (opts.mode === "img2video" ? "让图片动起来" : "生成一段视频") },
+  ]
+  const imgs = (opts.images ?? []).filter((u) => /^https?:\/\//i.test(String(u).trim()))
+  if (opts.mode === "img2video" && imgs.length > 0) {
+    for (const url of imgs) {
+      content.push({ type: "image_url", image_url: { url }, role: "reference_image" })
+    }
+  } else if (opts.mode === "img2video") {
+    return { ok: false, model: opts.model, error: "火山图生视频需要至少上传 1 张首帧图（需公网 https 地址）" }
+  }
+
+  // Wan 家族（wan2-1-14b 等）文生/图生走不同 Model ID，按 mode 解析；Seedance 单 ID 通用
+  const bodyModel = resolveVolcengineModel(opts.model, opts.mode)
+  const body: Record<string, unknown> = {
+    model: bodyModel,
+    content,
+    generate_audio: opts.audio !== "off",
+    watermark: false,
+    output_format: "mp4",
+  }
+  const dur = Number(opts.durationSec)
+  if (Number.isFinite(dur) && dur > 0) body["duration"] = dur
+  if (opts.ratio) body["ratio"] = opts.ratio
+  if (opts.resolution) body["resolution"] = opts.resolution
+
+  const genLog = (msg: string, extra?: unknown): void => {
+    console.log(`[volc-gen][${new Date().toISOString()}] ${msg}`, extra === undefined ? "" : JSON.stringify(extra))
+  }
+
+  try {
+    onProgress?.(`正在提交到火山方舟（${opts.model}）…`)
+    const submit = await fetch(`${VOLC_BASE_URL}/contents/generations/tasks`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(20000),
+    })
+    const submitRaw: unknown = await submit.json().catch(() => null)
+    const submitData = (submitRaw && typeof submitRaw === "object" ? submitRaw : {}) as Record<string, unknown>
+    if (!submit.ok) {
+      const errObj = (submitData["error"] ?? {}) as Record<string, unknown> | null
+      const msg = typeof errObj?.message === "string" ? errObj.message : `HTTP ${submit.status}`
+      genLog(`提交失败 status=${submit.status} msg=${msg}`)
+      return { ok: false, model: opts.model, error: `火山方舟提交失败: ${msg}${submit.status === 429 ? "（限流，请稍后再试）" : ""}` }
+    }
+    const rawTaskId = submitData["id"]
+    const taskId = typeof rawTaskId === "string" ? rawTaskId : undefined
+    if (!taskId) {
+      genLog("提交成功但响应缺少 id", submitData)
+      return { ok: false, model: opts.model, error: "火山方舟提交响应缺少任务 id" }
+    }
+
+    onProgress?.("提交成功，正在生成视频…")
+    const startedAt = Date.now()
+    const INTERVAL_MS = 5000
+    const MAX_POLLS = 90 // 约 7.5 分钟上限
+    let polls = 0
+    for (;;) {
+      await new Promise((r) => setTimeout(r, INTERVAL_MS))
+      polls++
+      let data: Record<string, unknown>
+      try {
+        const res = await fetch(`${VOLC_BASE_URL}/contents/generations/tasks/${taskId}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${key}` },
+          signal: AbortSignal.timeout(15000),
+        })
+        const rawPoll: unknown = await res.json().catch(() => null)
+        data = (rawPoll && typeof rawPoll === "object" ? rawPoll : {}) as Record<string, unknown>
+      } catch {
+        if (polls >= MAX_POLLS) {
+          return { ok: false, model: opts.model, error: `火山方舟任务轮询超时（约 ${Math.round((Date.now() - startedAt) / 1000)} 秒），可能仍在生成或已失败` }
+        }
+        continue
+      }
+      const status = String(data["status"] ?? "UNKNOWN")
+      if (status === "succeeded" || status === "success") {
+        const items = Array.isArray(data["content"]) ? (data["content"] as Array<Record<string, unknown>>) : []
+        const video = items.find((it) => typeof it["video_url"] === "string")
+        const poster = items.find((it) => typeof it["poster_url"] === "string")
+        if (!video) {
+          genLog("终态 succeeded 但 content 缺少 video_url", data)
+          return { ok: false, model: opts.model, error: "火山方舟任务 SUCCESS 但缺少视频地址" }
+        }
+        genLog(`生成成功 video_url=${video["video_url"]} polls=${polls}`)
+        return {
+          ok: true,
+          videoUrl: String(video["video_url"]),
+          coverImageUrl: typeof poster?.["poster_url"] === "string" ? String(poster["poster_url"]) : undefined,
+          traceId: taskId,
+          model: opts.model,
+        }
+      }
+      if (status === "failed" || status === "cancelled" || status === "expired") {
+        const reason = data["error"] ? String(data["error"]) : status
+        genLog(`任务终态非成功: ${status}`, data)
+        return { ok: false, model: opts.model, error: `火山方舟任务${status}${reason === status ? "" : `：${reason}`}` }
+      }
+      if (polls >= MAX_POLLS) {
+        return { ok: false, model: opts.model, error: `火山方舟任务轮询超时（约 ${Math.round((Date.now() - startedAt) / 1000)} 秒）` }
+      }
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    genLog(`未捕获异常: ${msg}`)
+    return { ok: false, model: opts.model, error: msg }
+  }
+}


### PR DESCRIPTION
## 修改内容

### 1. 火山方舟 API 适配器
- 新增 volcengine.ts：火山方舟 API 适配器（文生视频/图生视频/首尾帧生成）
- 支持免费视频模型：doubao-seedance-1-0-lite-i2v、doubao-seedance-1-0-lite-t2v 等
- API Key 绑定流程 + 额度查询

### 2. API Branch 架构扩展
- api-branch.ts：新增 volcengine 分支，支持火山方舟生成模式
- providers.ts：新增 volcengine 相关 IPC 处理（captureSession/encrypt/healthCheck）

### 3. 桌面端 UI 适配
- Providers.tsx：新增火山方舟账号绑定入口
- Modals.tsx：新增火山方舟 API Key 输入弹窗
- Dashboard.tsx：新增火山方舟任务状态展示
- spec.ts：新增火山方舟厂商标识和模型列表
- styles.css：新增火山方舟相关样式

### 4. 数据库迁移
- 0031_add_volcengine_provider.sql：新增火山方舟厂商配置
- 0032_provider_caps_volcengine.sql：火山方舟能力配置

### 5. 文档
- 火山方舟 API Key 绑定.md
- 火山方舟免费视频模型额度对接.md

### 6. 新增文件
- packages/providers/src/volcengine.ts
- migrations/0031_add_volcengine_provider.sql
- migrations/0032_provider_caps_volcengine.sql