### PR TITLE
feat: 火山方舟免费视频额度防误扣拦截 + 无接入点模型标识

### DIFF
--- a/apps/desktop/src/main/api-branch.ts
+++ b/apps/desktop/src/main/api-branch.ts
@@ -17,7 +17,11 @@ import {
   fetchZhipuQuota,
   zhipuGenerateWithKey,
   volcengineFreeVideoModels,
-  volcengineGenerateWithKey
+  volcengineGenerateWithKey,
+  volcengineGenBlocker,
+  volcengineModelFreeStatus,
+  volcGenTokenEstimate,
+  VOLC_DECOMMISSIONED_MODELS
 } from '@quota-flow/providers'
 import type { VolcengineFreeVideoModel, ZhipuGenerateOptions } from '@quota-flow/providers'
 import { ipcMain, safeStorage } from 'electron'
@@ -34,6 +38,8 @@ export interface ApiGenerateOutcome {
   coverImageUrl?: string
   traceId?: string
   error?: string
+  /** 火山方舟提交失败时，若平台判定模型不可用（无接入点 / 已下架），透出供调度台落库标记 */
+  unavailable?: 'decommissioned' | 'no_endpoint'
 }
 
 export interface ApiGenerateParams {
@@ -65,6 +71,20 @@ export interface ApiGenerationBranch {
     /** 火山方舟：该账号绑定时实时抓到的免费视频模型（优先于固定目录） */
     captured?: VolcengineFreeVideoModel[]
   ): ApiModelInfo[]
+  /**
+   * 多账号选号（可选）：在多个已启用账号中按厂商策略选出最优下标。
+   * 返回下标则 dispatch 改用该账号对应的解密负载；返回 null 由调用方回退默认/首个。
+   * dispatches 中的 plain 已是解密后的加密负载明文。
+   */
+  pick?(
+    keys: Array<{ id: string; accountName: string | null; isDefault: boolean; enabled: boolean; plain: string }>,
+    model: string
+  ): number | null
+  /**
+   * 提交前预检（可选）：账号解密后、向 API 提交之前执行。
+   * 返回 !ok 则在提交前拦截（模型未开通/额度用尽等）。
+   */
+  preflight?(model: string, plain: string, ctx?: { durationSec?: number }): { ok: boolean; reason?: string }
   generate(input: GenerateInput, creds: ApiCredential, params: ApiGenerateParams): Promise<ApiGenerateOutcome>
 }
 
@@ -82,8 +102,12 @@ export interface ApiModelInfo {
   modes: Array<{ value: string; label: string }>
   /** 是否已开通该模型（火山方舟未开通模型提示开通；默认 true） */
   activated?: boolean
-  /** 【每账号】免费 token 额度（火山方舟免费视频模型）：剩余/总数，未抓到为 undefined */
+  /** 每账号免费 token 额度（火山方舟免费视频模型）：剩余/总数，未抓到为 undefined */
   freeQuota?: { remaining?: number; total?: number }
+  /** 模型不可用标记（火山方舟）：平台下架 / 账号无接入点 */
+  unavailable?: 'decommissioned' | 'no_endpoint'
+  /** 不可用原因的展示标签，仅当 unavailable 有值时存在 */
+  unavailableLabel?: string
 }
 
 const ZHIPU_MODEL_COST: Record<string, number> = {
@@ -314,21 +338,59 @@ function makeVolcengineBranch(): ApiGenerationBranch {
       // 免费 token 额度按账号、且无公开 API 可读；实时额度走本地账本，此处返回 null 表示未知。
       return null
     },
+    pick(keys, model) {
+      // 多账号优选：能力分主导（能否开通 + 剩余额度），is_default 仅作同分时的二次兜底，
+      // 确保「默认账号未开通、其它账号已开通」时仍自动选用能生成的账号。
+      // known=false（未知）的候选不因未知加分也不拦截；真正的拦截交给 preflight 依据明确证据处理。
+      try {
+        let bestIdx: number | null = null
+        let bestScore = -Infinity
+        keys.forEach((k, idx) => {
+          const st = volcengineModelFreeStatus(k.plain, model)
+          // 能力分：未开通扣分、已开通与有剩余各加分；未知按 0，不因未知误伤
+          let cap = 0
+          if (st.known) {
+            if (st.activated === true) cap += 1
+            if (st.activated === false) cap -= 2
+            if (typeof st.remaining === 'number') cap += st.remaining > 0 ? 1 : 0
+          }
+          // 能力分占主导权（×10），默认只作为同能力下的平局用户名
+          const score = cap * 10 + (k.isDefault ? 1 : 0)
+          if (score > bestScore) {
+            bestScore = score
+            bestIdx = idx
+          }
+        })
+        return bestIdx
+      } catch {
+        return null
+      }
+    },
+    preflight(model, plain, ctx) {
+      // 硬性防误扣拦截：未开通 / 额度不可确认 / 剩余不足以完成一次生成 一律拦截，绝不让火山补扣账号余额。
+      // （火山无「免费额度不足即拒绝」的服务端开关，免费额度耗尽会强制转按量付费。）
+      return volcengineGenBlocker(plain, model, volcGenTokenEstimate(ctx?.durationSec))
+    },
     catalog(perModelFreeQuota, captured?: VolcengineFreeVideoModel[]) {
       // 优先使用该账号绑定时实时抓到的免费模型目录；未抓到则回退内置固定目录
       const base = Array.isArray(captured) && captured.length > 0 ? captured : freeModels
       // 内置目录按 id 的默认免费额度，作为兜底：账号负载里存的旧模型缺 freeQuota 时，仍能展示具体 token 量
       const defaultQuota = new Map(freeModels.map((m) => [m.id, m.freeQuota]))
-      return base.map((m) => ({
-        model: m.id,
-        priceLabel: m.price,
-        cost: 0,
-        durations: VOLC_ENGINE_MODEL_DURATIONS,
-        size: null,
-        modes: VOLC_ENGINE_MODEL_MODES,
-        activated: m.activated,
-        freeQuota: perModelFreeQuota?.[m.id] ?? m.freeQuota ?? defaultQuota.get(m.id)
-      }))
+      return base.map((m) => {
+        const unavail = m.unavailable ?? (VOLC_DECOMMISSIONED_MODELS.includes(m.id) ? ('decommissioned' as const) : null)
+        return {
+          model: m.id,
+          priceLabel: m.price,
+          cost: 0,
+          durations: VOLC_ENGINE_MODEL_DURATIONS,
+          size: null,
+          modes: VOLC_ENGINE_MODEL_MODES,
+          activated: m.activated,
+          freeQuota: perModelFreeQuota?.[m.id] ?? m.freeQuota ?? defaultQuota.get(m.id),
+          unavailable: unavail ?? undefined,
+          unavailableLabel: unavail === 'decommissioned' ? '已下架' : unavail === 'no_endpoint' ? '无接入点' : undefined
+        }
+      })
     },
     async generate(input, creds, params) {
       if (params.mode !== 'text2video' && params.mode !== 'img2video') {
@@ -355,7 +417,8 @@ function makeVolcengineBranch(): ApiGenerationBranch {
         videoUrl: r.videoUrl,
         coverImageUrl: r.coverImageUrl,
         traceId: r.traceId,
-        error: r.error
+        error: r.error,
+        unavailable: r.unavailable
       }
     }
   }

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -10,6 +10,7 @@ import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
 import { runDoubaoGeneration } from './webview-engine'
 import type { ProviderCookie, OriginStorage } from './webview-engine'
 import { parseStoredCredentials as parseProviderCredentials } from './providers'
+import { clearVolcModelUnavailable, markVolcModelUnavailable } from './providers'
 import { runQwenGeneration } from './qwen-webview'
 import { runYuanbaoGeneration } from './yuanbao-webview'
 import { runDolaGeneration } from './dola-webview'
@@ -246,10 +247,17 @@ export async function runGenerate(
       const imgDir = join(app.getPath('userData'), 'images')
       mkdirSync(imgDir, { recursive: true })
       for (let i = 0; i < images.length; i++) {
+        const img = images[i]
         try {
-          const ext = (/\.(png|gif|webp)$/i.exec(images[i])?.[1] ?? 'jpg').toLowerCase()
+          // 远程公网 URL（开放平台 API 参考图已上传到 Supabase）→ 直接记录 URL，历史详情按公网地址回显
+          if (/^https?:\/\//i.test(img)) {
+            jobImages.push(img)
+            continue
+          }
+          // 本地图片路径 → 复制一份本地副本到 userData/images 持久化，透过多段历史详情回显
+          const ext = (/\.(png|gif|webp)$/i.exec(img)?.[1] ?? 'jpg').toLowerCase()
           const dest = join(imgDir, `${job.id}-${i}.${ext}`)
-          copyFileSync(images[i], dest)
+          copyFileSync(img, dest)
           jobImages.push(dest)
         } catch {}
       }
@@ -638,18 +646,45 @@ async function runApiBranch(
   emit({ jobId: job.id, status: 'pending', message: '任务已创建' })
   onJobCreated?.(job.id, runCancelState)
 
+  // 图片 https URL 随任务持久化，历史详情可回显「上传图片」；api 厂商参考图为 Supabase 公网 URL
+  const jobImages = (input.images ?? [])
+    .filter((u): u is string => typeof u === 'string' && /^https?:\/\//i.test(u))
+    .slice(0, 5)
   const jobOptions: Record<string, unknown> = {
     mode: input.mode,
     model,
     durationSec: input.durationSec
   }
+  if (jobImages.length > 0) jobOptions.images = jobImages
 
   const keys = input.teamId
     ? await providerSvc.listTeamProviderKeysWithSecrets(input.teamId)
     : (await providerSvc.listProviderKeysWithSecrets(input.userId)).filter((k) => !k.team_id)
   const providerKeys = keys.filter((k) => k.provider_id === providerId && k.enabled !== false)
-  // 默认账号优先，无默认则取首个可用账号
-  const cand = providerKeys.find((k) => k.is_default) ?? providerKeys[0]
+  // 选号：厂商实现 pick 时按其策略在多个已启用账号间选最优（如火山按「是否开通+剩余额度」），
+  // 否则回退现状：默认账号优先，无默认取首个可用账号。
+  let cand = providerKeys.find((k) => k.is_default) ?? providerKeys[0]
+  let plain = ''
+  if (branch.pick && providerKeys.length > 0) {
+    try {
+      const list = providerKeys.map((k) => ({
+        id: k.id,
+        accountName: k.account_name ?? null,
+        isDefault: !!k.is_default,
+        enabled: k.enabled !== false,
+        plain: safeStorage.isEncryptionAvailable()
+          ? safeStorage.decryptString(Buffer.from(k.encrypted_key ?? '', 'base64'))
+          : ''
+      }))
+      const idx = branch.pick(list, model)
+      if (idx != null && providerKeys[idx]) {
+        cand = providerKeys[idx]
+        plain = list[idx]?.plain ?? ''
+      }
+    } catch {
+      // 选号异常：回退默认/首个，不阻断
+    }
+  }
   if (!cand) {
     const err = `未绑定${branch.displayName}账号（请在厂商页绑定后重试）`
     await jobSvc.updateJob(input.userId, job.id, {
@@ -664,13 +699,29 @@ async function runApiBranch(
 
   let creds: ApiCredential | null = null
   try {
-    const plain = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(Buffer.from(cand.encrypted_key ?? '', 'base64'))
-      : ''
+    if (!plain && safeStorage.isEncryptionAvailable()) {
+      plain = safeStorage.decryptString(Buffer.from(cand.encrypted_key ?? '', 'base64'))
+    }
     creds = branch.parseCredentials(plain)
   } catch {
     creds = null
   }
+
+  // 提交前预检：模型未开通 / 免费额度用完等，在向 API 提交之前拦截，避免白跑
+  if (branch.preflight) {
+    const pf = branch.preflight(model, plain, { durationSec: input.durationSec })
+    if (!pf.ok) {
+      await jobSvc.updateJob(input.userId, job.id, {
+        status: 'failed',
+        error: pf.reason,
+        options: jobOptions,
+        completedAt: new Date().toISOString()
+      })
+      emit({ jobId: job.id, status: 'failed', message: pf.reason })
+      return { ok: false, jobId: job.id, error: pf.reason }
+    }
+  }
+
   if (!creds) {
     const err = '账号「' + (cand.account_name || '未命名') + '」凭据解密失败'
     await jobSvc.updateJob(input.userId, job.id, {
@@ -720,6 +771,19 @@ async function runApiBranch(
   const res = await branch.generate(input, creds, params)
   if (!res.ok || !res.videoUrl) {
     const err = res.error || '生成失败'
+    // 火山方舟提交失败且平台判定模型不可用（无接入点 / 已下架）→ 立即写不可用标记落库，后续生成前拦截 + 查看模型置灰
+    if (providerId === 'volcengine' && res.unavailable && model && plain) {
+      const marked = markVolcModelUnavailable(plain, model, res.unavailable)
+      if (marked.ok && safeStorage.isEncryptionAvailable()) {
+        try {
+          await providerSvc.refreshProviderKey(input.userId, cand.id, {
+            encryptedKey: safeStorage.encryptString(marked.plain).toString('base64')
+          })
+        } catch {
+          // 标记写库失败不回滚本次生成失败
+        }
+      }
+    }
     await jobSvc.updateJob(input.userId, job.id, {
       status: 'failed',
       error: err,
@@ -761,6 +825,20 @@ async function runApiBranch(
     message: '生成成功',
     data: { resultUrl, cost, localPath, accountId: cand.id }
   })
+
+  // 火山方舟生成成功 → 自愈清除该模型的历史不可用标记（平台恢复可用即重新放行）
+  if (providerId === 'volcengine' && model && plain) {
+    const cleared = clearVolcModelUnavailable(plain, model)
+    if (cleared.ok && safeStorage.isEncryptionAvailable()) {
+      try {
+        await providerSvc.refreshProviderKey(input.userId, cand.id, {
+          encryptedKey: safeStorage.encryptString(cleared.plain).toString('base64')
+        })
+      } catch {
+        // 自愈写库失败不影响生成成功返回
+      }
+    }
+  }
 
   // API 型厂商本地账本不做原子扣减（真实额度在平台）；生成完成后下发热点字段，
   // 渲染层据此重新拉取/同步该账号真实额度：智谱走 fetch-quota，火山走开通管理页静默同步。

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto'
 import { app, BrowserWindow, ipcMain, safeStorage, session, shell } from 'electron'
 import type { Cookie } from 'electron'
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, openSync, closeSync, readSync, statSync, truncateSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   fetchZhipuQuota,
@@ -12,9 +12,55 @@ import {
   decodeVolcenginePayload,
   jwtExpiryMs,
   captureVolcengineFreeVideoModels,
+  volcengineAuthoritativeIds,
   VOLCENGINE_FREE_NAME_TO_ID
 } from '@quota-flow/providers'
 import type { VolcengineFreeVideoModel } from '@quota-flow/providers'
+
+/** 对「解密后的明文」仅做透明的 models 不可用标记写入，返回新明文（不触发网络；consoleJwt/accountId 原样保留）。 */
+export function markVolcModelUnavailable(
+  plain: string,
+  model: string,
+  kind: 'decommissioned' | 'no_endpoint'
+): { ok: true; plain: string } | { ok: false } {
+  try {
+    const d = decodeVolcenginePayload(plain)
+    if (!d.apiKey) return { ok: false }
+    const models = Array.isArray(d.models) ? d.models : []
+    const byId = new Map(models.map((m) => [m.id, m]))
+    const copy = byId.get(model)
+    if (copy) {
+      copy.unavailable = kind
+    } else {
+      byId.set(model, { id: model, unavailable: kind } as VolcengineFreeVideoModel)
+    }
+    const next = JSON.stringify({ v: 1, apiKey: d.apiKey, consoleJwt: d.consoleJwt ?? null, accountId: d.accountId ?? null, models: Array.from(byId.values()) })
+    return { ok: true, plain: next }
+  } catch {
+    return { ok: false }
+  }
+}
+
+/** 对「解密后的明文」仅做透明的 models 不可用标记清除（生成成功后自愈），返回新明文。 */
+export function clearVolcModelUnavailable(plain: string, model: string): { ok: true; plain: string } | { ok: false } {
+  try {
+    const d = decodeVolcenginePayload(plain)
+    if (!d.apiKey) return { ok: false }
+    const models = Array.isArray(d.models) ? d.models : []
+    const byId = new Map(models.map((m) => [m.id, m]))
+    const cur = byId.get(model)
+    if (cur && 'unavailable' in cur) {
+      delete cur.unavailable
+      // 该 id 除 id 外无其它字段时移除整项，避免占位
+      const { unavailable: _u, ...rest } = cur
+      if (Object.keys(rest).length <= 1) byId.delete(model)
+    }
+    const next = JSON.stringify({ v: 1, apiKey: d.apiKey, consoleJwt: d.consoleJwt ?? null, accountId: d.accountId ?? null, models: Array.from(byId.values()) })
+    return { ok: true, plain: next }
+  } catch {
+    return { ok: false }
+  }
+}
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
@@ -1043,9 +1089,64 @@ function volcEngineConsoleSession(keyId?: string): Electron.Session {
   return session.fromPartition(volcConsolePartitionFor(keyId))
 }
 /** 火山同步诊断日志（userData/volc-sync.log）：排查静默抓取为何未命中控制台免费模型 */
+// 日志只用于排查火山控制台抓取/绑定问题，无须无限累积：超过上限时自动截断，只保留最近一段。
+const VOLC_SYNC_LOG_MAX_BYTES = 2 * 1024 * 1024 // 2MB
+const VOLC_SYNC_LOG_KEEP_BYTES = 512 * 1024 // 截断后保留尾部 512KB
+// 避免每次追加都 stat 开销；距上次裁剪超阈值才检查一次
+let volcSyncLastTrimMs = 0
+const VOLC_SYNC_TRIM_INTERVAL_MS = 60 * 1000
+// SYNC_HB 心跳节流：同步期间每秒探一次，仅在「页面状态变化」（URL/登录/模型数/滚动/行/分页/注入）时才落日志，
+// 静止页面不再每秒刷一条大日志；配合上方的 2MB 自动裁剪，避免一次同步堆砌几十条干扰排查。
+let volcSyncHbSig = ''
+// 接口响应体 / 请求 URL 去抖：轮询中每拍返回同一个 JSON dump，只在内容变化时才写日志，
+// 避免每拍重复落一条冗长的 SYNC_MODELBODY/SYNC_RAW/SYNC_RAWURLS（响应体常达 4~6KB）。
+let volcSyncModelBodySig = ''
+let volcSyncRawBodySig = ''
+let volcSyncRawUrlsSig = ''
+// ListModelTokenLimit 逐页累积的额度集合去抖：随分页每拍都会带上已累积的 token 集合，
+// 集合收敛后重复落一条 SYNC_TOKENS，只在 <模型名:额度> 集合整体变化时才记录。
+let volcSyncTokensSig = ''
+// SYNC_HB 只记首尾两条：首拍落第一个快照后，后续每拍仅把最新快照更新进 fireh 内存，
+// 由同步收尾（done）统一落一条 SYNC_HB_END，避免滚动期间每拍都刷一条。
+let volcSyncHbFired = false
+let volcSyncHbLast: string | null = null
+// 各火山账号额度同步成功时间戳缓存 keyId → Date.now()，供「查看模型」秒开时判断是否可命中缓存跳过 webview 同步
+const volcSyncAt = new Map<string, number>()
+
 function logVolcSync(line: string): void {
+  // 仅开发模式记录同步诊断日志：发布版本（app.isPackaged）不落盘，避免无谓写盘与同步日志累积
+  if (app.isPackaged) return
+  const file = join(app.getPath('userData'), 'volc-sync.log')
   try {
-    appendFileSync(join(app.getPath('userData'), 'volc-sync.log'), `[${new Date().toISOString()}] ${line}\n`)
+    const now = Date.now()
+    // 定时裁剪（本地账本自清理）：不超过频率上限，避免每次写入都去 stat 文件
+    if (now - volcSyncLastTrimMs >= VOLC_SYNC_TRIM_INTERVAL_MS) {
+      volcSyncLastTrimMs = now
+      let size = -1
+      try {
+        size = statSync(file).size
+      } catch {
+        size = -1 // 文件尚不存在或读取失败，跳过裁剪
+      }
+      if (size > VOLC_SYNC_LOG_MAX_BYTES) {
+        let tail = ''
+        const fd = openSync(file, 'r')
+        try {
+          const pos = Math.max(0, size - VOLC_SYNC_LOG_KEEP_BYTES)
+          const buf = Buffer.alloc(size - pos)
+          readSync(fd, buf, 0, buf.length, pos)
+          tail = buf.toString('utf8')
+          // 左裁剪到首个换行之后，避免截断把一行日志劈成两半
+          const nl = tail.indexOf('\n')
+          if (nl >= 0) tail = tail.slice(nl + 1)
+        } finally {
+          closeSync(fd)
+        }
+        truncateSync(file, 0)
+        appendFileSync(file, tail)
+      }
+    }
+    appendFileSync(file, `[${new Date().toISOString()}] ${line}\n`)
   } catch {
     // ignore
   }
@@ -1389,12 +1490,83 @@ export async function captureVolcEngineConsoleSession(opts?: {
     window.__QUOTA_FLOW_VOLC__ = true;
     window.__VF_CAPTURED__ = window.__VF_CAPTURED__ || null;
     window.__VF_ACCOUNT__ = window.__VF_ACCOUNT__ || null;
+    // —— 真实账号标识（去重首选）——
+    // 火山控制台把「当前登录账号」存在会话 localStorage（如 SLARDARmlmaas_volcconsole / SLARDARvolc_console），
+    // 值可能是 base64（URL 编码）或纯 JSON，含 userId 形如 "2112155528_0"（「账号_子账号」），账号唯一且专属于当前登录。
+    // 相比从接口响应里扫 accountId（可能命中跨账号共享的静态值，如两次绑到同一 2100466578），用它做去重最可靠，
+    // 且能保留「同一火山账号多把 API Key 自动去重」的诉求。
+    const extractRealUserid = () => {
+      try {
+        // 注：本段注入代码位于模板字符串 INJECT 内，正则里的 \d/\s 必须以 \\d/\\s 转义，
+        // 否则模板字面量会把它降级成字面量字符，导致正则在页面端完全失效（表现为 REAL=null）。
+        const uidRe = /^(?:(\\d{4,20})(?:_\\d+)?)$/;
+        const dig = (u) => { if (typeof u !== 'string') return null; const m = uidRe.exec(u.trim()); return m ? m[1] : null; };
+        // 火山会话值是 urlsafe base64（可能含 - / _，无 padding），atob 前需换算为标准字符集。
+        const decodeB64 = (s) => {
+          const t = s.replace(/-/g, '+').replace(/_/g, '/');
+          const pad = t.length % 4 ? '='.repeat(4 - (t.length % 4)) : '';
+          try { return atob(t + pad); } catch (_) { return null; }
+        };
+        const decode = (s) => {
+          if (typeof s !== 'string' || !s) return s;
+          // base64/urlsafe-base64；火山会话值常为该形态，atob 后有 %7B 这类 URL 编码，先解码再 URL 解码。
+          if (/^[A-Za-z0-9+/_-]+={0,2}$/.test(s)) {
+            const d = decodeB64(s);
+            if (d !== null) {
+              try { return decodeURIComponent(d); } catch (_) { return d; }
+            }
+          }
+          return s;
+        };
+        // 权威来源：火山主登录会话 key。只认这一个 key 的 userId/UserID/user_id 字段，
+        // 避免遍历「所有 console/volc 相关 key 取首个数字」时误抓到无关 token/accountId（如 377810）。
+        const AUTH_KEYS = ['SLARDARmlmaas_volcconsole', 'SLARDARvolc_console'];
+        const AUTH_FIELDS = ['userId', 'UserID', 'user_id'];
+        const read = (k) => { try { return window.localStorage.getItem(k); } catch (_) { return null; } };
+        for (const ak of AUTH_KEYS) {
+          const raw = read(ak);
+          if (!raw) continue;
+          const s = decode(raw);
+          try {
+            const j = JSON.parse(s);
+            for (const f of AUTH_FIELDS) {
+              const d = dig(j[f]);
+              if (d) return d;
+            }
+          } catch (_) {}
+          // 兜底：正则从解码串里找 userId 形如 "2112155528_0" / "2112155528"
+          const m = /"userId"\\s*:\\s*"?((\\d{4,20})(?:_\\d+)?)?"?/i.exec(s);
+          if (m) return m[1];
+        }
+        // 次权威：key 名自带账号 id 的来源：CONSOLE_RECENT_VISIT_<中间_数字_>userId（形如 ..._2112155528 尾段），
+        // 账号 id 是 4~12 位（时间戳为 13 位毫秒），取最后一个符合位数的尾段。
+        for (let i = 0; i < window.localStorage.length; i++) {
+          const k = window.localStorage.key(i) || '';
+          if (!/^CONSOLE_RECENT_VISIT_/i.test(k)) continue;
+          const kparts = k.split('_');
+          const lastSeg = kparts[kparts.length - 1];
+          if (/^\\d{4,12}$/.test(lastSeg)) return lastSeg;
+        }
+      } catch (_) {}
+      return null;
+    };
+    const realUidResolve = () => { const r = extractRealUserid(); if (r) window.__VF_REAL_UID__ = r; return r || null; };
+    window.__VF_REAL_UID__ = null;
     // 账号标识写入 + 落 localStorage：volc 控制台从「开通管理」切到「API Key 管理」是整页跳转(非 SPA)，
     // 页面全局 __VF_ACCOUNT__ 会被清空；持久化到同源 localStorage(按分区隔离)后，任何一次整页加载都能恢复。
     const persistAccount = (id) => {
-      try { window.__VF_ACCOUNT__ = id; window.localStorage.setItem('qf:volc:account', String(id)); } catch (_) {}
+      // 真实 userId 一旦可解析即为权威：优先写它；仅当解析不到（可能登录晚于注入）才用接口扫到的
+      // 临时/共享值（如 2100466578）兜底，但绝不因上次已写入 shared 而阻止后续用 real 覆盖。
+      const real = window.__VF_REAL_UID__ || realUidResolve();
+      const target = real || id;
+      if (!target) return;
+      try { window.__VF_ACCOUNT__ = target; window.localStorage.setItem('qf:volc:account', String(target)); } catch (_) {}
     };
-    try { const _a = window.localStorage.getItem('qf:volc:account'); if (_a && !window.__VF_ACCOUNT__) window.__VF_ACCOUNT__ = _a; } catch (_) {}
+    if (realUidResolve()) {
+      persistAccount(window.__VF_REAL_UID__);
+    } else {
+      try { const _a = window.localStorage.getItem('qf:volc:account'); if (_a && !window.__VF_ACCOUNT__) window.__VF_ACCOUNT__ = _a; } catch (_) {}
+    }
     window.__VF_SUBMIT__ = false;
     const JWT_RE = /(eyJ[A-Za-z0-9_-]{5,}\\.[A-Za-z0-9_-]{5,}\\.[A-Za-z0-9_-]{5,})/;
     const store = (v) => {
@@ -1417,8 +1589,9 @@ export async function captureVolcEngineConsoleSession(opts?: {
     const BUCKET_ACCOUNT_RE = /ark-(?:auto-)?(\\d{6,20})-cn-/i;
     const extractAccount = (text) => {
       if (typeof text !== 'string' || !text || window.__VF_ACCOUNT__) return;
-      // 优先 whitelist 字段；无则用存储桶名兜底（专属性区分账号）
-      const m = text.match(ACCOUNT_KEY_RE) || text.match(BUCKET_ACCOUNT_RE);
+      // 优先「存储桶名」来源（ark-auto-{accountId}-cn-...，每个火山账号唯一），再回退通用 whitelist 字段。
+      // 通用字段可能命中 bot 预设模板里的静态 AccountId（跨账号相同），若被它抢先会把不同账号误识别成同一账号。
+      const m = text.match(BUCKET_ACCOUNT_RE) || text.match(ACCOUNT_KEY_RE);
       if (m && m[1]) persistAccount(m[1]);
     };
     // 开通管理页模型接口：网上承载「freeQuota / quota / activated / modelId」的响应体
@@ -1610,7 +1783,8 @@ export async function captureVolcEngineConsoleSession(opts?: {
         }
       } catch (_) {}
     };
-    window.__VF_SCAN2__ = setInterval(scrapeFreeModels, 2000);
+    // 定期扫描卡片 + 表格行（新 UI 表格行无「剩/共 token」额度也可用开通状态识别；回调延迟执行无 TDZ 问题）
+    window.__VF_SCAN2__ = setInterval(function () { scrapeFreeModels(); scrapeTableRows(); }, 2000);
     scrapeFreeModels();
     // 改版后开通管理页为「表格」布局（列：模型名/提供方、状态、免费推理额度、在线推理定价…）。
     // 表格逐屏虚拟渲染，Wan/Seedance-1.0 等有额度模型常在列表深处：新增面向表格行的抓取，
@@ -1626,8 +1800,10 @@ export async function captureVolcEngineConsoleSession(opts?: {
           // 表头行（无模型名且多为中文列名），跳过
           if (!t || t.length > 400 || /^模型名|^提供方|^状态$/.test(t)) continue;
           const q = t.match(volcQuotaRe);
-          // 门禁：行内必须带「剩 x /共 y token」免费推理额度才收录（2.x 无免费额度的行不混入）
-          if (!q) continue;
+          // 新 UI 行不再显示「剩 x /共 y token」，改用「安心体验/并发数/RPM」。额度匹配降级为可选：
+          // 行内含 开通状态（已开通/未开通/…）即视为模型行，额度有则带、无则留空由 ListModelTokenLimit 接口补齐。
+          const stM = t.match(/已开通|未开通|尚未开通|待开通|去开通/);
+          if (!q && !stM) continue;
           // 取自提供方(中文)前的连续模型名 token：行首第一个无中文的连续串即模型名。
           // 表格行常把模型名连写重复多次（如 Doubao-Seedance-1.5-pro …×3 且无空格），取最小重复周期去重。
           const nm = t.match(/^[A-Za-z][A-Za-z0-9._-]*/);
@@ -1640,15 +1816,16 @@ export async function captureVolcEngineConsoleSession(opts?: {
           // 开通状态：行文本含「未开通/待开通/去开通」→ 未开通；否则视为已开通
           const notActivated = /未开通|尚未开通|待开通|去开通/i.test(t);
           if (window.__VF_MODELS__.some((m) => m.name === name)) continue;
-          window.__VF_MODELS__.push({
-            name,
-            remaining: Number(q[1].replace(/,/g, '')),
-            total: Number(q[2].replace(/,/g, '')),
-            activated: notActivated ? false : true
-          });
+          const rec = { name, activated: notActivated ? false : true };
+          if (q) {
+            rec.remaining = Number(q[1].replace(/,/g, ''));
+            rec.total = Number(q[2].replace(/,/g, ''));
+          }
+          window.__VF_MODELS__.push(rec);
         }
       } catch (_) {}
     };
+    scrapeTableRows();
     let vfScreenIdx = 0;
     // 额度同步模式：逐屏渐进滚动所有可滚动容器，一屏一屏往下，滚动一屏就解析该屏表格行。
     // 每次滚一屏而非直接到底，避免跳底导致中间屏幕的模型行未渲染而漏收。
@@ -1734,7 +1911,27 @@ export async function captureVolcEngineConsoleSession(opts?: {
         '<div style="color:#c9cdd4;font-size:12px;">请使用「手机号登录/账号登录」，进入「API Key 管理」复制 Key 后点击下方按钮即可（第三方登录已拦截，需在外部浏览器完成）</div>' +
         '<button id="qf-volc-done" style="margin-top:2px;border:none;border-radius:6px;background:#22c55e;color:#fff;font:600 12.5px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:7px 12px;cursor:pointer;align-self:flex-start;">已获取 key 返回</button>';
       document.body.appendChild(bar);
-      bar.querySelector('#qf-volc-done').addEventListener('click', () => { window.__VF_SUBMIT__ = true; window.__VF_STATE__ = window.__VF_CAPTURED__ ? 'ok' : 'empty'; });
+      bar.querySelector('#qf-volc-done').addEventListener('click', () => {
+        let diag = '';
+        try {
+          // 诊断：webview 里权威 key 是否存在、解码结果、real 解析结果（定位为何取不到真实 userId）
+          const db2 = (s) => { const t = s.replace(/-/g, '+').replace(/_/g, '/'); const pad = t.length % 4 ? '='.repeat(4 - (t.length % 4)) : ''; try { return atob(t + pad); } catch (_) { return null; } };
+          const dc2 = (s) => { if (typeof s !== 'string' || !s) return s; if (/^[A-Za-z0-9+/_-]+={0,2}$/.test(s)) { const d = db2(s); if (d !== null) { try { return decodeURIComponent(d); } catch (_) { return d; } } } return s; };
+          const parts = [];
+          for (const ak of ['SLARDARmlmaas_volcconsole', 'SLARDARvolc_console']) {
+            let raw = null; try { raw = window.localStorage.getItem(ak); } catch (_) {}
+            if (!raw) { parts.push(ak + '=ABSENT'); continue; }
+            let dec = raw; try { dec = dc2(raw); } catch (_) {}
+            parts.push(ak + '=' + String(dec).slice(0, 90));
+          }
+          const r = realUidResolve();
+          parts.push('REAL=' + (r || 'null'));
+          diag = parts.join(' | ');
+          try { window.localStorage.setItem('qf:volc:diag', diag); } catch (_) {}
+        } catch (_) {}
+        realUidResolve(); if (window.__VF_REAL_UID__) persistAccount(window.__VF_REAL_UID__);
+        window.__VF_SUBMIT__ = true; window.__VF_STATE__ = window.__VF_CAPTURED__ ? 'ok' : 'empty';
+      });
       let dragging = false, offX = 0, offY = 0;
       const grip = document.getElementById('qf-volc-grip');
       const header = document.getElementById('qf-volc-header');
@@ -1788,6 +1985,10 @@ export async function captureVolcEngineConsoleSession(opts?: {
       finished = true
       clearInterval(pollTimer)
       if (renewTimeout) clearTimeout(renewTimeout)
+      // 收尾落 SYNC_HB_END（仅额度同步模式产生过首拍时）：给出结束时的最新页面快照，补全首尾视角
+      if (volcSyncHbFired && volcSyncHbLast) {
+        logVolcSync(`SYNC_HB_END ${Date.now() - winStart}ms ${volcSyncHbLast}`)
+      }
       if (!win.isDestroyed()) win.destroy()
       loginWindows.delete(winKey)
       resolve(result)
@@ -1918,7 +2119,32 @@ sample:(function(){
   return out;
 })()})`
             )
-            .then((s) => logVolcSync(`SYNC_HB ${Date.now() - winStart}ms page=${s}`))
+            .then((s) => {
+              // 心跳节流：仅在页面状态变化时记录，避免静止页面每秒刷一条大日志
+              let sig = ''
+              let compact = ''
+              try {
+                const o = JSON.parse(s) as Record<string, unknown>
+                // 紧凑字段（诊断空 __VF_MODELS__ 所需）：URL/登录墙/模型数/注入/滚动/卡片/模型行/分页
+                sig = [o.url, o.login, o.vf, o.vfIds, o.injected, o.submit, o.scroller, o.cards, o.rows, o.pag].join('|')
+                compact = JSON.stringify({
+                  url: o.url, login: o.login, vf: o.vf, vfIds: o.vfIds, injected: o.injected,
+                  submit: !!o.submit, scroller: o.scroller, cards: o.cards, rows: o.rows, pag: o.pag
+                })
+              } catch {
+                sig = ''
+              }
+              // 只记首尾：首拍落一条 SYNC_HB 快照；后续每拍仅把最新摘要更新进内存，
+              // 由同步收尾（done）在结束时统一落一条 SYNC_HB_END，避免滚动期间每拍刷屏。
+              if (sig && sig !== volcSyncHbSig) {
+                volcSyncHbSig = sig
+                volcSyncHbLast = compact
+                if (!volcSyncHbFired) {
+                  volcSyncHbFired = true
+                  logVolcSync(`SYNC_HB ${Date.now() - winStart}ms ${compact}`)
+                }
+              }
+            })
             .catch((e) => logVolcSync(`SYNC_HB_err ${e}`))
           void win.webContents
             .executeJavaScript('window.__VF_MODELS__ && (window.__VF_MODELS__.length > 0 || Object.keys(window.__VF_TOKEN_LIMITS__).length > 0 || window.__VF_HAS_RATE__) ? [window.__VF_CAPTURED__, window.__VF_ACCOUNT__ || null, window.__VF_MODELS__, window.__VF_SCREEN__ || 0, window.__VF_SAVED_RAW__ ? window.__VF_SAVED_RAW__.slice(0, 3000) : null, (window.__VF_MODELS_RAW__||[]).map(function(r){return r.url;}).filter(function(u,i,a){return a.indexOf(u)===i;}).slice(0,15), window.__VF_MODEL_BODY__ ? window.__VF_MODEL_BODY__.slice(0, 6000) : null, window.__VF_TOKEN_LIMITS__ || {}, window.__VF_HAS_RATE__ || false, window.__VF_PAGE__ || 0, window.__VF_HASMORE__ ? true : false, (window.__VF_PAGEDEBUG__ || []).join(";")] : null')
@@ -1939,24 +2165,38 @@ sample:(function(){
                 string
               ]
               // 接口原始响应抓取：优先用接口 JSON 解析模型额度的开通状态，DOM 卡片只是兜底。
+              // 去抖：URL/响应体在每轮轮询中重复出现，只在内容变化时记录，避免每拍重复 dump。
               if (Array.isArray(rawUrls) && rawUrls.length > 0) {
-                logVolcSync(`SYNC_RAWURLS ${rawUrls.join(' | ')}`)
+                const urlSig = rawUrls.join('|')
+                if (urlSig !== volcSyncRawUrlsSig) {
+                  volcSyncRawUrlsSig = urlSig
+                  logVolcSync(`SYNC_RAWURLS ${rawUrls.join(' | ')}`)
+                }
               }
-              if (typeof modelBody === 'string' && modelBody.length > 80 && modelBody !== rawBody) {
+              if (typeof modelBody === 'string' && modelBody.length > 80 && modelBody !== rawBody && modelBody !== volcSyncModelBodySig) {
+                volcSyncModelBodySig = modelBody
                 logVolcSync(`SYNC_MODELBODY ${modelBody.slice(0, 6000)}`)
               }
-              if (typeof rawBody === 'string' && rawBody.length > 80) {
+              if (typeof rawBody === 'string' && rawBody.length > 80 && rawBody !== volcSyncRawBodySig) {
+                volcSyncRawBodySig = rawBody
                 logVolcSync(`SYNC_RAW sample=${rawBody.slice(0, 2200)}`)
               }
               // 接口级模型：ListModelTokenLimit 的 TokenLimit 即每个已开通模型的免费总额度。
               // 换算为与目录一致的单位（火山 TokenLimit 单位是 token），remaining = TokenLimit - currentUsage。
               const tokenNames = Object.keys(tokenLimits || {})
               if (tokenNames.length > 0) {
-                logVolcSync(
-                  `SYNC_TOKENS ${tokenNames
-                    .map((n) => `${n}:${tokenLimits[n].tokenLimit}/used${tokenLimits[n].currentUsage}`)
-                    .join(' | ')}`
-                )
+                // 去抖：只用集合整体变化时记录一次，避免每拍重复落一条已收敛的 SYNC_TOKENS
+                const tokSig = tokenNames
+                  .map((n) => `${n}:${tokenLimits[n].tokenLimit}/${tokenLimits[n].currentUsage}`)
+                  .join('|')
+                if (tokSig !== volcSyncTokensSig) {
+                  volcSyncTokensSig = tokSig
+                  logVolcSync(
+                    `SYNC_TOKENS ${tokenNames
+                      .map((n) => `${n}:${tokenLimits[n].tokenLimit}/used${tokenLimits[n].currentUsage}`)
+                      .join(' | ')}`
+                  )
+                }
                 // 把接口真实额度 upsert 进 rawModels（副本），供下方 capture 合并，保证已开通模型不被
                 // 目录 fallback 显示「待开通」。随后继续走 capture/稳定收敛，不做 return。
                 for (const name of tokenNames) {
@@ -2000,14 +2240,33 @@ sample:(function(){
                 (scrolledEnough && syncStableCount >= 3 && !morePages) ||
                 (scrolledEnough && Date.now() - winStart >= 18000)
               ) {
+                // 权威判定「未开通」：分页耗尽(morePages=false) 且 ListModelTokenLimit 已返回过真实 token
+                // 额度（该接口只覆盖已开通模型、随分页逐页累积），认定已抓到全量已开通免费模型；
+                // 未被抓到的目录模型即为「未开通」，据此覆盖目录默认 activated:true，避免未开通模型
+                // （如本账号未开通的 seedance-1.5-pro）误显示「已开通」。
+                const complete = !morePages && Object.keys(tokenLimits || {}).length > 0
+                const finalCaptured = captureVolcengineFreeVideoModels(rawModels, undefined, {
+                  markAbsentInactivated: complete
+                })
+                const finalModels = finalCaptured.models
+                // 接口为准+未知保守：只信任 ListModelTokenLimit 返回（权威）模型的 freeQuota；
+                // 未命中模型的 freeQuota 来自 DOM/旧缓存，会误导「查看模型」展示（如 seedance-1.0-pro
+                // 显示 272120/2000000 而官网为已开通剩0），一律置空按「— 未知」保守展示。
+                const authoritative = volcengineAuthoritativeIds(Object.keys(tokenLimits || {}))
+                if (authoritative.size > 0) {
+                  for (const m of finalModels) {
+                    if (!authoritative.has(m.id)) m.freeQuota = undefined
+                  }
+                }
                 logVolcSync(
-                  `SYNC_HIT models=${sig.slice(0, 400)} raw=${rawModels.length} stable=${syncStableCount} screen=${screenIdx} page=${curPage} more=${hasMore ? true : false} pgdb=${pageDebug || ''}`
+                  `SYNC_FINAL complete=${complete ? 'YES' : 'NO'} authoritative=${authoritative.size} models=${finalModels.map((m) => `${m.id}:${m.activated ? 'T' : 'F'}${m.freeQuota ? '/Q' : '/-'}`).join(',')}`
                 )
+                if (syncLatest) syncLatest.models = finalModels
                 done({
                   ok: true,
                   consoleJwt: syncLatest.consoleJwt,
                   accountId: typeof syncLatest.accountId === 'string' ? syncLatest.accountId : undefined,
-                  models: syncLatest.models,
+                  models: finalModels,
                   source: 'console'
                 })
               }
@@ -2026,20 +2285,21 @@ sample:(function(){
         return
       }
       void win.webContents
-        .executeJavaScript('window.__VF_SUBMIT__ ? [window.__VF_STATE__, window.__VF_CAPTURED__, (window.__VF_ACCOUNT__ || (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return null}})()), window.__VF_MODELS__ || [], (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return \'e\'}})() ] : null')
+        .executeJavaScript('window.__VF_SUBMIT__ ? [window.__VF_STATE__, window.__VF_CAPTURED__, (window.__VF_ACCOUNT__ || (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return null}})()), window.__VF_MODELS__ || [], (function(){try{return window.localStorage.getItem(\'qf:volc:account\')||null}catch(_){return \'e\'}})(), (function(){try{return window.localStorage.getItem(\'qf:volc:diag\')||null}catch(_){return null}})() ] : null')
         .then((val: unknown) => {
           if (!val) return
-          const [state, jwt, accountId, rawModels, lsVal] = val as [
+          const [state, jwt, accountId, rawModels, lsVal, diag] = val as [
             string,
             string | null,
             string | null,
             Array<{ name: string; remaining?: number; total?: number }>,
+            string | null,
             string | null
           ]
           // 绑定诊断：accountId 可能来自页面全局 __VF_ACCOUNT__，或整页跳转后从 localStorage 恢复读取；
           // 两者都空才能判定绑定时确未抓到账号 id（否则是链路其它环节丢的）
           logVolcSync(
-            `CAPTURE_SUBMIT state=${state} accountId=${accountId ? 'YES' : 'NO'} ls=${(typeof lsVal === 'string' && lsVal) ? 'YES' : 'NO'}`
+            `CAPTURE_SUBMIT state=${state} accountId=${accountId ? `YES:${accountId}` : 'NO'} ls=${(typeof lsVal === 'string' && lsVal) ? `YES:${lsVal}` : 'NO'} diag=${typeof diag === 'string' && diag ? diag : 'NONE'}`
           )
           // 火山方舟控制台走 cookie 会话，通常不产生进入 Authorization 头的三段式 JWT（consoleJwt）。
           // 故「已获取 key 返回」时不再把缺 JWT 视为失败：绑定只需 API Key，consoleJwt 作为可选增强，
@@ -2103,7 +2363,7 @@ export function initProviders(): void {
         if (providerId === 'volcengine') {
           const { accountId } = decodeVolcenginePayload(plain)
           logVolcSync(
-            `ENC_VOLC accountId=${accountId ? 'YES' : 'NO'} fp_level=${fingerprint ? (accountId ? 'account' : 'key-hash') : 'none'}`
+            `ENC_VOLC accountId=${accountId ? `YES:${accountId}` : 'NO'} fp_level=${fingerprint ? (accountId ? 'account' : 'key-hash') : 'none'}`
           )
         }
       }
@@ -2217,8 +2477,29 @@ export function initProviders(): void {
   // 成功则重建加密负载（更新 models + 最新 consoleJwt/accountId）返回 newEncrypted，供渲染层落库并刷新展示。
   ipcMain.handle(
     'provider:volc-sync-models',
-    async (_e, _providerId: string, keyId: string, encrypted: string) => {
+    async (_e, _providerId: string, keyId: string, encrypted: string, maxStaleMs?: number) => {
       if (!encrypted) return { ok: false, reason: 'no-secret', error: '缺少密钥' }
+      // 缓存命中：maxStaleMs>0 且上次同步成功未超期，且负载里已有 models → 直接返回，跳过一次 webview 同步让弹窗秒开
+      if (typeof maxStaleMs === 'number' && maxStaleMs > 0) {
+        try {
+          const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
+          const { models } = decodeVolcenginePayload(plain)
+          const syncedAt = volcSyncAt.get(keyId)
+          if (Array.isArray(models) && models.length > 0 && typeof syncedAt === 'number' && Date.now() - syncedAt < maxStaleMs) {
+            logVolcSync(`SYNC_CACHED key=${keyId}`)
+            return { ok: true, cached: true }
+          }
+        } catch {
+          /* 负载解析失败则按未命中继续走完整同步 */
+        }
+      }
+      volcSyncHbSig = '' // 新一次同步重置心跳节流，保证每次都会记录首个状态快照
+      volcSyncModelBodySig = ''
+      volcSyncRawBodySig = ''
+      volcSyncRawUrlsSig = ''
+      volcSyncTokensSig = ''
+      volcSyncHbFired = false
+      volcSyncHbLast = null
       logVolcSync(`SYNC_START key=${keyId}`)
       try {
         const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
@@ -2243,6 +2524,7 @@ export function initProviders(): void {
           if (newAccountId) {
             newFingerprint = await volcengineAccountFingerprint(newPlain)
           }
+          volcSyncAt.set(keyId, Date.now()) // 记录本次成功同步时间，供后续缓存判断
           console.log(`[volc-sync] 回写 models=${res.models.map((m) => m.id).join(',')} accountId=${newAccountId ?? 'NO'}`)
           logVolcSync(`SYNC_BACKFILL key=${keyId} accountId=${newAccountId ? 'YES' : 'NO'} fp=${newFingerprint ? 'account' : (accountId ? 'account' : 'key-hash')}`)
           logVolcSync(`SYNC_WRITEBACK key=${keyId} models=${res.models.map((m) => m.id).join(',')} accountId=${newAccountId ? 'YES' : 'NO'} fp=${newFingerprint ? 'account' : 'key-hash'}`)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -131,6 +131,10 @@ export interface ApiModelInfo {
   activated?: boolean
   /** 【每账号】免费 token 额度（火山方舟免费视频模型）：剩余/总数；未抓到为 undefined */
   freeQuota?: { remaining?: number; total?: number }
+  /** 火山方舟模型不可用标记：平台下架 / 账号无接入点 */
+  unavailable?: 'decommissioned' | 'no_endpoint'
+  /** 不可用原因标签（已下架 / 无接入点），仅当 unavailable 有值时存在 */
+  unavailableLabel?: string
 }
 
 /** 火山方舟绑定时控制台抓到的免费视频模型（含每账号 token 额度），随加密负载持久化 */
@@ -290,12 +294,13 @@ export interface DesktopApi {
      * 额度/开通状态；命中则返回重建后的新加密负载（encrypted）+ models，供调用方落库并刷新展示；
      * 未抓到（登录态失效/页面未就绪）返回 {ok:true, preserved:true} 保留旧值。
      */
-    volcSyncModels: (keyId: string, encrypted: string) => Promise<{
+    volcSyncModels: (keyId: string, encrypted: string, maxStaleMs?: number) => Promise<{
       ok: boolean
       encrypted?: string
       models?: VolcengineCapturedModel[]
       accountFingerprint?: string | null
       preserved?: boolean
+      cached?: boolean
       reason?: string
       error?: string
     }>
@@ -439,12 +444,13 @@ const api: DesktopApi = {
         reason?: string
         error?: string
       }>,
-    volcSyncModels: (keyId, encrypted) =>
-      ipcRenderer.invoke('provider:volc-sync-models', 'volcengine', keyId, encrypted) as Promise<{
+    volcSyncModels: (keyId, encrypted, maxStaleMs) =>
+      ipcRenderer.invoke('provider:volc-sync-models', 'volcengine', keyId, encrypted, maxStaleMs) as Promise<{
         ok: boolean
         encrypted?: string
         models?: VolcengineCapturedModel[]
         preserved?: boolean
+        cached?: boolean
         reason?: string
         error?: string
       }>

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -188,6 +188,8 @@ export default function Dashboard({
   const [images, setImages] = useState<string[]>([])
   const [imageFiles, setImageFiles] = useState<File[]>([])
   const [savedImagePaths, setSavedImagePaths] = useState<string[]>([])
+  // 开放平台 API 型厂商（智谱/火山）图片异步上传计数：>0 表示尚有图片在上传，禁用「开始生成」
+  const [uploadingCount, setUpLoadingCount] = useState(0)
   const [prompt, setPrompt] = useState('')
   const [generating, setGenerating] = useState(false)
   const [genError, setGenError] = useState<string | null>(null)
@@ -491,6 +493,11 @@ export default function Dashboard({
   const handleGenerate = useCallback(async (): Promise<void> => {
     const currentMode = provider === 'dola' ? 'multi_ref' : mode
     if (generating) return
+    // 开放平台 API 型厂商（智谱/火山）：图生/多参考/首尾帧需公网 https 图片，上传未完成时禁用，避免提交空图报错
+    if ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0) {
+      setGenError('图片正在上传中，请稍候再生成')
+      return
+    }
     if (fresh && step === 1) {
       onGoProviders()
       return
@@ -592,7 +599,7 @@ export default function Dashboard({
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, model, features, caps, providerCaps, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, model, features, caps, providerCaps, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, uploadingCount, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -660,21 +667,25 @@ export default function Dashboard({
     fileInputRef.current?.click()
   }, [])
 
-  // 智谱走开放平台 API，图生/多参考/首尾帧的图片必须为公网 https URL：
+  // 开放平台 API 型厂商（智谱 / 火山方舟）的图生/多参考/首尾帧图片必须为公网 https URL：
   // 先立即显示本地预览（blob URL），再逐个后台上传到 qf-images 桶取公开 URL（回填 savedImagePaths 同序号格子）。
-  const appendZhipuImages = useCallback(
+  const appendApiImages = useCallback(
     async (files: File[]) => {
       const base = savedImagePaths.length
       // 预览立刻出现，不等网络上传
       setImages((prev) => [...prev, ...files.map((f) => URL.createObjectURL(f))])
       // 预占储存格保证 savedImagePaths 与 images 序号对齐；上传完成后回填 https URL
       setSavedImagePaths((prev) => [...prev, ...files.map(() => '')])
+      setUpLoadingCount((c) => c + files.length)
       for (let i = 0; i < files.length; i++) {
+        const idx = base + i
         try {
           const url = await uploadReferenceImage(files[i])
-          setSavedImagePaths((prev) => prev.map((p, idx) => (idx === base + i ? url : p)))
+          setSavedImagePaths((prev) => prev.map((p, j) => (j === idx ? url : p)))
         } catch (e) {
           setGenError('图片上传失败：' + (e instanceof Error ? e.message : String(e)))
+        } finally {
+          setUpLoadingCount((c) => Math.max(0, c - 1))
         }
       }
     },
@@ -685,8 +696,8 @@ export default function Dashboard({
     const files = Array.from(e.target.files ?? [])
     const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
     const picked = files.slice(0, remaining)
-    if (provider === 'zhipu') {
-      void appendZhipuImages(picked)
+    if (provider === 'zhipu' || provider === 'volcengine') {
+      void appendApiImages(picked)
       e.target.value = ''
       return
     }
@@ -694,7 +705,7 @@ export default function Dashboard({
     setImages((prev) => [...prev, ...urls])
     setImageFiles((prev) => [...prev, ...picked])
     e.target.value = ''
-  }, [provider, model, savedImagePaths, appendZhipuImages])
+  }, [provider, model, savedImagePaths, appendApiImages])
 
   const onPasteImages = useCallback((e: ReactClipboardEvent<HTMLDivElement>) => {
     const files = Array.from(e.clipboardData.files ?? []).filter((f) => f.type.startsWith('image/'))
@@ -702,14 +713,14 @@ export default function Dashboard({
     e.preventDefault()
     const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
     const picked = files.slice(0, remaining)
-    if (provider === 'zhipu') {
-      void appendZhipuImages(picked)
+    if (provider === 'zhipu' || provider === 'volcengine') {
+      void appendApiImages(picked)
       return
     }
     const urls = picked.map((f) => URL.createObjectURL(f))
     setImages((prev) => [...prev, ...urls])
     setImageFiles((prev) => [...prev, ...picked])
-  }, [provider, model, savedImagePaths, appendZhipuImages])
+  }, [provider, model, savedImagePaths, appendApiImages])
 
   const onRemoveImage = useCallback((idx: number) => {
     setImages((prev) => prev.filter((_, i) => i !== idx))
@@ -920,6 +931,11 @@ export default function Dashboard({
                       }}
                     >
                       <img src={src} alt="" />
+                      {idx < savedImagePaths.length && savedImagePaths[idx] === '' && (
+                        <div className="thumb-loading" title="图片上传中…">
+                          <span className="thumb-loading-spinner" />
+                        </div>
+                      )}
                       <button className="remove-thumb" onClick={(e) => { e.stopPropagation(); onRemoveImage(idx) }}>×</button>
                     </div>
                   ))}
@@ -961,7 +977,7 @@ export default function Dashboard({
             )}
             <button
               className="btn-primary"
-              disabled={generating && cancelling}
+              disabled={(generating && cancelling) || ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0)}
               onClick={() => {
                 if (generating) void handleCancel()
                 else void handleGenerate()

--- a/apps/desktop/src/renderer/src/components/History.tsx
+++ b/apps/desktop/src/renderer/src/components/History.tsx
@@ -202,7 +202,8 @@ export default function History({
     }
   }, [])
 
-  // 打开详情时，把上传图片的本地路径解析成可预览的 http 地址
+  // 打开详情时，把上传图片解析成可预览的 http 地址。
+  // 兼容两类来源：本地图片副本（userData/images，走本地媒体服务）与公网 https 地址（开放平台 API 上传到 Supabase qf-images 桶）。
   useEffect(() => {
     if (!detail) {
       setDetailImgUrls([])
@@ -210,11 +211,16 @@ export default function History({
       return
     }
     let cancelled = false
-    const names = detail.record.images
-      .map((p) => p.replace(/\\/g, '/').split('/').pop() || '')
-      .filter(Boolean)
+    const paths = detail.record.images.map((p) => p.replace(/\\/g, '/')).filter(Boolean)
     Promise.all(
-      names.map((n) => window.api.media.getImageUrl(n).catch(() => null))
+      paths.map((p) => {
+        // 已是公网 http(s) URL（如 Supabase 公开地址）→ 直接展示，无需本地媒体服务
+        if (/^https?:\/\//i.test(p)) return Promise.resolve(p)
+        // 本地图片副本：取 basename 走本地媒体服务解析
+        const name = p.split('/').pop() || ''
+        if (!name) return Promise.resolve(null)
+        return window.api.media.getImageUrl(name).catch(() => null)
+      })
     )
       .then((urls) => {
         if (!cancelled) setDetailImgUrls(urls.filter((u): u is string => !!u))

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -731,6 +731,11 @@ export function AddProviderModal({
     setLoginTempId(null)
     setDupCandidate(null)
     setPendingSave(null)
+    // 清空上一账号残留的控制台捕获上下文（accountId/consoleJwt/models），防止重开/切换厂商时
+    // 把上一账号的 accountId 带入本次保存，导致不同账号被误判为重复账号（指纹退化成同账号级）。
+    setVolcAccountId(null)
+    setConsoleJwt(null)
+    setVolcModels(null)
   }
 
   const saveEncrypted = async (
@@ -949,9 +954,14 @@ export function AddProviderModal({
     setError(null)
     setNotice(null)
     try {
-      // 按账号绑定：先生成绑定 keyId（作为控制台分区与 DB 记录 id），确保登录态存入该账号自己的分区、多账号互不串号
-      let bindId = loginTempId
-      if ((providerId === 'zhipu' || providerId === 'volcengine') && !bindId) {
+      // 按账号绑定：每次「获取 API Key」都生成全新临时 keyId（作为控制台分区与 DB 记录 id），
+      // 确保登录态独立分区、多账号互不串号（避免复用上一账号的分区 localStorage 导致账号标识串号）。
+      // 同时清空上一账号残留的捕获上下文，防止不同账号误判为重复账号。
+      setVolcAccountId(null)
+      setConsoleJwt(null)
+      setVolcModels(null)
+      let bindId: string | null = null
+      if (providerId === 'zhipu' || providerId === 'volcengine') {
         bindId = crypto.randomUUID()
         setLoginTempId(bindId)
       }

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -12,6 +12,9 @@ import type { ApiModelInfo } from '../../../preload'
 
 const PAGE_SIZE = 10
 
+// 火山「查看模型」额度缓存有效期：有效期内点开不再触发 webview 同步，直接秒开展示缓存值；过期后台静默刷新
+const VOLC_VIEW_MODELS_CACHE_MS = 5 * 60 * 1000
+
 /** 顶部额度汇总条
  * - volcengine：聚合免费模型的额度（保持火山方舟原有展示，单位 tokens）
  * - zhipu（及其他）：展示账号级共用额度（付费模型共用），单位按厂商配置
@@ -28,10 +31,13 @@ function ModelsQuotaSummary({
   unit?: string
 }) {
   if (providerId === 'volcengine') {
-    // 火山方舟：聚合免费模型额度
-    const freeModels = models.filter((m) => m.cost === 0 && m.freeQuota?.total)
-    const total = freeModels.reduce((sum, m) => sum + (m.freeQuota?.total ?? 0), 0)
-    const remaining = freeModels.reduce((sum, m) => sum + (m.freeQuota?.remaining ?? 0), 0)
+    // 火山方舟：聚合所有免费模型额度。
+    // total 含已开通 + 未开通的所有免费模型；remaining 只计已开通（activated !== false）模型的可用量。
+    const modelsWithQuota = models.filter((m) => m.cost === 0 && m.freeQuota?.total)
+    const total = modelsWithQuota.reduce((sum, m) => sum + (m.freeQuota?.total ?? 0), 0)
+    const remaining = modelsWithQuota
+      .filter((m) => m.activated !== false)
+      .reduce((sum, m) => sum + (m.freeQuota?.remaining ?? 0), 0)
     if (total <= 0) return null
     const pct = Math.min(100, Math.max(0, (remaining / total) * 100))
     return (
@@ -88,6 +94,21 @@ function ModelQuotaCell({
   const freeQuota = model.freeQuota
 
   if (providerId === 'volcengine') {
+    // 火山方舟：不可用模型（已下架 / 无接入点）置灰 + 徽标，提示原因
+    const unavail = model.unavailable
+    if (unavail === 'decommissioned' || unavail === 'no_endpoint') {
+      return (
+        <span
+          className="models-quota-cell"
+          title={unavail === 'decommissioned' ? '该模型已被火山平台下架/停用，无法生成' : '该账号无此模型接入点，无法生成；可在开通管理页开通或更换模型'}
+        >
+          <span className={unavail === 'decommissioned' ? 'badge badge-danger' : 'badge badge-pending'}>
+            {unavail === 'decommissioned' ? '已下架' : '无接入点'}
+          </span>
+          <span className="models-quota-text models-quota-text--dim">不可生成</span>
+        </span>
+      )
+    }
     // 火山方舟：免费模型 + 待开通徽章
     const activated = model.activated !== false
     if (!activated) {
@@ -108,7 +129,12 @@ function ModelQuotaCell({
         </span>
       )
     }
-    return <span className="models-quota-text models-quota-text--dim">— token</span>
+    // 已开通但接口未返回免费额度（额度耗尽/不在权威列表）：接口为准，未知保守，避免 DOM 旧值误导
+    return (
+      <span className="models-quota-text models-quota-text--dim" title="接口未返回该模型的免费推理额度，暂不展示具体数值">
+        — 未知
+      </span>
+    )
   }
 
   // 其他厂商（智谱等）
@@ -153,7 +179,7 @@ interface ProvidersProps {
 
 export default function Providers({ fresh, viewScope, usageScope, onBound, providers, canBind = true }: ProvidersProps) {
   const { user, team } = useAuth()
-  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, setKeyHealth, refreshVolcengineModelsOnce } = providers
+  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, volcTokenOverrides, setKeyHealth, refreshVolcengineModelsOnce } = providers
   const [text, setText] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -207,7 +233,7 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
     }
   }
 
-  // API Key 型厂商「查看模型」：拉取模型目录（火山方舟先静默同步最新免费模型额度/开通状态）
+  // API Key 型厂商「查看模型」：拉取模型目录（火山方舟先展示缓存额度，再按 5min 缓存后台静默同步刷新）
   const handleViewModels = async (providerId: string, keyId: string, accountName: string, unitName: string) => {
     // 立即弹出弹窗并进入加载态，让火山方舟较慢的静默同步有可见反馈
     const token = ++modelsTokenRef.current
@@ -225,21 +251,35 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
         if (svc && user) {
           const secret = await svc.getProviderKeySecret(user.id, keyId)
           if (secret) encrypted = secret.encrypted_key
-          // 先静默同步该账号最新免费模型额度/开通状态；命中则用重建的加密负载展示最新值
-          const fresh = await refreshVolcengineModelsOnce(keyId)
-          if (fresh) encrypted = fresh
         }
       }
-      // 用户在同步期间已关闭弹窗，则丢弃本次结果
+      // 先立即用缓存展示模型目录，让弹窗第一次打开就秒出内容
       if (token !== modelsTokenRef.current) return
-      const res = await window.api.providers.apiModels(providerId, encrypted)
+      const cachedRes = encrypted ? await window.api.providers.apiModels(providerId, encrypted) : null
       if (token !== modelsTokenRef.current) return
-      if (res.ok && res.models) {
-        setModels(res.models)
-      } else {
+      if (cachedRes?.ok && cachedRes.models) {
+        setModels(cachedRes.models)
+        setModelsLoading(false)
+      }
+      // 后台静默同步最新额度/开通状态（火山方舟：命中 5min 缓存则跳过，否则同步后刷新展示）
+      if (providerId === 'volcengine') {
+        const fresh = await refreshVolcengineModelsOnce(keyId, { maxStaleMs: VOLC_VIEW_MODELS_CACHE_MS })
+        if (fresh && token === modelsTokenRef.current) {
+          const newRes = await window.api.providers.apiModels(providerId, fresh)
+          if (token === modelsTokenRef.current && newRes.ok && newRes.models) {
+            setModels(newRes.models)
+          }
+        }
+        // 非火山：无缓存可秒开，同步完成后重新拉取展示最新值
+      } else if (cachedRes && (!cachedRes.ok || !cachedRes.models)) {
+        const res = await window.api.providers.apiModels(providerId, encrypted)
         if (token === modelsTokenRef.current) {
-          showToast(res.error || '无法加载模型目录', false)
-          setModels(null)
+          if (res.ok && res.models) {
+            setModels(res.models)
+          } else {
+            showToast(res.error || '无法加载模型目录', false)
+            setModels(null)
+          }
         }
       }
     } catch (e) {
@@ -446,6 +486,7 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
                         onTestApiKey={(keyId) => handleTestApiKey(p.providerId, keyId)}
                         onViewModels={(keyId, accountName) => handleViewModels(p.providerId, keyId, accountName, p.unitName)}
                         zhipuQuotaOverrides={zhipuQuotaOverrides}
+                        volcTokenOverrides={volcTokenOverrides}
                         currentUserId={user?.id ?? ''}
                         team={team}
                       />
@@ -517,7 +558,11 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
                     </thead>
                     <tbody>
                       {models.map((m) => (
-                        <tr key={m.model}>
+                        <tr
+                          key={m.model}
+                          className={m.unavailable ? 'models-row-disabled' : undefined}
+                          title={m.unavailable === 'decommissioned' ? '该模型已被火山平台下架/停用，无法生成' : m.unavailable === 'no_endpoint' ? '该账号无此模型接入点，无法生成；可在开通管理页开通或更换模型' : undefined}
+                        >
                           <td className="models-cell-model">
                             <code className="models-model-code">{m.model}</code>
                           </td>
@@ -567,6 +612,7 @@ function ProviderRow({
   onTestApiKey,
   onViewModels,
   zhipuQuotaOverrides,
+  volcTokenOverrides,
   currentUserId,
   team
 }: {
@@ -587,24 +633,37 @@ function ProviderRow({
   onTestApiKey: (keyId: string) => Promise<void>
   onViewModels: (keyId: string, accountName: string) => Promise<void>
   zhipuQuotaOverrides: Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
+  volcTokenOverrides: Record<string, { remaining: number; total: number } | null>
   currentUserId: string
   team: { id: string } | null
 }) {
   const isApiKeyProvider = agg.authType === 'apikey'
   const activeBindings = agg.bindings.filter((b) => b.enabled)
   const totalUsed = activeBindings.reduce((s, b) => s + b.used, 0)
-  // 智谱等 API 型厂商：额度以平台真实资源包余额为准，而非静态默认额度；汇总只累计有可用余额的账号
+  // API 型厂商：额度以平台真实资源包余额 / token 汇总为准，而非静态默认日额度；汇总只累计有可用数据的账号
   const isApiQuota = agg.providerId === 'zhipu'
+  const isVolc = agg.providerId === 'volcengine'
   const quotaOf = (keyId: string) =>
-    zhipuQuotaOverrides[keyId] && zhipuQuotaOverrides[keyId].available ? zhipuQuotaOverrides[keyId] : undefined
+    isApiQuota
+      ? zhipuQuotaOverrides[keyId] && zhipuQuotaOverrides[keyId].available
+        ? zhipuQuotaOverrides[keyId]
+        : undefined
+      : isVolc
+        ? volcTokenOverrides[keyId] && volcTokenOverrides[keyId]!.total > 0
+          ? volcTokenOverrides[keyId]
+          : undefined
+        : undefined
   const remaining = activeBindings.reduce(
-    (s, b) => s + (isApiQuota ? quotaOf(b.keyId)?.remaining ?? 0 : b.remaining),
+    (s, b) => s + (isApiQuota || isVolc ? quotaOf(b.keyId)?.remaining ?? 0 : b.remaining),
     0
   )
   const totalQuota = activeBindings.reduce(
-    (s, b) => s + (isApiQuota ? quotaOf(b.keyId)?.total ?? 0 : b.dailyTotal),
+    (s, b) => s + (isApiQuota || isVolc ? quotaOf(b.keyId)?.total ?? 0 : b.dailyTotal),
     0
   )
+  // 火山方舟：所有启用账号都未拿到真实 token 汇总时，厂商行总计显示占位（避免展示假的 0/0 或账本日额度）
+  const volcNoQuota =
+    isVolc && activeBindings.length > 0 && activeBindings.every((b) => !(volcTokenOverrides[b.keyId] && volcTokenOverrides[b.keyId]!.total > 0))
   const disabledCount = agg.bindings.length - activeBindings.length
   const [editKeyId, setEditKeyId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
@@ -625,7 +684,7 @@ function ProviderRow({
           </span>
         </td>
         <td>{agg.unitName}</td>
-        <td>{remaining} / {totalQuota}</td>
+        <td>{volcNoQuota ? <span className="models-quota-text--dim">—</span> : `${remaining.toLocaleString()} / ${totalQuota.toLocaleString()}`}</td>
         <td className="col-accounts">{agg.boundCount} 个账号{disabledCount > 0 ? `（${disabledCount} 已停用）` : ''}</td>
         <td>
           <span className={'badge ' + badge.cls}>{badge.label}</span>
@@ -721,6 +780,20 @@ function ProviderRow({
                             return (
                               <span>{q?.available ? `${q.remaining} / ${q.total} ${agg.unitName}` : '—'}</span>
                             )
+                          })()
+                        ) : agg.providerId === 'volcengine' ? (
+                          (() => {
+                            const t = volcTokenOverrides[acc.keyId]
+                            // 已取到真实 token 汇总：显示真实额度（剩余 / 总数 token）
+                            if (t && t.total > 0) {
+                              return <span>{t.remaining.toLocaleString()} / {t.total.toLocaleString()} tokens</span>
+                            }
+                            // 拉取完成但未拿到真实额度：显示占位提示，替代账本假额度（50/50 次）
+                            if (t === null) {
+                              return <span className="models-quota-text models-quota-text--dim">额度待查看</span>
+                            }
+                            // 拉取中：短暂沿用旧值避免闪烁
+                            return <span>{acc.remaining} / {acc.dailyTotal} {agg.unitName}</span>
                           })()
                         ) : (
                           `${acc.remaining} / ${acc.dailyTotal} ${agg.unitName}`

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -185,8 +185,10 @@ export interface ProvidersResult {
     string,
     { hasSession: boolean; status?: 'alive' | 'expiring' | 'expired'; expMs?: number | null; remainingMs?: number | null }
   >
+  /** 火山方舟账号真实 token 汇总覆盖（keyId -> remaining/total；null 表示已拉取但未拿到真实额度） */
+  volcTokenOverrides: Record<string, { remaining: number; total: number } | null>
   /** 火山方舟额度同步：后台静默抓取该账号最新免费模型额度/开通状态并落库；命中返回新加密负载，未抓到返回 false */
-  refreshVolcengineModelsOnce: (keyId: string) => Promise<string | false>
+  refreshVolcengineModelsOnce: (keyId: string, opts?: { maxStaleMs?: number }) => Promise<string | false>
 }
 
 export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult {
@@ -203,6 +205,11 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
   // 智谱等 API 型厂商账号真实额度覆盖（平台资源包余额），key = keyId
   const [zhipuQuotaOverrides, setZhipuQuotaOverrides] = useState<
     Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
+  >({})
+  // 火山方舟账号真实 token 汇总覆盖（该账号所有免费模型 freeQuota 之和），key = keyId。
+  // 值为 null 表示已拉取但未拿到真实 token 汇总（用于展示占位，避免误显示账本假额度 50/50）。
+  const [volcTokenOverrides, setVolcTokenOverrides] = useState<
+    Record<string, { remaining: number; total: number } | null>
   >({})
 
   // 单次拉取智谱某账号真实额度（平台资源包余额）并写入覆盖；返回剩余次数（查询失败返回 null）
@@ -355,6 +362,47 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     [user]
   )
 
+  // 拉取火山某账号真实 token 汇总（该账号所有免费模型 freeQuota 之和），并写入覆盖。
+  // 口径与「查看模型」弹窗 ModelsQuotaSummary 一致：聚合 cost 0 且 freeQuota?.total 存在的模型。
+  // 未取到任何真实额度时写 null（前端据此显示占位，而不是账本假额度 50/50）。
+  const fetchVolcTokenSummaryOnce = useCallback(
+    async (keyId: string): Promise<void> => {
+      const svc = getProviderService()
+      if (!svc || !user) return
+      let found = false
+      try {
+        const secret = await svc.getProviderKeySecret(user.id, keyId)
+        if (!secret) return
+        const res = await window.api.providers.apiModels('volcengine', secret.encrypted_key)
+        const models = res.ok ? res.models : undefined
+        if (Array.isArray(models) && models.length > 0) {
+          let total = 0
+          let remaining = 0
+          // 总数：含所有免费模型（已开通 + 未开通）
+          // 可用：只计已开通（activated !== false）模型的可用量
+          for (const m of models) {
+            if (m.cost === 0 && m.freeQuota && typeof m.freeQuota.total === 'number' && m.freeQuota.total > 0) {
+              total += m.freeQuota.total
+              if (m.activated !== false && typeof m.freeQuota.remaining === 'number') {
+                remaining += m.freeQuota.remaining
+              }
+            }
+          }
+          if (total > 0) {
+            found = true
+            setVolcTokenOverrides((prev) => ({ ...prev, [keyId]: { remaining, total } }))
+          }
+        }
+      } catch {
+        // 拉取失败不阻断
+      }
+      if (!found) {
+        setVolcTokenOverrides((prev) => ({ ...prev, [keyId]: null }))
+      }
+    },
+    [user]
+  )
+
   // 对单个火山账号做一次静默续期：成功则用新加密负载落库并重拉真实额度；全局一次只续一个（共享会话分区）
   const renewVolcSessionOnce = useCallback(
     async (keyId: string, encrypted: string): Promise<boolean> => {
@@ -390,13 +438,14 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
   // 命中（抓到新 models）则用重建的加密负载更新 DB 并返回新 encrypted，供「查看模型」即时展示；
   // 未抓到（登录态失效/页面未就绪）保留旧值返回 false，不打断调用方。
   const refreshVolcengineModelsOnce = useCallback(
-    async (keyId: string): Promise<string | false> => {
+    async (keyId: string, opts?: { maxStaleMs?: number }): Promise<string | false> => {
       const svc = getProviderService()
       if (!svc || !user) return false
       try {
         const secret = await svc.getProviderKeySecret(user.id, keyId)
         if (!secret) return false
-        const res = await window.api.providers.volcSyncModels(keyId, secret.encrypted_key)
+        const res = await window.api.providers.volcSyncModels(keyId, secret.encrypted_key, opts?.maxStaleMs)
+        if (res.cached) return false // 命中缓存：数据仍新鲜，无需回写与返回
         if (!res.ok || res.preserved || !res.encrypted) return false
         await svc.refreshProviderKey(user.id, keyId, {
           encryptedKey: res.encrypted,
@@ -458,6 +507,14 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     if (volcKeys.length === 0) return
     volcKeys.forEach((key) => void fetchVolcengineQuotaOnce(key.id))
   }, [user?.id, keys, fetchVolcengineQuotaOnce])
+
+  // 初始化 / 刷新时主动拉取火山各账号真实 token 汇总（供厂商列表行展示，替代账本假额度 50/50）
+  useEffect(() => {
+    if (!user || keys.length === 0) return
+    const volcKeys = keys.filter((k) => k.provider_id === 'volcengine')
+    if (volcKeys.length === 0) return
+    volcKeys.forEach((key) => void fetchVolcTokenSummaryOnce(key.id))
+  }, [user?.id, keys, fetchVolcTokenSummaryOnce])
 
   // 会话内覆盖某账号健康状态（API Key 测试成功/失败后即时反映，不落库）
   const setKeyHealth = useCallback((keyId: string, status: string) => {
@@ -844,6 +901,7 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     setKeyHealth,
     zhipuSessionStatuses,
     volcSessionStatuses,
+    volcTokenOverrides,
     refreshVolcengineModelsOnce
   }
 }

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -23,7 +23,7 @@ export const MODELS: Record<string, string[]> = {
   kling: ['可灵-标准', '可灵-大师'],
   hailuo: ['海螺-标准'],
   zhipu: ['cogvideox-flash', 'cogvideox-2', 'cogvideox-3', 'Vidu Q1', 'Vidu 2'],
-  volcengine: ['doubao-seedance-1-0-pro-250528', 'doubao-seedance-1-5-pro-251215', 'doubao-seedance-1-0-pro-fast-251015', 'doubao-seedance-1-0-lite-t2v', 'doubao-seedance-1-0-lite-i2v']
+  volcengine: ['doubao-seedance-1-0-pro-250528', 'doubao-seedance-1-5-pro-251215', 'doubao-seedance-1-0-pro-fast-251015', 'doubao-seedance-1-0-lite-t2v-250428', 'doubao-seedance-1-0-lite-i2v-250428']
 }
 
 /** 智谱模型展示价格（与主进程 api-branch 保持一致） */
@@ -54,8 +54,8 @@ export const VOLC_MODEL_PRICE: Record<string, string> = {
   'doubao-seedance-1-0-pro-250528': '免费',
   'doubao-seedance-1-5-pro-251215': '免费',
   'doubao-seedance-1-0-pro-fast-251015': '免费',
-  'doubao-seedance-1-0-lite-t2v': '免费',
-  'doubao-seedance-1-0-lite-i2v': '免费'
+  'doubao-seedance-1-0-lite-t2v-250428': '免费',
+  'doubao-seedance-1-0-lite-i2v-250428': '免费'
 }
 
 /** 火山方舟各模型固定生成时长（秒）；以相机生产链路为准，未收录模型走默认档 */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -995,6 +995,28 @@ body {
 .upload-zone .thumb-item:hover .remove-thumb {
   opacity: 1;
 }
+/* API 型厂商（智谱/火山）图片上传中的加载遮罩 */
+.upload-zone .thumb-item .thumb-loading {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.upload-zone .thumb-item .thumb-loading-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: qf-spin 0.8s linear infinite;
+}
+@keyframes qf-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 .upload-zone .thumb-add {
   width: 40px;
   height: 40px;
@@ -3055,6 +3077,10 @@ body {
   display: inline-block;
   vertical-align: middle;
   white-space: nowrap;
+}
+/* 不可用模型整行置灰 */
+.models-row-disabled {
+  opacity: 0.55;
 }
 .models-quota-text {
   color: var(--fg);

--- a/docs/厂商与API平台接入/火山方舟免费视频额度防误扣拦截方案.md
+++ b/docs/厂商与API平台接入/火山方舟免费视频额度防误扣拦截方案.md
@@ -1,0 +1,124 @@
+# 火山方舟免费视频额度「防误扣余额」拦截方案
+
+## 一、背景与现状（问题）
+
+火山方舟的免费视频模型（如 `doubao-seedance-1-0-pro`）有免费推理额度（token）。平台行为是：
+
+- **免费额度够 → 不扣钱**；
+- **免费额度耗尽 / 不够一次生成 → 自动转按量付费，直接扣账号余额**。
+
+火山服务端**没有**「免费额度不足就拒绝、不转付费」的请求开关
+（视频生成 API 无 `free_only`/`charge_off` 类参数，免费额度耗尽是平台强制转按量付费）。
+
+因此只能靠**提交前客户端拦截**来防呆。当前拦截存在两个漏洞：
+
+1. **剩余>0 但不够一次生成**：预检只挡 `remaining === 0`，`remaining` 只要 >0 就放行，
+   而视频一次生成耗 token 很大（实测 `doubao-seedance-1-0-pro` 单次 10s ≈ 20.6 万 token），
+   剩余一点点就会在生成时补扣余额。
+2. **额度未知 / known=false**：账本/负载没抓到该模型额度时，`remaining` 为 `null`，
+   预检按「未知即放行」，同样会生成并扣余额。
+
+当前预检位置：[api-branch.ts `makeVolcengineBranch.preflight`](file:///d:/project/quota-flow/apps/desktop/src/main/api-branch.ts#L360-L370)
+只处理「已确认未开通」和「已确认剩余=0」，其余全部放行。
+
+## 二、目标
+
+在**火山方舟视频生成**链路里增加一道硬性预检：当模型免费额度**不足以完成一次生成**，或**额度不可确认**时，
+**直接拦截禁止提交**，绝不产生账号余额扣费。
+
+- 判定口径：按**单次预估 token 耗量**判定（用户选定：默认约 25 万 token / 10s）。
+- 拦截策略：**直接拦截禁止提交**（用户选定），不弹确认、不静默放行。
+
+## 三、方案
+
+核心是**收紧 `preflight`**，并让阈值可配置、可按时长更精确估算。改动集中在 3 个文件。
+
+### 3.1 `packages/providers/src/volcengine.ts`（新增判定逻辑与阈值常量）
+
+**为什么**：判定「是否足够一次生成」所需的预估耗量、以及统一的拦截判断函数应放在厂商适配层，
+`api-branch.ts`（桌面主进程）直接复用，保证逻辑单点、可单测。
+
+- 新增导出常量：
+
+  ```ts
+  /** 火山视频模型单次生成的预估 token 耗量（按秒估算，取保守上修为防误扣）：seedance-1.0-pro 实测 10s≈20.6w，按 2.5w/s 上修 */
+  export const VOLC_GEN_TOKENS_PER_SEC = 25_000
+  /** 未知时长时按 10s 预估（对应默认时长档） */
+  export const VOLC_GEN_DEFAULT_DURATION = 10
+  export function volcGenTokenEstimate(durationSec?: number): number {
+    return (Number.isFinite(durationSec) && durationSec > 0 ? durationSec : VOLC_GEN_DEFAULT_DURATION) * VOLC_GEN_TOKENS_PER_SEC
+  }
+  ```
+
+- 新增统一拦截判断函数（沿用 `volcengineModelFreeStatus` 读取额度，返回“可提交 or 拦截原因”）：
+
+  ```ts
+  /** 火山提交前防误扣拦截：额度不足 / 未开通 / 额度不可确认 一律拦截 */
+  export interface VolcengineGenBlocker { ok: boolean; reason?: string }
+  export function volcengineGenBlocker(plain: string, model: string, estimateTokens?: number): VolcengineGenBlocker {
+    const st = volcengineModelFreeStatus(plain, model)
+    if (st.activated === false) return { ok: false, reason: `模型「${model}」在该账号未开通，请先在开通管理页开通后再生成` }
+    if (st.remaining == null) return { ok: false, reason: `该账号「${model}」免费额度信息不可确认（可能未抓取或登录态失效）。为避免误扣账号余额已拦截，请先在厂商页「查看模型」刷新额度后重试` }
+    const need = estimateTokens ?? volcGenTokenEstimate()
+    if (st.remaining < need) return { ok: false, reason: `该账号「${model}」免费额度剩余 ${st.remaining.toLocaleString()} token，不足以完成本次生成（约需 ${need.toLocaleString()} token）。继续将扣取账号余额，已为您拦截。请开通/充值该模型或更换模型` }
+    return { ok: true }
+  }
+  ```
+
+- 注意：`known=false`（负载无该模型）在 `volcengineModelFreeStatus` 里体现为 `remaining=null`，
+  会被上表 `remaining == null` 分支一并拦截（符合「额度不可确认即拦」）。
+
+### 3.2 `apps/desktop/src/main/api-branch.ts`（收紧 preflight）
+
+**为什么**：`preflight` 是调度台提交前的唯一闸口（见 `dispatch.ts` `runApiBranch` 第 698 行），
+收紧它即全链路生效。
+
+- 扩展 `ApiGenerationBranch.preflight` 签名，增加可选上下文参数，便于按时长细化预估：
+  `preflight(model: string, plain: string, ctx?: { durationSec?: number }): { ok: boolean; reason?: string }`
+  （其他厂商分支的 `preflight` 因 `ctx` 可选而无需改动。）
+- 改写 `makeVolcengineBranch.preflight`：
+
+  ```ts
+  preflight(model, plain, ctx) {
+    return volcengineGenBlocker(plain, model, volcGenTokenEstimate(ctx?.durationSec))
+  }
+  ```
+- 原有两个分支判断（未开通 / 剩余=0）已被 `volcengineGenBlocker` 覆盖，删除。
+- `pick()` 保持用 `volcengineModelFreeStatus` 做账号评分（只影响选号优先级，不再负责拦截）。
+
+### 3.3 `apps/desktop/src/main/dispatch.ts`（透传时长给预检）
+
+**为什么**：让预估按用户选择时长更精确（5s≈12.5w、10s≈25w），避免 5s 误伤、10s 漏判。
+
+- 将第 698 行调用改为透传时长：
+
+  ```ts
+  const pf = branch.preflight(model, plain, { durationSec: input.durationSec })
+  ```
+
+### 3.4（可选，低优先）UI 提示
+
+在调度台模型选中后 / 厂商页「查看模型」对 `剩余额度 < 预估耗量` 的模型加一个「额度不足，可能转付费已禁用」的弱提示徽标。
+非阻断，仅辅助用户理解拦截原因。若实现成本高可暂缓，不阻塞核心拦截。
+
+## 四、假设与决策
+
+- **无服务端开关**：火山没有「免费额度不足即拒绝/不扣费」的请求参数，只能客户端提交前拦截（已在背景说明，用户确认）。
+- **拦截策略 = 直接禁止提交**（用户选定），不做确认弹窗。
+- **判定口径 = 按单次预估耗量**：默认 10s≈25 万 token（`VOLC_GEN_TOKENS_PER_SEC=25000`，对上修实测 20.6w 安全）。
+  按 `durationSec` 缩放，未知时长回退 10s。
+- **额度不可确认一律拦截**（含 `known=false`、`remaining=null`）：这是为了让「freeQuota 没抓到/登录态失效」时也绝不误扣，
+  属于用户选择「直接拦截禁止提交」的覆盖范围。副作用是额度同步偶发失败时相应模型会暂时无法生成，需用户「查看模型」刷新额度一次，
+  属可接受的防呆成本。
+- 本次**只改火山方舟（volcengine）**；智谱等其他免费模型厂商可能有同类问题，但不在本轮范围（可后续复用同一模式）。
+
+## 五、验证
+
+1. **构造拦截场景**（单元或手动）：
+   - 账号负载里 `doubao-seedance-1-0-pro` 设 `remaining=1000`（< 预估）→ 提交被 `preflight` 拒绝，任务 `failed`，报「额度不足 … 已拦截」。
+   - 设 `remaining=null`（负载无该模型/额度未抓取）→ 同样被拦截，报「额度信息不可确认 … 已拦截」。
+   - 设 `remaining=1_000_000`（>= 预估）→ 正常放行提交。
+2. **调度台实测**：选 `doubao-seedance-1-0-pro`，把该账号剩余额度（厂商页查看）调到低于 25 万 token（或临时用小`remaining`负载）→
+   提交被拦截且不产生任何 API 调用（日志无 `提交 model=` 行）。
+3. **时长口径**：5s 时长时预估约 12.5 万 token，剩余 15 万 → 预期放行；10s 时长同剩余 → 预期拦截。
+4. `packages/providers` `typecheck` + `build` 通过，桌面端重启生效。

--- a/docs/厂商与API平台接入/火山无接入点与下架模型标记拦截方案.md
+++ b/docs/厂商与API平台接入/火山无接入点与下架模型标记拦截方案.md
@@ -1,0 +1,113 @@
+# 火山方舟「无接入点 / 已下架」模型的标记与拦截方案
+
+## 一、背景与现状（问题）
+
+火山方舟免费视频模型在调度台/厂商页展示的数量，来自该账号绑定时实际抓到的免费模型目录（`api-branch.catalog` → `provider:api-models` → `providerCaps`/licol）。这些模型虽显示「免费额度 token」，但**不代表一定能生成**，存在两类失效情况：
+
+1. **无接入点**：该账号在火山控制台没有该模型的预置推理接入点（或不满足调用前置），提交即失败 `InvalidEndpointOrModel.NotFound` / `ModelNotOpen`。
+2. **平台侧下架/停用**：模型在火山平台已不再提供服务，提交返回「模型不存在 / 下架」。
+
+**当前行为的两个缺陷：**
+
+- 预检 `volcengineGenBlocker` 只挡「未开通（`activated===false`）」和「额度不足/不可确认」。对**已开通且有额度但实际无接入点 / 已下架**的模型，预检放行，直到**向火山提交后才**才报「不存在/无权访问」失败——既白跑一次，用户也不知道该模型根本用不了、该怎么处理。
+
+- 查看模型的列表（`Providers.tsx`）只展示「待开通 / 正常」两类状态，没有「无接入点 / 已下架」的可视标记，用户无法在生成前识别并避开这类模型。下架列表也没有意识积累。
+
+## 二、目标（用户已确认策略）
+
+- **标记不可用 + 拦截指引**：
+  - 模型被火山判定为「无接入点」或「已下架」时，**马上落库标记**，后续：
+    - 「查看模型」列表对该模型**标灰 + 徽标**（已下架 / 无接入点 / 待开通），并给出原因提示；
+    - 生成**提交前拦截**，给出明确原因（不再白跑再失败）。
+  - 下架判定口径 = **火山平台侧停用/下架**（用户确认）。
+- 标记来源：**运行时由火山真实响应驱动**（不在代码里臆造哪个模型下架），`NotFound`/无接入点失败 → `no_endpoint`，平台下架/停用类错误 → `decommissioned`；生成成功后**自动清除**该模型的历史标记（自愈，平台恢复可用即重新放行）。
+- 不新增服务端配置；只改客户端判定 + 落库 + 展示/拦截。
+
+## 三、现状代码位置（Phase 1 探索结论）
+
+- 模型目录 & 额度来源：[volcengine.ts](file:///d:/project/quota-flow/packages/providers/src/volcengine.ts) `volcengineFreeVideoModels()` / `captureVolcengineFreeVideoModels()` / `volcengineModelFreeStatus()` / `volcengineGenBlocker()` / `volcengineGenerateWithKey()`（提交失败错误码分支在 `generateWithKey` 内，含 `ModelNotOpen`、`InvalidEndpointOrModel.NotFound`、`notOpened` 正则）。
+- 预检闸口：[api-branch.ts](file:///d:/project/quota-flow/apps/desktop/src/main/api-branch.ts#L361-L365) `makeVolcengineBranch.preflight` 调 `volcengineGenBlocker`；`catalog()` 在第 [367](file:///d:/project/quota-flow/apps/desktop/src/main/api-branch.ts#L367-L385) 行拼 `ApiModelInfo`；[L421](file:///d:/project/quota-flow/apps/desktop/src/main/api-branch.ts#L421-L441) `provider:api-models` IPC 返回 `branch.catalog(...)`。
+- 调用与结果回传：[volcengineGenerateWithKey](file:///d:/project/quota-flow/packages/providers/src/volcengine.ts) 返回 `VolcengineGenerateResult`；`api-branch.generate` 透传结果；[dispatch.ts](file:///d:/project/quota-flow/apps/desktop/src/main/dispatch.ts#L758-L769) 收到失败更新 job。
+- 落库写回：`ProviderService.refreshProviderKey(userId, keyId, { encryptedKey })`（[db-supabase index.ts](file:///d:/project/quota-flow/packages/db-supabase/src/index.ts#L520-L540)）；`dispatch.ts` 已有 `providerSvc`（[L616](file:///d:/project/quota-flow/apps/desktop/src/main/dispatch.ts#L616)）与 `plain`（解密后的凭证字符串）。
+- 展示：`Providers.tsx`「查看模型」画激活/额度徽标（[L88-L121](file:///d:/project/quota-flow/apps/desktop/src/renderer/src/components/Providers.tsx#L88-L121)）；`Dashboard.tsx` 模型下拉为纯字符串列表（[L831](file:///d:/project/quota-flow/apps/desktop/src/renderer/src/components/Dashboard.tsx#L831)），激活/额度信息只在“查看模型”弹窗体现。
+
+## 四、方案（按依赖顺序）
+
+核心：把「无接入点 / 已下架」作为**模型级标记**随账号负载 `models[]` 持久化，生成失败即时写入、生成成功自愈清除；预检与展示都读该标记。
+
+### 4.1 `packages/providers/src/volcengine.ts`（模型字段 + 判定 + 分类 + 生成结果标记）
+
+- `VolcengineFreeVideoModel` 新增可选字段：
+  `unavailable?: 'decommissioned' | 'no_endpoint'`。
+
+- 新增 `VOLC_DECOMMISSIONED_MODELS: string[]`（**权威下架清单，当前先置空**），并让以下方法把命中该清单的目录项预置 `unavailable: 'decommissioned'`：
+  - `volcengineFreeVideoModels()` 返回的目录项；
+  - `captureVolcengineFreeVideoModels(scraped, carryUnavailable?)`：新增可选 `carryUnavailable?: VolcengineFreeVideoModel[]` 参数，在合并 `byId` 时，若 carry 中有同 id 且带 `unavailable`，则**覆盖到目录项上**——保证标记跨「查看模型」同步（`capture` 用新抓取的模型重建时）不回退。
+
+- 新增错误分类：
+  `export function volcGenUnavailableKind(code?: string, msg?: string): 'decommissioned' | 'no_endpoint' | undefined`
+  - `decommissioned`：命中平台下架/停用关键词（如 `下架|下线|decommission|discontinued|offline|end of service|not for sale`，不区分大小写）。
+  - `no_endpoint`：命中 `InvalidEndpointOrModel.NotFound`、`ModelNotOpen`，或「不存在|not found|no access|not accessible|无权访问|未开通」等关键词。
+  - 其余返回 `undefined`。
+
+- `VolcengineModelFreeStatus` 增加 `unavailable?: 'decommissioned' | 'no_endpoint' | null`；`volcengineModelFreeStatus()` 读取该模型 `unavailable`（目录预置 + 负载 models 读写统一走 decoded `models` 字段），并叠加 `VOLC_DECOMMISSIONED_MODELS` 判定结果。
+
+- `volcengineGenBlocker()` 在现有分支前增加不可用拦截：
+  - `unavailable === 'decommissioned'` → `{ ok:false, reason: '模型「m」已被火山平台下架/停用，无法生成' }`
+  - `unavailable === 'no_endpoint'` → `{ ok:false, reason: '该账号「m」无可用接入点（未在开通管理页开通或调用失败），无法生成。请先在火山方舟开通管理页开通该模型或更换模型' }`
+
+- `VolcengineGenerateResult` 增加可选 `unavailable?: 'decommissioned' | 'no_endpoint'`；在 `volcengineGenerateWithKey` 提交失败分支（`ModelNotOpen` / `InvalidEndpointOrModel.NotFound` / `notOpened` 命中处）调用 `volcGenUnavailableKind(code, msg)` 填充该字段并返回。
+
+### 4.2 `apps/desktop/src/main/providers.ts`（标记明文工具）
+
+- 新增两个**纯函数**（对解密后的明文 payload 操作，返回新明文）：
+  - `export function markVolcModelUnavailable(plain: string, model: string, kind: 'decommissioned' | 'no_endpoint'): { ok: true; plain: string } | { ok: false }`
+    —— `decodeVolcenginePayload` → 对该 id 的 model 置 `unavailable = kind`（如 `models` 无该 id 则 push 一个 `{ id: model, unavailable: kind }`）→ `JSON.stringify({ v:1, ...保留原字段, models })` 返回。
+  - `export function clearVolcModelUnavailable(plain: string, model: string): { ok: true; plain: string } | { ok: false }`
+    —— 删除该 id 的 `unavailable` 字段（删除后该 id 无有效字段可选是否保留；无其它字段则移除该项，避免占位）。
+- 说明：这两个函数只改透明 `models`，不触发网络；`consoleJwt/accountId` 原样保留。实现在 `providers.ts` 复用已导入的 `decodeVolcenginePayload`。
+
+### 4.3 `apps/desktop/src/main/dispatch.ts`（失败写标记 / 成功自愈）
+
+在 `runApiBranch` 生成结果处理处：
+
+- 失败分支（[L758-L769](file:///d:/project/quota-flow/apps/desktop/src/main/dispatch.ts#L758-L769)）：`const res = await branch.generate(...)` 后，若 `providerId==='volcengine' && res.unavailable`：
+  - 用当前 `plain`（解密凭证字符串，已在作用域内）调 `markVolcModelUnavailable(plain, model, res.unavailable)`，成功则 `safeStorage.encryptString(newPlain).toString('base64')` → `await providerSvc.refreshProviderKey(input.userId, cand.id, { encryptedKey })`（复用于智谱续期同款路径）。用 `try/catch` 包裹，标记失败不回滚 job 失败。
+- 成功分支（L776 后）：若 `providerId==='volcengine'`，则尝试 `clearVolcModelUnavailable(plain, model)` 并同样 `refreshProviderKey` 自愈清除历史标记（同样 try/catch 包裹，失败不影响成功返回）。
+- `dispatch.ts` 顶部导入 `markVolcModelUnavailable, clearVolcModelUnavailable`（从 `./providers`）。（`safeStorage` 已导入于 [L4](file:///d:/project/quota-flow/apps/desktop/src/main/dispatch.ts#L4)。）
+
+### 4.4 `apps/desktop/src/main/api-branch.ts`（目录透出状态 → 展示拦截一致）
+
+- `makeVolcengineBranch.catalog()`：把 `m.unavailable` 透出到 `ApiModelInfo` 条目（[L88](file:///d:/project/quota-flow/apps/desktop/src/main/api-branch.ts#L88-L104)）新增可选字段：
+  `unavailable?: 'decommissioned' | 'no_endpoint'`
+  并在条目上附带 `unavailableLabel`（`'已下架'` / `'无接入点'`，仅二者有值）。`catalog` 里映射：`unavailable: (base.find 同 id m)?.unavailable`。
+- `preflight` 无需改动：已委托 `volcengineGenBlocker`，4.1 的不可用分支自动生效。
+
+### 4.5 `apps/desktop/src/renderer/src/components/Providers.tsx`（查看模型标记）
+
+在「查看模型」每行徽标逻辑（[L88-L121](file:///d:/project/quota-flow/apps/desktop/src/renderer/src/components/Providers.tsx#L88-L121)）中，按 `model.unavailable` 优先级展示与置灰：
+- `'decommissioned'` → `badge-danger` 灰底「已下架」，`title`「该模型已被火山平台下架/停用」。
+- `'no_endpoint'` → `badge-pending` 灰底「无接入点」，`title`「该账号无此模型接入点，无法生成；可在开通管理页开通或更换模型」。
+- 无标记：维持现有「待开通 / 正常」逻辑。
+- （如存在）单行置灰样式：未开启时 `opacity` 降低以示不可用。
+
+### 4.6 `apps/desktop/src/renderer/src/components/Dashboard.tsx`（可选，低优先）
+
+调度台模型下拉为纯字符串列表（[L831](file:///d:/project/quota-flow/apps/desktop/src/renderer/src/components/Dashboard.tsx#L831)），无模型元数据。不可用模型的**生成拦截**由 4.1 的 `preflight`（提交前）保证，下拉内逐一置灰成本高，列为本项**可选增强**：若需在选中前就规避，可后续给 `volcModels` 改为携带 `{value,label,disabled}` 并对不可用项置灰。本轮**不阻塞核心拦截**，先做 4.1–4.5。
+
+## 五、假设与决策
+
+- **不可用标记为运行时驱动**：不在代码里臆造「哪个模型下架」。`decommissioned` / `no_endpoint` 由火山真实响应码/文案分类，故 `VOLC_DECOMMISSIONED_MODELS` 初始为空，仅作为「平台侧明确下架」的权威兜底；等有确凿下架 Model ID 再补充。
+- **标记随账号负载 `models[]` 持久化**（`refreshProviderKey` 重加密落 `encrypted_key`），跨重启、跨同步保留。
+- **自愈**：生成成功自动清标记，平台恢复可用即重新放行；`captureCarry` 让标记在「查看模型」重建目录时不丢失。
+- **范围只改火山方舟（volcengine）**；智谱等厂商若同类问题不在本轮。
+- 拦截/展示全部以「模型不可用标记」为单一来源，避免与服务端/额度校验相互打架；`精度不足/不可确认` 的既有拦截行为保持不变。
+
+## 六、验证
+
+1. **单元（volcengine.ts 判定）**：`volcGenUnavailableKind` 对 `InvalidEndpointOrModel.NotFound` → `no_endpoint`；对「下架/decommissioned」文案 → `decommissioned`；其它错误 → `undefined`。
+2. **预检拦截**：账号负载把某模型置 `unavailable:'no_endpoint'` / `'decommissioned'` → `volcengineGenBlocker` 返回不可用，`preflight` 拒绝提交，任务 `failed` 且文案含「无可用接入点 / 已下架」。
+3. **运行时标记写回**：对无接入点模型发起生成 → 提交失败 → job `failed`，且 `provider_keys.encrypted_key` 解密后该模型出现 `unavailable` 字段；再次打开「查看模型」该模型显示「无接入点」徽标并置灰。
+4. **自愈**：把该模型标记清除后重新生成成功 → 第 3 步的 `unavailable` 被清除。
+5. **目录透出**：`provider:api-models` 对带标记的模型返回 `unavailable` + `unavailableLabel`。
+6. `packages/providers` typecheck+build 通过；`apps/desktop` typecheck 通过；重启桌面端生效。

--- a/migrations/0033_volcengine_lite_model_ids.sql
+++ b/migrations/0033_volcengine_lite_model_ids.sql
@@ -1,0 +1,16 @@
+-- 0033_volcengine_lite_model_ids.sql
+-- 修正火山方舟（volcengine）provider_caps 免费视频模型目录：lite 系列官方 Model ID 带 -250428 日期后缀
+-- （doubao-seedance-1-0-lite-t2v-250428 / doubao-seedance-1-0-lite-i2v-250428），且 t2v/i2v 为两个独立 ID。
+-- 与 spec.ts 的 MODELS.volcengine、providers/caps catalog 保持一致（厂商级 Catalog）。
+-- provider_caps 语义、NULL target_id 幂等方式同 0032。
+
+UPDATE public.provider_caps
+SET models = ARRAY[
+      'doubao-seedance-1-0-pro-250528',
+      'doubao-seedance-1-5-pro-251215',
+      'doubao-seedance-1-0-pro-fast-251015',
+      'doubao-seedance-1-0-lite-t2v-250428',
+      'doubao-seedance-1-0-lite-i2v-250428'
+    ],
+    updated_at = now()
+WHERE target_type = 'global' AND target_id IS NULL AND provider = 'volcengine';

--- a/packages/providers/src/volcengine.ts
+++ b/packages/providers/src/volcengine.ts
@@ -26,6 +26,15 @@ export interface VolcengineQuota {
 }
 
 /**
+ * 支持有声视频（generate_audio）的火山视频模型（官方仅标注有声能力的模型可下发）。
+ * 1.0 Pro / Fast / Lite 不支持有声；当前免费目录与后续可能的 2.0 系列都在此登记。
+ */
+export const VOLC_AUDIO_MODELS = new Set([
+  "doubao-seedance-1-5-pro-251215",
+  "doubao-seedance-2-0-mini-260615",
+])
+
+/**
  * 解火山方舟加密负载（兼容多种格式）：
  * - 新版：{ v: 1; apiKey: string; consoleJwt?: string | null; accountId?: string | null; models?: VolcengineFreeVideoModel[] } JSON 字符串
  * - 旧版：纯 API Key 字符串（非 `{` 开头）
@@ -163,72 +172,38 @@ export interface VolcengineFreeVideoModel {
   activated?: boolean
   /** 【每账号】绑定控制台抓到的免费 token 额度（剩余/总数）；未抓到为 undefined */
   freeQuota?: { remaining?: number; total?: number }
+  /**
+   * 【每账号/平台】运行时由火山真实响应判定的「不可用」标记：
+   * - 'decommissioned'：平台已下架/停用，无法生成；
+   * - 'no_endpoint'：该账号无可用接入点或接入失败，无法生成。
+   * 定义后随账号负载 models[] 持久化，生成成功自动清除（自愈）。
+   */
+  unavailable?: 'decommissioned' | 'no_endpoint'
 }
 
+/**
+ * 火山平台侧明确下架的权威 Model ID 清单（兜底）。
+ * 不可用标记主要靠运行时真实响应驱动（volcGenUnavailableKind），此处仅用于平台明确下架时的预置，
+ * 需等有确凿下架的 Model ID 再补充，避免误标可用模型。
+ */
+export const VOLC_DECOMMISSIONED_MODELS: string[] = []
+
 export function volcengineFreeVideoModels(): VolcengineFreeVideoModel[] {
-  return [
-    {
-      id: "doubao-seedance-1-0-pro-250528",
-      name: "Doubao-Seedance-1.0-pro",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（开通管理页）",
-      activated: true,
-      freeQuota: { remaining: 272120, total: 2000000 }
-    },
-    {
-      id: "doubao-seedance-1-5-pro-251215",
-      name: "Doubao-Seedance-1.5-pro",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（开通管理页）",
-      activated: true,
-      freeQuota: { remaining: 2000000, total: 2000000 }
-    },
-    {
-      id: "doubao-seedance-1-0-pro-fast-251015",
-      name: "Doubao-Seedance-1.0-pro-fast",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
-      activated: false,
-      freeQuota: { remaining: 2000000, total: 2000000 }
-    },
-    {
-      id: "doubao-seedance-1-0-lite-t2v",
-      name: "Doubao-Seedance-1.0-lite-t2v",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
-      activated: false,
-      freeQuota: { remaining: 2000000, total: 2000000 }
-    },
-    {
-      id: "doubao-seedance-1-0-lite-i2v",
-      name: "Doubao-Seedance-1.0-lite-i2v",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）",
-      activated: false,
-      freeQuota: { remaining: 2000000, total: 2000000 }
-    },
-    // Wan 家族：文生/图生走不同 Model ID（-t2v / -i2v），本目录存基名 wan2-1-14b，调用时由 resolveVolcengineModel 按 mode 追加
-    {
-      id: "wan2-1-14b",
-      name: "Wan2.1-14B",
-      modes: ["text2video", "img2video"],
-      free: true,
-      price: "免费",
-      quotaHint: "免费推理额度（开通管理页）",
-      activated: false,
-      freeQuota: { remaining: 2000000, total: 2000000 }
-    }
+  // 本目录只声明免费视频模型「元数据」（id/名称/能力/开通状态），不写死任何额度（total/remaining）。
+  // 额度是账号级动态数据，一律由实测接口 ListModelTokenLimit 抓取后写入 freeQuota（见 capture*），
+  // 抓不到即「额度未知」：前端显示 —、生成前保守拦截。切勿在目录里填静态余额，否则会随平台变化失真并放行误扣。
+  const list: VolcengineFreeVideoModel[] = [
+    { id: "doubao-seedance-1-0-pro-250528", name: "Doubao-Seedance-1.0-pro", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（开通管理页）", activated: true },
+    { id: "doubao-seedance-1-5-pro-251215", name: "Doubao-Seedance-1.5-pro", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（开通管理页）", activated: true },
+    { id: "doubao-seedance-1-0-pro-fast-251015", name: "Doubao-Seedance-1.0-pro-fast", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）", activated: false },
+    { id: "doubao-seedance-1-0-lite-t2v-250428", name: "Doubao-Seedance-1.0-lite-t2v", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）", activated: false },
+    { id: "doubao-seedance-1-0-lite-i2v-250428", name: "Doubao-Seedance-1.0-lite-i2v", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（未开通模型，需到控制台开通后使用）", activated: false },
+    // Wan 家族：文生/图生走不同 Model ID，真实端点带日期版本（wan2-1-14b-t2v-250225 / -i2v-250225），存基名 wan2-1-14b，由 resolveVolcengineModel 按 mode 拼接
+    { id: "wan2-1-14b", name: "Wan2.1-14B", modes: ["text2video", "img2video"], free: true, price: "免费", quotaHint: "免费推理额度（开通管理页）", activated: false }
   ]
+  return list.map((m) =>
+    VOLC_DECOMMISSIONED_MODELS.includes(m.id) ? { ...m, unavailable: 'decommissioned' as const } : m
+  )
 }
 
 /** 控制台「开通管理→视觉模型」页抓到的免费 Seedance 条目（名 / Model ID / 剩余与总免费额度 / 是否已开通） */
@@ -316,6 +291,21 @@ export function isVolcengineVideoFamilyName(name: string): boolean {
 }
 
 /**
+ * 把「权威接口 ListModelTokenLimit 返回的 FoundationModelName」归一到目录 Model ID 集合。
+ * 该接口只返回有免费额度的已开通模型；对「已开通但额度耗尽」等不在列表的模型不返回。
+ * 上层用它作为「额度可信集合」：只有命中该集合的目录模型的 freeQuota 才是接口权威值，
+ * 未命中模型的 freeQuota 一律不可信（DOM/旧缓存值会误导展示），应置空并按「— 未知」保守展示。
+ */
+export function volcengineAuthoritativeIds(authorizedTokenNames: Array<string | undefined>): Set<string> {
+  const set = new Set<string>()
+  for (const raw of authorizedTokenNames || []) {
+    const id = resolveVolcScrapedId((raw || "").trim())
+    if (id) set.add(id)
+  }
+  return set
+}
+
+/**
  * 「绑定即抓模型」：把控制台实时抓到的免费模型规范化为目录（权威层）。
  * - 收录页面上**所有**「有免费推理额度且属于视频家族」的模型（含 lite、Wan 系列），按页面顺序给出；
  *   （页面同屏混有图像 Seedream、3D Seed3D/Hyper3D/Hitem3D 等免费模型，跑 videoFamily 过滤剔除）
@@ -324,11 +314,19 @@ export function isVolcengineVideoFamilyName(name: string): boolean {
  * - token（剩余/总）与是否已开通由页面实抓回填；
  * - 完全未抓到（无会话/未进开通页/CSP 阻断）时回退内置目录，由 caller 以 [volc-caps] 标记回退。
  */
+/**
+ * @param opts.markAbsentInactivated 仅当上层判定抓取已覆盖全量已开通模型（分页耗尽 + 模型列表接口已见）时置 true，
+ * 把「未被抓到的目录免费视频模型」强制置为未开通(false)，覆盖目录默认的 activated:true。
+ * 未开通模型因无免费额度文案不会被收录进 src，若不覆盖将沿用目录默认值导致误显示「已开通」。
+ */
 export function captureVolcengineFreeVideoModels(
   scraped: VolcengineScrapedFreeModel[] | null | undefined,
+  carryUnavailable?: VolcengineFreeVideoModel[],
+  opts?: { markAbsentInactivated?: boolean },
 ): { models: VolcengineFreeVideoModel[]; source: "console" | "fallback" } {
   const src = Array.isArray(scraped) ? scraped : []
   const catalog = FREE_CATALOG.map((m) => ({ ...m }))
+  // 预置平台明确下架标记：命中清单的模型直接标 decommissioned（目录/catalog 已含该标记，这里对来自目录的项再兜底一遍）
   if (src.length === 0) {
     return { models: catalog, source: "fallback" }
   }
@@ -340,6 +338,7 @@ export function captureVolcengineFreeVideoModels(
   //   畸形拼接串（如 wan2-1-14b×3+wanai）都会被折叠到正确条目，杜绝同一模型以残片形式重复出现。
   const byId = new Map<string, VolcengineFreeVideoModel>()
   for (const m of catalog) byId.set(m.id, m)
+  const seenIds = new Set<string>()
   for (const s of src) {
     const name = s.name?.trim() || ""
     if (!name) continue
@@ -348,18 +347,25 @@ export function captureVolcengineFreeVideoModels(
     // 归一化到权威 Model ID；畸形/无效名返回 null → 跳过，不引入重复或垃圾条目
     const id = resolveVolcScrapedId(name)
     if (!id) continue
+    seenIds.add(id)
     // 实抓额度只在是「有限正数」时才覆盖目录默认值；NaN/undefined 会弄脏展示，回退目录默认
     const hasQuota =
       Number.isFinite(s.remaining) && Number.isFinite(s.total) && (s.total as number) > 0
     const existing = byId.get(id)
     if (existing) {
       // 已收录于目录：保留目录权威 id/name/modes，仅覆盖实时额度与开通状态。
-      // activated 取「任一来源判为已开通」即开通（只升不降），避免先到的 DOM 误标覆盖接口后续抓到的 true。
-      if (hasQuota) existing.freeQuota = { remaining: s.remaining as number, total: s.total as number }
-      if (s.activated === true) existing.activated = true
-      continue
+    // 以控制台实时抓取为准（双向）：开通则升为 true，明确「未开通」则降为 false。
+    // 同一快照内已开通模型必由 ListModelTokenLimit 接口置 activated:true（见注入脚本 upsert 逻辑），
+    // 故「未开通(false)」只会来自确实未开通的模型，不会误覆盖接口后续的 true。
+    if (hasQuota) existing.freeQuota = { remaining: s.remaining as number, total: s.total as number }
+    if (s.activated === true) existing.activated = true
+    else if (s.activated === false) existing.activated = false
+    continue
     }
-    // 目录未收录的新免费模型：以规范化干净 id 占位
+    // 目录未收录的新免费模型：仅在「带真实额度」时才建占位。新 UI 表格行不再显示「剩/共 token」，
+    // DOM 只上报名称+开通状态、无额度（hasQuota=false）；这类条目只能用于纠正目录已有模型的开通状态，
+    // 不能挤进免费列表充当新模型（否则无免费额度的 2.x 系列会被当成免费视频模型混入调度台）。
+    if (!hasQuota) continue
     byId.set(id, {
       id,
       name,
@@ -371,6 +377,28 @@ export function captureVolcengineFreeVideoModels(
       activated: s.activated === true
     })
   }
+  // 权威覆盖「未开通」：仅在抓取已覆盖全量已开通模型（分页耗尽 + 模型列表接口已见，由上层判定）时启用。
+  // 只对「目录默认 activated:false」的模型执行覆盖（fast/lite/wan），把它们保持为 未开通；
+  // 绝不覆盖目录默认 activated:true 的平台默认可开免费模型（如 seedance-1.0-pro）——
+  // 接口 ListModelTokenLimit 对「已开通但额度耗尽」的模型不返回，与「未开通」无法靠接口区分，
+  // 若也强制标 false 会诱发「已开通却显示待开通」的间歇性误判。这些模型真实开通与否
+  // 由实抓 DOM 状态列覆盖：s.activated 显式 true/false 已在上面按实抓覆盖 existing.activated。
+  if (opts?.markAbsentInactivated) {
+    for (const m of catalog) {
+      if (!seenIds.has(m.id) && m.activated === false) (m as VolcengineFreeVideoModel).activated = false
+    }
+  }
+  // 携带上层（历史账号负载 payload.models）的「不可用」标记按 id 覆盖，保证标签跨「查看模型」重建目录时不回退
+  if (Array.isArray(carryUnavailable) && carryUnavailable.length > 0) {
+    const carryMap = new Map<string, 'decommissioned' | 'no_endpoint'>()
+    for (const c of carryUnavailable) {
+      if (c?.id && (c.unavailable === 'decommissioned' || c.unavailable === 'no_endpoint')) carryMap.set(c.id, c.unavailable)
+    }
+    for (const it of byId.values()) {
+      const kind = carryMap.get(it.id)
+      if (kind) it.unavailable = kind
+    }
+  }
   const models = Array.from(byId.values())
   if (models.length === 0) {
     return { models: catalog, source: "fallback" }
@@ -380,14 +408,98 @@ export function captureVolcengineFreeVideoModels(
 
 /**
  * 火山方舟 Model ID 的 Mode 解析：Seedance 家族单 Model ID 同时覆盖文生/图生；
- * Wan 家族（wan2-1-14b 等）文生/图生走不同 Model ID（-t2v / -i2v），按 mode 追加后缀。
+ * Wan2.1 家族（wan2-1-14b 等）文生/图生走不同 Model ID 且真实端点带日期版本（如
+ * wan2-1-14b-t2v-250225 / wan2-1-14b-i2v-250225），按 mode 拼出带版本的端点；
+ * lite 系列（doubao-seedance-1-0-lite，官方 Model ID 带 -250428 日期后缀）同样是 t2v/i2v 两个独立 ID，
+ * 按 mode 归一：剥离已有的 -(t2v|i2v)-\d{6}$ 后缀后重建，确保用户切换文生/图生时模型与模式一致。
  */
 export function resolveVolcengineModel(model: string, mode: "text2video" | "img2video"): string {
   const m = (model || "").trim()
   if (/^wan\b/i.test(m) || /^wan[-.\d]/i.test(m)) {
-    return mode === "img2video" ? `${m}-i2v` : `${m}-t2v`
+    // Wan2.1 真实端点带日期版本（已核实 i2v 为 wan2-1-14b-i2v-250225），文生/图生对应 t2v/i2v
+    return mode === "img2video" ? `${m}-i2v-250225` : `${m}-t2v-250225`
+  }
+  if (/doubao-seedance-1-0-lite/i.test(m)) {
+    // 已有的模式后缀与日期后缀剥掉，按 mode 重建为 -t2v-250428 / -i2v-250428
+    const base = m.replace(/-(t2v|i2v)-(?:\d{6})?$/i, "")
+    return mode === "img2video" ? `${base}-i2v-250428` : `${base}-t2v-250428`
   }
   return m
+}
+
+/**
+ * 把火山提交/查询失败的响应码与文案归类为「模型不可用」标记：
+ * - 'decommissioned'：平台下架/停用类（关键词：下架/下线/decommission/discontinued/offline/end of service/not for sale）
+ * - 'no_endpoint'：无接入点/未开通/不存在/无权访问（InvalidEndpointOrModel.NotFound、ModelNotOpen 及「不存在/not found/no access」等）
+ * - undefined：其它错误，不标记为不可用（可能只是限流/参数等瞬时问题）
+ */
+export function volcGenUnavailableKind(code?: string, msg?: string): 'decommissioned' | 'no_endpoint' | undefined {
+  const codeText = String(code ?? "")
+  const msgText = String(msg ?? "")
+  const text = `${codeText} ${msgText}`
+  if (/下架|下线|decommission|discontinued|offline|end of service|not for sale/i.test(text)) {
+    return 'decommissioned'
+  }
+  if (
+    /not found|does not exist|do not have access|no access|not accessible|not activated|not enabled|invalidendpointormodel|modelnotopen|不存在|无权访问|未开通|未激活/i.test(text)
+  ) {
+    return 'no_endpoint'
+  }
+  return undefined
+}
+
+/**
+ * 火山方舟所选模型的「能否生成」状态（调取账号加密负载里绑定时抓到的模型目录）：
+ * 用于调度前预检/多账号优选。账本对火山不做原子扣减，故仅作「能否生成」判据，不代表扣减额度。
+ * - known：负载是否含所选模型信息（旧格式/抓取不全 → false，由上层「未知即放行」）
+ * - activated：activated===true/false；未知 null
+ * - remaining：freeQuota?.remaining；未知 null
+ * - unavailable：不可用标记（decommissioned 平台下架 / no_endpoint 无接入点）；未知 null
+ */
+export interface VolcengineModelFreeStatus {
+  known: boolean
+  activated: boolean | null
+  remaining: number | null
+  unavailable?: 'decommissioned' | 'no_endpoint' | null
+}
+
+export function volcengineModelFreeStatus(plain: string, model: string): VolcengineModelFreeStatus {
+  const { models } = decodeVolcenginePayload(plain)
+  const match = Array.isArray(models) ? models.find((m) => m?.id === model) : undefined
+  // 平台明确下架清单兜底；账号负载里的标记优先（运行时写入），清单命中同样置 decommissioned
+  const decommUnavailable = VOLC_DECOMMISSIONED_MODELS.includes(model) ? ('decommissioned' as const) : null
+  const unavailable = match?.unavailable === 'decommissioned' || match?.unavailable === 'no_endpoint'
+    ? match.unavailable
+    : decommUnavailable
+  const remaining = typeof match?.freeQuota?.remaining === "number" ? match.freeQuota.remaining : null
+  return {
+    known: !!match,
+    activated: match ? (match.activated === true ? true : match.activated === false ? false : null) : null,
+    remaining,
+    unavailable
+  }
+}
+
+/** 火山视频模型单次生成的预估 token 耗量（按秒估算，取保守上修为防误扣）：seedance-1.0-pro 实测 10s≈20.6w，按 2.5w/s 上修 */
+export const VOLC_GEN_TOKENS_PER_SEC = 25_000
+/** 未知时长时按 10s 预估（对应默认时长档） */
+export const VOLC_GEN_DEFAULT_DURATION = 10
+export function volcGenTokenEstimate(durationSec?: number): number {
+  const sec = Number.isFinite(durationSec) && (durationSec as number) > 0 ? (durationSec as number) : VOLC_GEN_DEFAULT_DURATION
+  return sec * VOLC_GEN_TOKENS_PER_SEC
+}
+
+/** 火山提交前防误扣拦截：额度不足 / 未开通 / 额度不可确认 / 无接入点 / 已下架 一律拦截 */
+export interface VolcengineGenBlocker { ok: boolean; reason?: string }
+export function volcengineGenBlocker(plain: string, model: string, estimateTokens?: number): VolcengineGenBlocker {
+  const st = volcengineModelFreeStatus(plain, model)
+  if (st.unavailable === 'decommissioned') return { ok: false, reason: `模型「${model}」已被火山平台下架/停用，无法生成` }
+  if (st.unavailable === 'no_endpoint') return { ok: false, reason: `该账号「${model}」无可用接入点（未在开通管理页开通或调用失败），无法生成。请先在火山方舟开通管理页开通该模型或更换模型` }
+  if (st.activated === false) return { ok: false, reason: `模型「${model}」在该账号未开通，请先在开通管理页开通后再生成` }
+  if (st.remaining == null) return { ok: false, reason: `该账号「${model}」免费额度信息不可确认（可能未抓取或登录态失效）。为避免误扣账号余额已拦截，请先在厂商页「查看模型」刷新额度后重试` }
+  const need = estimateTokens ?? volcGenTokenEstimate()
+  if (st.remaining < need) return { ok: false, reason: `该账号「${model}」免费额度剩余 ${st.remaining.toLocaleString()} token，不足以完成本次生成（约需 ${need.toLocaleString()} token）。继续将扣取账号余额，已为您拦截。请开通/充值该模型或更换模型` }
+  return { ok: true }
 }
 
 export interface VolcengineGenerateOptions {
@@ -411,6 +523,8 @@ export interface VolcengineGenerateResult {
   traceId?: string
   model: string
   error?: string
+  /** 提交失败且火山判定该模型「无接入点 / 已下架」时返回，供上层持久化标记并拦截后续生成 */
+  unavailable?: 'decommissioned' | 'no_endpoint'
 }
 
 /**
@@ -431,10 +545,14 @@ export async function volcengineGenerateWithKey(
     { type: "text", text: opts.prompt?.trim() || (opts.mode === "img2video" ? "让图片动起来" : "生成一段视频") },
   ]
   const imgs = (opts.images ?? []).filter((u) => /^https?:\/\//i.test(String(u).trim()))
+  // 图片 role 必须按模型家族区分：Seedance 图生视频用 first_frame/last_frame（首帧/首尾帧），
+  // 否则 ARK 会把 reference_image 当 task_type=r2v 而 seedance 不支持直接拒绝；Wan 系才用 reference_image。
+  const isSeedance = /^doubao-seedance/i.test((opts.model || "").trim())
   if (opts.mode === "img2video" && imgs.length > 0) {
-    for (const url of imgs) {
-      content.push({ type: "image_url", image_url: { url }, role: "reference_image" })
-    }
+    imgs.forEach((url, idx) => {
+      const role = isSeedance ? (idx === 0 ? "first_frame" : "last_frame") : "reference_image"
+      content.push({ type: "image_url", image_url: { url }, role })
+    })
   } else if (opts.mode === "img2video") {
     return { ok: false, model: opts.model, error: "火山图生视频需要至少上传 1 张首帧图（需公网 https 地址）" }
   }
@@ -444,14 +562,24 @@ export async function volcengineGenerateWithKey(
   const body: Record<string, unknown> = {
     model: bodyModel,
     content,
-    generate_audio: opts.audio !== "off",
     watermark: false,
     output_format: "mp4",
   }
+  // 有声（generate_audio）仅官方支持有声的模型可下发；无声模型（1.0 Pro/Fast/Lite）不发以免被拒
+  if (VOLC_AUDIO_MODELS.has(bodyModel)) body["generate_audio"] = opts.audio !== "off"
   const dur = Number(opts.durationSec)
   if (Number.isFinite(dur) && dur > 0) body["duration"] = dur
   if (opts.ratio) body["ratio"] = opts.ratio
-  if (opts.resolution) body["resolution"] = opts.resolution
+  // 分辨率不能作为顶层参数传给火山（会报 InvalidParameter「resolution ... not valid」），需按模型家族写成文本控制令牌：
+  //   Seedance 系：--rs <720p|1080p>；Wan 系：--resolution <720p|1080p>。追加到首条文本提示词末尾。
+  if (opts.resolution) {
+    const resVal = `${opts.resolution}p`
+    const textItem = content.find((c) => c.type === "text") as { type: string; text?: string } | undefined
+    if (textItem) {
+      const token = bodyModel.startsWith("wan") ? `--resolution ${resVal}` : `--rs ${resVal}`
+      textItem.text = `${textItem.text ?? ""} ${token}`.trim()
+    }
+  }
 
   const genLog = (msg: string, extra?: unknown): void => {
     console.log(`[volc-gen][${new Date().toISOString()}] ${msg}`, extra === undefined ? "" : JSON.stringify(extra))
@@ -459,6 +587,11 @@ export async function volcengineGenerateWithKey(
 
   try {
     onProgress?.(`正在提交到火山方舟（${opts.model}）…`)
+    // 明确日志当前实际发出的 Model ID 与端点区域：便于核对「模型名/地域」是否与账号开通的一致
+    genLog(`提交 model=${bodyModel} url=${VOLC_BASE_URL}/contents/generations/tasks`, {
+      mode: opts.mode,
+      imgs: imgs.length,
+    })
     const submit = await fetch(`${VOLC_BASE_URL}/contents/generations/tasks`, {
       method: "POST",
       headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
@@ -469,8 +602,39 @@ export async function volcengineGenerateWithKey(
     const submitData = (submitRaw && typeof submitRaw === "object" ? submitRaw : {}) as Record<string, unknown>
     if (!submit.ok) {
       const errObj = (submitData["error"] ?? {}) as Record<string, unknown> | null
+      const code = typeof errObj?.code === "string" ? errObj.code : ""
       const msg = typeof errObj?.message === "string" ? errObj.message : `HTTP ${submit.status}`
-      genLog(`提交失败 status=${submit.status} msg=${msg}`)
+      genLog(`提交失败 status=${submit.status} code=${code} msg=${msg}`)
+      // 判定该模型是否因「无接入点 / 平台下架」失败：是则一并返回，供上层持久化标记并拦截后续生成
+      const unavail = volcGenUnavailableKind(code, msg)
+      const unavailableSpread = unavail ? { unavailable: unavail } : {}
+      // 方舟官方错误码区分两类，给出精准提示而非笼统报「未开通」：
+      //   ModelNotOpen                     = 该账号确实没开通模型；请在开通管理页开通
+      //   InvalidEndpointOrModel.NotFound  = 模型/端点不存在或无权访问；多为「调用地域≠开通地域」或「API Key 账号≠开通模型的主账号」
+      if (code === "ModelNotOpen") {
+        return { ok: false, model: opts.model, error: `「${opts.model}」当前账号未开通该模型服务，请在开通管理页开通后再试`, ...unavailableSpread }
+      }
+      if (code === "InvalidEndpointOrModel.NotFound") {
+        return {
+          ok: false,
+          model: opts.model,
+          error: `「${opts.model}」模型/端点不存在或无权访问（多为开通地域不是 cn-beijing，或 API Key 与开通模型的不是同一主账号）。请核对开通管理页该模型的地域与账号`,
+          ...unavailableSpread,
+        }
+      }
+      const notOpened =
+        /does not exist|do not have access|no access|not accessible|model not (found|activated|enabled)|not enabled|invalid model|未开通|无访问权限/i.test(
+          msg
+        )
+      if (notOpened) {
+        const modeLabel = opts.mode === "img2video" ? "图生" : "文生"
+        return {
+          ok: false,
+          model: opts.model,
+          error: `「${opts.model}」的${modeLabel}模型服务未开通或无访问权限，请到开通管理页确认该模型已开通后再试`,
+          ...unavailableSpread,
+        }
+      }
       return { ok: false, model: opts.model, error: `火山方舟提交失败: ${msg}${submit.status === 429 ? "（限流，请稍后再试）" : ""}` }
     }
     const rawTaskId = submitData["id"]
@@ -505,18 +669,25 @@ export async function volcengineGenerateWithKey(
       }
       const status = String(data["status"] ?? "UNKNOWN")
       if (status === "succeeded" || status === "success") {
-        const items = Array.isArray(data["content"]) ? (data["content"] as Array<Record<string, unknown>>) : []
-        const video = items.find((it) => typeof it["video_url"] === "string")
-        const poster = items.find((it) => typeof it["poster_url"] === "string")
+        // 响应里 content 既可能是「对象」{video_url, poster_url}（seedance 用），也可能是旧版「数组」[{…}]：统一归一成数组再取
+        const contentRaw = data["content"]
+        const cList: Array<unknown> = Array.isArray(contentRaw)
+          ? (contentRaw as unknown[])
+          : contentRaw && typeof contentRaw === "object"
+            ? [contentRaw]
+            : []
+        const safe = (it: unknown): Record<string, unknown> => (it && typeof it === "object" ? (it as Record<string, unknown>) : {})
+        const video = cList.find((it) => typeof safe(it)["video_url"] === "string")
+        const poster = cList.find((it) => typeof safe(it)["poster_url"] === "string")
         if (!video) {
           genLog("终态 succeeded 但 content 缺少 video_url", data)
           return { ok: false, model: opts.model, error: "火山方舟任务 SUCCESS 但缺少视频地址" }
         }
-        genLog(`生成成功 video_url=${video["video_url"]} polls=${polls}`)
+        genLog(`生成成功 video_url=${safe(video)["video_url"]} polls=${polls}`)
         return {
           ok: true,
-          videoUrl: String(video["video_url"]),
-          coverImageUrl: typeof poster?.["poster_url"] === "string" ? String(poster["poster_url"]) : undefined,
+          videoUrl: String(safe(video)["video_url"]),
+          coverImageUrl: poster ? String(safe(poster)["poster_url"]) : undefined,
           traceId: taskId,
           model: opts.model,
         }


### PR DESCRIPTION
## 修改内容

### 1. 免费视频额度防误扣拦截
- api-branch.ts：新增免费视频额度防误扣拦截逻辑，防止免费模型误扣额度
- dispatch.ts：调度逻辑适配免费模型额度校验
- providers.ts：新增防误扣相关 IPC 处理

### 2. 无接入点模型标识
- volcengine.ts：新增无接入点模型标识处理，标记不支持直接接入的模型
- 新增 migrations/0033_volcengine_lite_model_ids.sql：lite 模型 ID 映射
- spec.ts：新增模型标识

### 3. 前端 UI 适配
- Providers.tsx：免费模型额度状态展示
- Modals.tsx：免费模型提示
- Dashboard.tsx：免费模型额度展示
- History.tsx：历史记录免费模型标识
- useProviders.ts：免费模型额度数据
- styles.css：免费模型样式

### 4. 文档
- 火山方舟免费视频额度防误扣拦截方案.md
- 火山方舟无接入点与下架模型标识拦截方案.md