### PR TITLE
feat: 阿里云百炼完整接入（api-branch + IPC + UI + 文档）

### DIFF
--- a/apps/desktop/src/main/api-branch.ts
+++ b/apps/desktop/src/main/api-branch.ts
@@ -14,6 +14,8 @@ import type { GenerateInput } from './dispatch'
 import { decodeZhipuPayload } from './providers'
 import {
   decodeVolcenginePayload,
+  decodeBailianPayload,
+  isBailianVideoFreeModel,
   fetchZhipuQuota,
   zhipuGenerateWithKey,
   volcengineFreeVideoModels,
@@ -432,6 +434,32 @@ export function registerApiIpc(): void {
   apiIpcRegistered = true
 
   ipcMain.handle('provider:api-models', async (_e, providerId: string, encrypted?: string) => {
+    // 阿里云百炼：展示该账号捕获的免费额度模型明细（freeTiers，来自绑定时的控制台会话捕获快照）
+    if (providerId === 'bailian') {
+      if (!encrypted) return { ok: true, models: [] }
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
+        const { freeTiers } = decodeBailianPayload(plain)
+        const models: ApiModelInfo[] = (freeTiers ?? [])
+          .filter((t) => isBailianVideoFreeModel(t.model) && !t.expired)
+          .map((t) => ({
+            model: t.model,
+            priceLabel: '免费',
+            cost: 0,
+            durations: [5],
+            size: null,
+            modes: [{ value: 'text2video', label: '文生视频' }],
+            activated: true,
+            freeQuota: {
+              remaining: t.remaining,
+              total: t.total
+            }
+          }))
+        return { ok: true, models }
+      } catch {
+        return { ok: false, error: '解析百炼免费额度失败' }
+      }
+    }
     const branch = API_BRANCHES[providerId]
     if (!branch) return { ok: false, error: '不支持的 API 厂商' }
     // 火山方舟：解密该账号负载里的每模型免费 token 额度 + 实时抓到的模型目录，叠加到目录上展示

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -15,8 +15,15 @@ import {
   volcengineAuthoritativeIds,
   VOLCENGINE_FREE_NAME_TO_ID
 } from '@quota-flow/providers'
-import { testBailianApiKey, bailianAccountFingerprint } from '@quota-flow/providers'
-import type { VolcengineFreeVideoModel } from '@quota-flow/providers'
+import {
+  testBailianApiKey,
+  bailianAccountFingerprint,
+  decodeBailianPayload,
+  parseBailianFreeTierPayload,
+  aggregateBailianFreeQuota,
+  isBailianVideoFreeModel
+} from '@quota-flow/providers'
+import type { VolcengineFreeVideoModel, BailianStoredCookie } from '@quota-flow/providers'
 
 /** 对「解密后的明文」仅做透明的 models 不可用标记写入，返回新明文（不触发网络；consoleJwt/accountId 原样保留）。 */
 export function markVolcModelUnavailable(
@@ -78,6 +85,7 @@ export type ProviderId =
   | 'dola'
   | 'kling'
   | 'hailuo'
+  | 'bailian'
 
 interface ProviderSite {
   loginUrl?: string
@@ -117,6 +125,11 @@ const PROVIDER_SITES: Record<ProviderId, ProviderSite> = {
   hailuo: {
     loginUrl: 'https://hailuoai.com/video',
     healthUrl: 'https://hailuoai.com/'
+  },
+  // 阿里云百炼：bailian 为 apikey 厂商，走 openProviderSite 通用分支打开 API Key 管理页
+  bailian: {
+    loginUrl: 'https://bailian.console.aliyun.com/cn-beijing?tab=model#/api-key',
+    healthUrl: 'https://bailian.console.aliyun.com/'
   }
 }
 
@@ -282,7 +295,7 @@ async function injectCookies(
         value: c.value,
         httpOnly: c.httpOnly,
         secure: c.secure,
-        expirationDate: c.expires > 0 ? Math.floor(c.expires / 1000) : undefined
+        expirationDate: typeof c.expires === 'number' && c.expires > 0 ? Math.floor(c.expires / 1000) : undefined
       })
     } catch {
       // 单条失败不阻塞其余注入
@@ -731,7 +744,8 @@ async function openProviderSite(
   keyId: string,
   encryptedKey?: string
 ): Promise<{ ok: boolean; error?: string }> {
-  // 智谱（bigmodel）/ 火山方舟（volcengine）：打开该账号控制台，使用按账号隔离的分区免重复登录且不串号
+  // 智谱（bigmodel）/ 火山方舟（volcengine）/ 阿里云百炼（bailian）：
+  // 打开该账号控制台，使用按账号隔离的分区免重复登录且不串号
   let url: string | undefined
   let partition: string
   let injectableEncrypted: string | undefined
@@ -741,6 +755,24 @@ async function openProviderSite(
   } else if (providerId === 'volcengine') {
     url = VOLC_CONSOLE_URL
     partition = partitionFor(providerId, keyId)
+  } else if (providerId === 'bailian') {
+    // 复用绑定时捕获会话所在分区（persist:qf-bailian-console:<keyId>），打开即带已登录会话；每账号独立分区不串号
+    url = BAILIAN_CONSOLE_URL
+    partition = bailianConsolePartitionFor(keyId)
+    injectableEncrypted = encryptedKey
+    // 诊断：确认登录 cookie 是否真的落在该账号控制台分区（用于排查「进入官网未登录」）
+    try {
+      const diagSes = session.fromPartition(partition)
+      const diagCks = await diagSes.cookies.get({ url: BAILIAN_CONSOLE_URL })
+      console.log(
+        `[qf-bailian] OPEN-SITE keyId=${keyId} partition=${partition} cookies=${diagCks.length} names=[${diagCks
+          .slice(0, 8)
+          .map((c) => c.name)
+          .join(',')}]`
+      )
+    } catch {
+      /* 诊断失败不影响打开官网 */
+    }
   } else {
     const site = providerSite(providerId)
     url = site?.loginUrl || site?.healthUrl
@@ -762,8 +794,27 @@ async function openProviderSite(
   // 智谱走共享控制台分区，无需注入账号级 cookie；其余厂商按账号分区并注入 cookie
   if (injectableEncrypted) {
     try {
-      const parsed = parseStoredCredentials(injectableEncrypted, providerId)
-      if (parsed.cookies.length > 0) await injectCookies(providerId, parsed.cookies, keyId)
+      if (providerId === 'bailian') {
+        // 百炼把「进入官网」落在其控制台持久分区，重启后 persist 分区可能未留存登录 cookie，
+        // 从加密负载中读取绑定时持久化的控制台 cookie 重新注入，重建登录态（不覆盖目标分区已有 cookie）
+        let payloadCookies = 0
+        try {
+          const plain = safeStorage.decryptString(Buffer.from(injectableEncrypted, 'base64'))
+          const d = decodeBailianPayload(plain)
+          payloadCookies = Array.isArray(d.cookies) ? d.cookies.length : 0
+          const before = await collectBailianConsoleCookies(keyId)
+          if (payloadCookies > 0) await injectBailianConsoleCookies(keyId, d.cookies!)
+          const after = await collectBailianConsoleCookies(keyId)
+          console.log(
+            `[qf-bailian] OPEN-SITE-INJECT keyId=${keyId} payloadCookies=${payloadCookies} before=${before.length} after=${after.length}`
+          )
+        } catch (e) {
+          console.log(`[qf-bailian] OPEN-SITE-INJECT keyId=${keyId} payloadCookies=${payloadCookies} err=${e instanceof Error ? e.message : String(e)}`)
+        }
+      } else {
+        const parsed = parseStoredCredentials(injectableEncrypted, providerId)
+        if (parsed.cookies.length > 0) await injectCookies(providerId, parsed.cookies, keyId)
+      }
     } catch {
       // 解密失败时仍尝试打开官网，至少让用户看到站点本身。
     }
@@ -2335,6 +2386,310 @@ sample:(function(){
   })
 }
 
+// ── 阿里云百炼控制台会话捕获（复用智谱/火山内核：独立分区 + 注入 hook 抓响应 + localStorage 兜底）──
+// 默认落点：API Key 管理页（tab=model#/api-key，用户最熟悉，方便复制/校验 Key）。
+// 捕获两样东西（需用户切到免费额度页 costing-balance/free-quota?modelType=Vision 后由注入脚本抓取）：
+//   1) accountId（阿里云账号 PK）→ 账号级去重指纹键（免费额度按账号共享，见方案 §6.1）
+//   2) freeTierQuotas（真实免费额度）→ 账号级聚合展示（剩余/总量）
+// 鉴权：页面内 fetch/XHR 依赖控制台会话 cookie + 页面 SDK 计算注入的 sec_token，故无法由主进程/裸
+//   API Key 重放，只能在本捕获窗口页面上下文内 hook 网络响应 + 读 localStorage 缓存整表（页面自身缓存
+//   CacheByUId-CURRENT_PK-<accountId>-free_quota_<ModelType>）。
+const BAILIAN_CONSOLE_URL = "https://bailian.console.aliyun.com/cn-beijing?tab=model#/api-key"
+// 免费额度页（用于注入提示与跳转引导；捕获监听即针对该页响应的 queryFreeTierQuotaAsyn）
+const BAILIAN_FREE_QUOTA_URL =
+  "https://bailian.console.aliyun.com/cn-beijing?tab=costing-balance#/costing-balance/free-quota?modelType=Vision"
+const BAILIAN_CONSOLE_PARTITION = "persist:qf-bailian-console"
+/** 百炼控制台分区按账号隔离：persist:qf-bailian-console[:keyId]，避免多账号串会话 */
+function bailianConsolePartitionFor(keyId?: string): string {
+  return keyId ? `${BAILIAN_CONSOLE_PARTITION}:${keyId}` : BAILIAN_CONSOLE_PARTITION
+}
+function bailianConsoleSession(keyId?: string): Electron.Session {
+  return session.fromPartition(bailianConsolePartitionFor(keyId))
+}
+
+const BAILIAN_CONSOLE_ORIGIN = 'https://bailian.console.aliyun.com'
+
+/** 读取百炼控制台分区 cookie（供持久化/回注入，跨重启重建登录态） */
+async function collectBailianConsoleCookies(keyId?: string): Promise<ProviderCookie[]> {
+  const ses = session.fromPartition(bailianConsolePartitionFor(keyId))
+  const all = await ses.cookies.get({})
+  return exportCookies(all)
+}
+
+/** 向百炼控制台分区回注入 cookie（与网页厂商 injectCookies 同构，但定向到控制台分区） */
+async function injectBailianConsoleCookies(keyId: string, cookies: BailianStoredCookie[]): Promise<void> {
+  const ses = session.fromPartition(bailianConsolePartitionFor(keyId))
+  ses.setUserAgent(CHROME_UA)
+  for (const c of cookies) {
+    try {
+      await ses.cookies.set({
+        url: `${c.secure ? 'https' : 'http'}://${(c.domain || '').replace(/^\./, '') || BAILIAN_CONSOLE_ORIGIN.replace(/^https?:\/\//, '')}${c.path || '/'}`,
+        domain: c.domain || undefined,
+        name: c.name,
+        value: c.value,
+        httpOnly: c.httpOnly,
+        secure: c.secure,
+        expirationDate: typeof c.expires === 'number' && c.expires > 0 ? Math.floor(c.expires / 1000) : undefined
+      })
+    } catch {
+      // 单条失败不阻塞其余注入
+    }
+  }
+}
+/** 静默捕获（续期/刷新额度）最长等待 */
+const BAILIAN_QUIET_WAIT_MS = 5000
+
+/**
+ * 绑定捕获时的控制台 cookie 缓存（按账号 accountId 暂存）。
+ * 用途：渲染层把捕获结果落库负载时可能因状态/旧 bundle 丢 cookies，加密兜底合并这里最近的捕获结果，
+ * 确保登录 cookie 一定随负载持久化，供「进入官网」跨重启重新注入。
+ */
+const bailianCapturedCookies = new Map<string, BailianStoredCookie[]>()
+
+export async function captureBailianConsoleSession(opts?: {
+  /** 静默捕获：不显示窗口、不要求点按钮，抓到数据或超时即自动返回 */
+  quiet?: boolean
+  /** 绑定/续期所属账号 keyId：隔离登录态，避免多账号串会话 */
+  keyId?: string
+}): Promise<{
+  ok: boolean
+  accountId?: string
+  freeTiersRaw?: string
+  source?: 'console' | 'cache' | 'none'
+  cookies?: ProviderCookie[]
+  error?: string
+}> {
+  const quiet = !!opts?.quiet
+  const optKeyId = opts?.keyId
+  const winKey = `${quiet ? 'bailian-console-quiet' : 'bailian-console'}:${optKeyId ?? 'shared'}`
+  const existing = loginWindows.get(winKey)
+  if (existing && !existing.isDestroyed()) {
+    existing.focus()
+    return { ok: false, error: quiet ? '百炼会话捕获进行中' : '百炼控制台窗口已打开' }
+  }
+  // 首次绑定清空登录态避免残留；静默复用已登录 cookie，跳过清空
+  if (!quiet) {
+    try {
+      await bailianConsoleSession(optKeyId).clearStorageData()
+    } catch {}
+  }
+  const ses = bailianConsoleSession(optKeyId)
+
+  // 主窗口（可见）：落 API Key 管理页，用户在此登录并复制/校验 API Key
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    minWidth: 840,
+    minHeight: 620,
+    title: '⋮⋮  Quota-Flow · 阿里云百炼控制台',
+    autoHideMenuBar: true,
+    backgroundColor: '#ffffff',
+    show: !quiet,
+    paintWhenInitiallyHidden: true,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      session: ses
+    }
+  })
+  win.webContents.setUserAgent(CHROME_UA)
+  loginWindows.set(winKey, win)
+  void win.loadURL(BAILIAN_CONSOLE_URL).catch(() => {})
+
+  // 隐藏捕获窗口：同一 partition 共用登录态（cookie），落免费额度页(视觉模型)，
+  // 页面 SDK 自动计算 sec_token 并发起 queryFreeTierQuotaAsyn，由注入脚本抓整表快照——用户无需手动切页
+  const capWin = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    show: false,
+    paintWhenInitiallyHidden: true,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      session: ses
+    }
+  })
+  capWin.webContents.setUserAgent(CHROME_UA)
+  void capWin.loadURL(BAILIAN_FREE_QUOTA_URL).catch(() => {})
+
+  // ── 捕获窗口注入：仅做数据 hook（fetch/XHR + localStorage 兜底），隐藏窗口不含 UI ──
+  const CAPTURE_INJECT = `(() => {
+    if (window.__QUOTA_FLOW_BAILIAN_CAP__) return;
+    window.__QUOTA_FLOW_BAILIAN_CAP__ = true;
+    window.__QB_FREE_TIERS_RAW__ = null;
+    window.__QB_ACCOUNT__ = null;
+    const setRaw = (text) => { try { if (typeof text === 'string' && text.length > 30 && (text.indexOf('freeTierQuot') > -1 || text.indexOf('quotaTotal') > -1)) { window.__QB_FREE_TIERS_RAW__ = text; } } catch (_) {} };
+    const ACCT_FROM_KEY = /CURRENT_PK[-_](\\d{6,20})/;
+    const ACCT_FROM_VAL = /["']?(?:accountId|userId|user_id|account_id|uid)["']?\\s*[:=]\\s*["']?(\\d{6,20})/i;
+    const setAccount = (source) => { try { if (window.__QB_ACCOUNT__) return; const m = String(source || '').match(ACCT_FROM_KEY) || String(source || '').match(ACCT_FROM_VAL); if (m && m[1]) window.__QB_ACCOUNT__ = m[1]; } catch (_) {} };
+    const ingest = (url, text) => { try { if (/queryFreeTierQuota/i.test(String(url || ''))) { setRaw(text); setAccount(text); } } catch (_) {} };
+    const origFetch = window.fetch;
+    if (origFetch) { window.fetch = function (...args) { const url = typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url) || ''; const p = origFetch.apply(this, args); try { p.then((resp) => { try { resp.clone().text().then((txt) => ingest(url, txt)); } catch (_) {} }).catch(() => {}); } catch (_) {} return p; }; }
+    const origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function (m, u) { try { window.__QB_XHR__ = String(u || ''); } catch (_) {} return origOpen.apply(this, arguments); };
+    const origSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.send = function (...rest) { try { if (window.__QB_XHR__) { const self = this; const u = window.__QB_XHR__; this.addEventListener('load', function () { try { const t = self.responseText || ''; ingest(u, t); } catch (_) {} }); } } catch (_) {} return origSend.apply(this, rest); };
+    const scanStorage = () => { try { for (let i = 0; i < localStorage.length; i++) { const k = localStorage.key(i) || ''; const v = localStorage.getItem(k) || ''; if (/free_quota|freeTier|CacheByUId/.test(k)) { setRaw(v); setAccount(k); } } } catch (_) {} };
+    window.__QB_SCAN__ = setInterval(scanStorage, 1200);
+    scanStorage();
+  })()`
+  const injectCap = (): void => {
+    void capWin.webContents.executeJavaScript(CAPTURE_INJECT).catch(() => {})
+  }
+  capWin.webContents.on('did-finish-load', () => {
+    setTimeout(injectCap, 500)
+  })
+  if (quiet) setTimeout(injectCap, 700)
+
+  // ── 主窗口注入：可拖拽提示条 + 「已捕获返回」按钮（数据在隐藏捕获窗口自动抓取）──
+  const UI_INJECT = `(() => {
+    if (window.__QUOTA_FLOW_BAILIAN_UI__) return;
+    window.__QUOTA_FLOW_BAILIAN_UI__ = true;
+    window.__QB_UI_SUBMIT__ = false;
+    const bar = document.createElement('div');
+    bar.id = 'qf-bailian-bar';
+    bar.style.cssText = 'position:fixed;top:12px;left:12px;z-index:2147483647;display:flex;flex-direction:column;gap:6px;padding:8px 12px;border-radius:8px;background:rgba(20,20,22,.92);color:#fff;font:12.5px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;box-shadow:0 4px 16px rgba(0,0,0,.35);user-select:none;max-width:440px;';
+    bar.innerHTML =
+      '<div id="qf-bailian-header" style="display:flex;align-items:center;gap:6px;font-weight:600;color:#fff;cursor:grab;font-size:12.5px;">' +
+      '<span id="qf-bailian-grip" style="color:#9aa0a6;letter-spacing:1px;font-size:13px;">⋮⋮</span>' +
+      '<span>Quota-Flow · 阿里云百炼控制台</span>' +
+      '</div>' +
+      '<div style="display:flex;align-items:center;gap:8px;">' +
+      '<span style="flex:1;min-width:0;color:#c4c8d0;font-size:12px;line-height:1.4;">请在页面登录并复制 API Key，免费额度已由后台自动捕获；返回请点击下方按钮</span>' +
+      '<button id="qf-bailian-return" style="flex-shrink:0;padding:5px 12px;border:0;border-radius:6px;background:#2ea56f;color:#fff;font:600 12px/1 inherit;cursor:pointer;white-space:nowrap;">已捕获返回</button>' +
+      '</div>';
+    document.body.appendChild(bar);
+    document.getElementById('qf-bailian-return').addEventListener('click', () => { window.__QB_UI_SUBMIT__ = true; });
+    let dragging = false, offX = 0, offY = 0;
+    const grip = document.getElementById('qf-bailian-grip');
+    const header = document.getElementById('qf-bailian-header');
+    const barEl = document.getElementById('qf-bailian-bar');
+    const startDrag = (e) => { dragging = true; offX = e.clientX - barEl.offsetLeft; offY = e.clientY - barEl.offsetTop; barEl.style.cursor = 'grabbing'; e.preventDefault(); };
+    if (grip) grip.addEventListener('mousedown', startDrag);
+    if (header) header.addEventListener('mousedown', startDrag);
+    document.addEventListener('mousemove', (e) => { if (!dragging) return; const x = Math.max(4, Math.min(window.innerWidth - barEl.offsetWidth - 4, e.clientX - offX)); const y = Math.max(4, Math.min(window.innerHeight - barEl.offsetHeight - 4, e.clientY - offY)); barEl.style.left = x + 'px'; barEl.style.top = y + 'px'; });
+    document.addEventListener('mouseup', () => { dragging = false; barEl.style.cursor = 'grab'; });
+  })()`
+  const injectUI = (): void => {
+    void win.webContents.executeJavaScript(UI_INJECT).catch(() => {})
+  }
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(injectUI, 500)
+  })
+
+  return new Promise<{
+    ok: boolean
+    accountId?: string
+    freeTiersRaw?: string
+    source?: 'console' | 'cache' | 'none'
+    cookies?: ProviderCookie[]
+    error?: string
+  }>((resolve) => {
+      let finished = false
+      let renewTimeout: NodeJS.Timeout | null = null
+      const done = (result: {
+        ok: boolean
+        accountId?: string
+        freeTiersRaw?: string
+        source?: 'console' | 'cache' | 'none'
+        cookies?: ProviderCookie[]
+        error?: string
+      }): void => {
+        if (finished) return
+        finished = true
+        clearInterval(pollTimer)
+        if (renewTimeout) clearTimeout(renewTimeout)
+        if (!win.isDestroyed()) win.destroy()
+        if (!capWin.isDestroyed()) capWin.destroy()
+        loginWindows.delete(winKey)
+        resolve(result)
+      }
+      win.on('closed', () => {
+        clearInterval(pollTimer)
+        if (renewTimeout) clearTimeout(renewTimeout)
+        try {
+          void win.webContents.executeJavaScript('clearInterval(window.__QB_UI_SCAN__)').catch(() => {})
+        } catch {}
+        if (!capWin.isDestroyed()) capWin.destroy()
+        if (loginWindows.get(winKey) === win) loginWindows.delete(winKey)
+        if (!finished) {
+          finished = true
+          resolve({ ok: false, error: '窗口已关闭' })
+        }
+      })
+
+      if (quiet) {
+        renewTimeout = setTimeout(() => {
+          done({ ok: true, source: 'none' })
+        }, BAILIAN_QUIET_WAIT_MS)
+      }
+
+      const readCapExpr =
+        'window.__QB_FREE_TIERS_RAW__ ? [window.__QB_ACCOUNT__ || null, window.__QB_FREE_TIERS_RAW__] : null'
+      const readUIExpr = 'window.__QB_UI_SUBMIT__ || false'
+      let reloadTick = 0
+      const pollTimer = setInterval(() => {
+        if (win.isDestroyed() || capWin.isDestroyed()) return
+        reloadTick = (reloadTick + 1) % 15 // 每 ~10.5s 一轮；登录前捕获窗口可能未授权跳走，周期刷新以带登录态重请求
+        Promise.all([
+          capWin.webContents.executeJavaScript(readCapExpr).catch(() => null),
+          quiet ? Promise.resolve(true) : win.webContents.executeJavaScript(readUIExpr).catch(() => false)
+        ])
+          .then(([capVal, uiGo]) => {
+            const val = capVal as [string | null, string] | null
+            if (!val) {
+              // 登录前窗口常无额度数据：非静默下周期 reload 捕获窗口，用户在主窗口登录后 cookie 生效即可抓到
+              if (!quiet && reloadTick === 0) {
+                try {
+                  void capWin.webContents.reload()
+                } catch {}
+              }
+              return
+            }
+            const [accountId, raw] = val
+            const hasData = typeof raw === 'string' && raw.length > 30
+            if (!hasData) {
+              if (quiet) return
+              // 用户已点「已捕获返回」但未抓到额度：提示而非静默失败
+              if (uiGo) done({ ok: false, error: '未捕获到免费额度数据，请确认已在页面登录成功再重试' })
+              return
+            }
+            if (!quiet && !uiGo) return // 数据已就绪但用户尚未点返回，继续等待
+            console.log(
+              `[qf-bailian] CAPTURE ok accountId=${accountId ? `YES:${accountId}` : 'NO'} rawLen=${raw.length} quiet=${quiet}`
+            )
+            // 捕获成功后读取该账号控制台分区的登录 cookie，随负载持久化，供「进入官网」跨重启重建登录态
+            void Promise.resolve()
+              .then(() => collectBailianConsoleCookies(optKeyId))
+              .then((cookies) => {
+                console.log(`[qf-bailian] CAPTURE cookies=${cookies.length}`)
+                // 最近一次成功捕获的 cookie 按 accountId 缓存，供后续 provider:encrypt 兜底合并进负载
+                if (accountId && cookies.length > 0) bailianCapturedCookies.set(accountId, cookies)
+                done({
+                  ok: true,
+                  accountId: accountId ?? undefined,
+                  freeTiersRaw: raw,
+                  source: accountId ? 'console' : 'cache',
+                  cookies
+                })
+              })
+              .catch(() => {
+                done({
+                  ok: true,
+                  accountId: accountId ?? undefined,
+                  freeTiersRaw: raw,
+                  source: accountId ? 'console' : 'cache'
+                })
+              })
+          })
+          .catch(() => {})
+      }, 700)
+    }
+  )
+}
+
 let registered = false
 
 export function initProviders(): void {
@@ -2348,7 +2703,27 @@ export function initProviders(): void {
   ipcMain.handle('provider:encrypt', async (_e, providerId: string, plain: string) => {
     if (typeof plain !== 'string') return { encrypted: '' }
     try {
-      const encrypted = safeStorage.encryptString(plain).toString('base64')
+      // 百炼兜底：若捕获时返回的 cookies 未随渲染层负载写进来（旧 bundle/状态丢失），
+      // 用缓存里最近一次成功捕获的同账号 cookies 合并后再加密，保证登录 cookie 一定落库
+      let payloadPlain = plain
+      if (providerId === 'bailian') {
+        const trimmedP = (plain || '').trim()
+        if (trimmedP.startsWith('{')) {
+          const d = decodeBailianPayload(trimmedP)
+          if (d.accountId && (!Array.isArray(d.cookies) || d.cookies.length === 0)) {
+            const live = bailianCapturedCookies.get(d.accountId)
+            if (live && live.length > 0) {
+              try {
+                const obj = JSON.parse(trimmedP)
+                obj.cookies = live
+                payloadPlain = JSON.stringify(obj)
+                console.log(`[qf-bailian] ENC mergeCapturedCookies accountId=${d.accountId} n=${live.length}`)
+              } catch {}
+            }
+          }
+        }
+      }
+      const encrypted = safeStorage.encryptString(payloadPlain).toString('base64')
       // apikey 型厂商：指纹用于去重。
       // 智谱：同一账号可有多个 API Key，优先按 customerId 生成账号级指纹（同账号不同 Key 去重）；
       //       拿不到 customerId（无会话 / 查询失败）时回退按 API Key 明文哈希，避免误拦截。
@@ -2369,10 +2744,10 @@ export function initProviders(): void {
             `ENC_VOLC accountId=${accountId ? `YES:${accountId}` : 'NO'} fp_level=${fingerprint ? (accountId ? 'account' : 'key-hash') : 'none'}`
           )
         }
-        // 阿里云百炼去重诊断：本期用登录账号（后续会话捕获可升为账号级），当前退化为 Key 哈希
+        // 阿里云百炼去重诊断：payload 带 accountId（会话捕获）时按「账号级」指纹去重，否则退化为 Key 哈希
         if (providerId === 'bailian') {
           console.log(
-            `[qf-bailian] ENC fp_level=${fingerprint ? 'key-hash' : 'none'} keyLen=${plain.trim().length}`
+            `[qf-bailian] ENC fp_level=${fingerprint ? (decodeBailianPayload(plain || '').accountId ? 'account' : 'key-hash') : 'none'} keyLen=${plain.trim().length}`
           )
         }
       }
@@ -2402,10 +2777,20 @@ export function initProviders(): void {
     }
   })
 
-  // API Key 型厂商真实额度查询：解密后取 apiKey + consoleJwt，调对应控制台接口拿资源包余额
+  // API Key 型厂商真实额度查询：解密后取 apiKey + consoleJwt，调对应控制台接口拿资源包余额；
+  // 百炼免费额度为一次性 90 天快照，随绑定时的控制台会话捕获落库（账号级聚合功耗，见方案 §6.1）
   ipcMain.handle('provider:fetch-quota', async (_e, providerId: string, encrypted: string) => {
     if (!encrypted) return { ok: false, error: '缺少密钥' }
     try {
+      if (providerId === 'bailian') {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { freeTiers } = decodeBailianPayload(plain)
+        // 展示口径：只统计视频生成模型且未过期的免费额度，与「查看模型」明细口径一致
+        const tiers = (freeTiers ?? []).filter(
+          (t) => isBailianVideoFreeModel(t.model) && !t.expired
+        )
+        return { ok: true, quota: aggregateBailianFreeQuota(tiers) }
+      }
       const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
       const { apiKey, consoleJwt } = decodeZhipuPayload(plain)
       if (!apiKey) return { ok: false, error: '未解析到 API Key' }
@@ -2433,6 +2818,23 @@ export function initProviders(): void {
       keyId: typeof keyId === 'string' && keyId ? keyId : undefined,
       targetUrl: VOLC_OPEN_MANAGEMENT_URL
     })
+  })
+
+  // 百炼控制台会话捕获：按账号 keyId 弹出对应分区控制台窗口，捕获账号 PK + 免费额度整表快照，
+  // 并把原始额度文本解析为归一化条目返回（随加密 payload 落库，供账号级去重 + 聚合总额展示）
+  ipcMain.handle('provider:capture-bailian-session', async (_e, keyId?: string) => {
+    const res = await captureBailianConsoleSession({
+      keyId: typeof keyId === 'string' && keyId ? keyId : undefined
+    })
+    if (!res.ok) return { ok: false, error: res.error }
+    const tiers = res.freeTiersRaw ? parseBailianFreeTierPayload(res.freeTiersRaw) : null
+    if (tiers === null || tiers.length === 0) {
+      return { ok: false, error: '未捕获到有效免费额度，请确认已打开「免费额度」视觉模型页' }
+    }
+    console.log(
+      `[qf-bailian] CAPTURE parsed accountId=${res.accountId ?? 'NO'} tiers=${tiers.length} remaining=${aggregateBailianFreeQuota(tiers).remaining}`
+    )
+    return { ok: true, accountId: res.accountId ?? null, freeTiers: tiers }
   })
 
   // 火山方舟控制台会话状态：视 JWT 的 exp 判定 alive / expiring / expired

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -145,6 +145,16 @@ export interface VolcengineCapturedModel {
   freeQuota?: { remaining?: number; total?: number }
 }
 
+/** 阿里云百炼免费额度单模型条目（会话捕获，账号级聚合展示） */
+export interface BailianFreeTier {
+  model: string
+  total: number
+  remaining: number
+  expired: boolean
+  expiredAtMs: number | null
+  status: string
+}
+
 /** 智谱控制台会话状态（依据 consoleJwt 的 JWT exp 判定），供自动续期调度参考 */
 export interface ZhipuSessionStatusResult {
   hasSession: boolean
@@ -273,6 +283,11 @@ export interface DesktopApi {
      * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
      */
     captureVolcengineSession: (keyId?: string) => Promise<{ ok: boolean; consoleJwt?: string; accountId?: string; models?: VolcengineCapturedModel[]; source?: 'console' | 'fallback'; error?: string }>
+    /**
+     * 捕获阿里云百炼控制台登录会话：账号 PK + 免费额度整表快照（解析为归一化条目）
+     * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
+     */
+    captureBailianSession: (keyId?: string) => Promise<{ ok: boolean; accountId?: string | null; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; error?: string }>
     /**
      * 读取指定火山方舟账号的控制台会话状态（依据 consoleJwt 的 JWT exp 判定 alive / expiring / expired）
      */
@@ -431,6 +446,13 @@ const api: DesktopApi = {
         accountId?: string
         models?: VolcengineCapturedModel[]
         source?: 'console' | 'fallback'
+        error?: string
+      }>,
+    captureBailianSession: (keyId) =>
+      ipcRenderer.invoke('provider:capture-bailian-session', keyId) as Promise<{
+        ok: boolean
+        accountId?: string | null
+        freeTiers?: BailianFreeTier[]
         error?: string
       }>,
     volcSessionStatus: (keyId, encrypted) =>

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -175,7 +175,7 @@ export default function Dashboard({
   onMaterialImagesConsumed,
   onRegenerateConsumed
 }: DashboardProps) {
-  const { aggs: provAggs, zhipuQuotaOverrides, volcTokenOverrides } = providers
+  const { aggs: provAggs, zhipuQuotaOverrides, volcTokenOverrides, bailianQuotaOverrides } = providers
   const { user, team } = useAuth()
   const { items: jobItems, reload: reloadJobs } = jobs
   const [provider, setProvider] = useState('doubao')
@@ -1065,6 +1065,7 @@ export default function Dashboard({
                 {visibleAggs.map((p) => {
                   const enabledBindings = p.bindings.filter((b) => b.enabled)
                   const isVolc = p.providerId === 'volcengine'
+                  const isBailian = p.providerId === 'bailian'
                   // 智谱等 API 型厂商：汇总取平台真实资源包余额（而非静态默认额度），生成后自动刷新
                   const quotaOf = (keyId: string) =>
                     zhipuQuotaOverrides[keyId] && zhipuQuotaOverrides[keyId].available
@@ -1075,6 +1076,11 @@ export default function Dashboard({
                     const v = volcTokenOverrides[keyId]
                     return v && v.total > 0 ? v : undefined
                   }
+                  // 阿里云百炼：汇总取账号级免费额度聚合（会话捕获快照）
+                  const bailianQuotaOf = (keyId: string) =>
+                    bailianQuotaOverrides[keyId] && bailianQuotaOverrides[keyId].available
+                      ? bailianQuotaOverrides[keyId]
+                      : undefined
                   const isApiQuota = p.providerId === 'zhipu'
                   const volcKnown = enabledBindings.some((b) => volcQuotaOf(b.keyId))
                   const used = enabledBindings.reduce((s, b) => s + b.used, 0)
@@ -1085,7 +1091,9 @@ export default function Dashboard({
                         ? quotaOf(b.keyId)?.remaining ?? 0
                         : isVolc
                           ? volcQuotaOf(b.keyId)?.remaining ?? 0
-                          : b.remaining),
+                          : isBailian
+                            ? bailianQuotaOf(b.keyId)?.remaining ?? 0
+                            : b.remaining),
                     0
                   )
                   const total = enabledBindings.reduce(
@@ -1095,7 +1103,9 @@ export default function Dashboard({
                         ? quotaOf(b.keyId)?.total ?? 0
                         : isVolc
                           ? volcQuotaOf(b.keyId)?.total ?? 0
-                          : b.dailyTotal),
+                          : isBailian
+                            ? bailianQuotaOf(b.keyId)?.total ?? 0
+                            : b.dailyTotal),
                     0
                   )
                   const fill = total > 0 ? Math.round((remaining / total) * 100) : 0

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -8,7 +8,7 @@ import { ensureFreshSession } from '../auth/session'
 import { errMsg } from '../utils/error'
 import type { AuthUser } from '../hooks/useAuth'
 import type { TeamContext } from '@quota-flow/db-supabase'
-import type { VolcengineCapturedModel } from '../../../preload'
+import type { VolcengineCapturedModel, BailianFreeTier } from '../../../preload'
 import desktopPackage from '../../../../package.json'
 
 export interface UpdaterStatusView {
@@ -667,6 +667,14 @@ export function AddProviderModal({
   const [volcAccountId, setVolcAccountId] = useState<string | null>(null)
   // 火山方舟绑定时控制台抓到的免费视频模型（含每账号 token 额度），随加密负载持久化供「查看模型」展示
   const [volcModels, setVolcModels] = useState<VolcengineCapturedModel[] | null>(null)
+  // 阿里云百炼账号标识：从控制台 costing-balance 页捕获，保存时并入 payload 作为账号级去重依据
+  const [bailianAccountId, setBailianAccountId] = useState<string | null>(null)
+  // 阿里云百炼免费额度整表快照：从控制台捕获并解析，随加密负载持久化供账号级聚合展示
+  const [bailianFreeTiers, setBailianFreeTiers] = useState<BailianFreeTier[] | null>(null)
+  // 阿里云百炼控制台登录 cookie：捕获时随负载持久化，供「进入官网」跨重启重建登录态
+  const [bailianCookies, setBailianCookies] = useState<
+    Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }> | null
+  >(null)
   const [apiKey, setApiKey] = useState('')
   const [accountName, setAccountName] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -899,12 +907,21 @@ export function AddProviderModal({
     setStatus('logging')
     try {
       const trimmed = apiKey.trim()
-      // 智谱 / 火山方舟：如有已捕获的控制台会话令牌(consoleJwt)或账号标识(volcAccountId)，并入结构化 payload，
-      // 供主进程生成「账号级」去重指纹（同账号不同 Key 去重）。
-      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine'
+      // 智谱 / 火山方舟 / 阿里云百炼：如有捕获的控制台会话令牌(consoleJwt)、账号标识(volcAccountId/bailianAccountId)
+      // 或免费额度快照，并入结构化 payload，供主进程生成「账号级」去重指纹 + 账号级聚合额度展示
+      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian'
+      const isBailian = providerId === 'bailian'
       const raw =
-        isApiProvider && (consoleJwt || volcAccountId || (providerId === 'volcengine' && volcModels?.length))
-          ? JSON.stringify({ v: 1, apiKey: trimmed, consoleJwt, accountId: volcAccountId, models: providerId === 'volcengine' ? (volcModels ?? []) : undefined })
+        isApiProvider && (consoleJwt || volcAccountId || bailianAccountId || (providerId === 'volcengine' && volcModels?.length) || (isBailian && (bailianFreeTiers?.length || bailianCookies?.length)))
+          ? JSON.stringify({
+              v: 1,
+              apiKey: trimmed,
+              consoleJwt,
+              accountId: isBailian ? bailianAccountId : volcAccountId,
+              models: providerId === 'volcengine' ? (volcModels ?? []) : undefined,
+              freeTiers: isBailian ? (bailianFreeTiers ?? undefined) : undefined,
+              cookies: isBailian ? (bailianCookies ?? undefined) : undefined
+            })
           : trimmed
       const enc = await window.api.providers.encrypt(selected.providerId, raw)
       if (!enc.encrypted) {
@@ -949,7 +966,8 @@ export function AddProviderModal({
     }
   }
 
-  // 智谱 / 火山方舟「获取 API Key」：打开对应控制台会话窗口以捕获 consoleJwt；用户在窗口内复制 API Key
+  // 智谱 / 火山方舟 / 阿里云百炼「获取 API Key」：打开对应控制台会话窗口以捕获会话/账号/免费额度；
+  // 用户在窗口内复制 API Key 后返回弹窗粘贴并保存
   const openGetApiKey = async (): Promise<void> => {
     setError(null)
     setNotice(null)
@@ -960,28 +978,49 @@ export function AddProviderModal({
       setVolcAccountId(null)
       setConsoleJwt(null)
       setVolcModels(null)
+      setBailianAccountId(null)
+      setBailianFreeTiers(null)
+      setBailianCookies(null)
       let bindId: string | null = null
-      if (providerId === 'zhipu' || providerId === 'volcengine') {
+      if (providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian') {
         bindId = crypto.randomUUID()
         setLoginTempId(bindId)
       }
-      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine'
-      // 火山方舟走独立的会话捕获入口（partition/注入与智谱隔离）
-      const volcRes = providerId === 'volcengine'
-        ? await window.api.providers.captureVolcengineSession(bindId ?? undefined)
-        : null
-      const finalRes: { ok: boolean; consoleJwt?: string; accountId?: string; models?: VolcengineCapturedModel[]; source?: 'console' | 'fallback'; error?: string } = volcRes
+      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian'
+      const isBailian = providerId === 'bailian'
+      // 火山方舟 / 百炼走独立会话捕获入口（partition/注入与智谱隔离）
+      const apiRes =
+        providerId === 'volcengine'
+          ? await window.api.providers.captureVolcengineSession(bindId ?? undefined)
+          : isBailian
+            ? await window.api.providers.captureBailianSession(bindId ?? undefined)
+            : null
+      const finalRes: { ok: boolean; consoleJwt?: string; accountId?: string | null; models?: VolcengineCapturedModel[]; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; source?: 'console' | 'fallback'; error?: string } = apiRes
         ?? (isApiProvider
           ? await window.api.providers.captureZhipuSession(bindId ?? undefined)
           : { ok: false, error: '该厂商不支持控制台会话捕获' })
       if (finalRes.ok) {
         if (finalRes.consoleJwt) setConsoleJwt(finalRes.consoleJwt)
-        if (finalRes.accountId) setVolcAccountId(finalRes.accountId)
+        if (finalRes.accountId) {
+          if (isBailian) setBailianAccountId(finalRes.accountId)
+          else setVolcAccountId(finalRes.accountId)
+        }
         // 「绑定即抓模型」：火山方舟在控制台页面抓到免费视频模型清单，提示用户并暂存随负载持久化
         if (providerId === 'volcengine' && Array.isArray(finalRes.models) && finalRes.models.length > 0) {
           const n = finalRes.models.length
           setVolcModels(finalRes.models)
           setNotice(finalRes.source === 'console' ? `已识别 ${n} 个免费视频模型（控制台抓取）` : `已识别 ${n} 个免费视频模型`)
+        }
+        // 「绑定即抓额度」：百炼在控制台抓到免费额度整表快照，提示用户并暂存随负载持久化（账号级聚合展示）
+        if (isBailian && Array.isArray(finalRes.freeTiers) && finalRes.freeTiers.length > 0) {
+          const n = finalRes.freeTiers.length
+          const total = finalRes.freeTiers.reduce((s, t) => s + (Number(t.remaining) || 0), 0)
+          setBailianFreeTiers(finalRes.freeTiers)
+          setNotice(`已捕获账号免费额度：${n} 个模型，剩余合计 ${total.toLocaleString()} 次`)
+        }
+        // 暂存百炼控制台登录 cookie：捕获成功即随负载持久化，供「进入官网」跨重启重建登录态
+        if (isBailian && Array.isArray(finalRes.cookies) && finalRes.cookies.length > 0) {
+          setBailianCookies(finalRes.cookies)
         }
       } else if (finalRes.error) {
         setError(finalRes.error)
@@ -1296,7 +1335,7 @@ export function AddProviderModal({
               <button className="btn-sm" onClick={() => void testApiKeyInput()} disabled={saving}>
                 测试 API Key
               </button>
-              {(providerId === 'zhipu' || providerId === 'volcengine') && (
+              {(providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian') && (
                 <button className="btn-sm primary" onClick={() => void openGetApiKey()} disabled={saving}>
                   获取 API Key
                 </button>

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -179,7 +179,7 @@ interface ProvidersProps {
 
 export default function Providers({ fresh, viewScope, usageScope, onBound, providers, canBind = true }: ProvidersProps) {
   const { user, team } = useAuth()
-  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, volcTokenOverrides, setKeyHealth, refreshVolcengineModelsOnce } = providers
+  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, volcTokenOverrides, bailianQuotaOverrides, setKeyHealth, refreshVolcengineModelsOnce } = providers
   const [text, setText] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -240,13 +240,13 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
     setModels(null)
     setModelsLabel(accountName)
     setModelsProviderId(providerId)
-    setModelsQuota(zhipuQuotaOverrides[keyId] ?? null)
+    setModelsQuota(providerId === 'bailian' ? (bailianQuotaOverrides[keyId] ?? null) : (zhipuQuotaOverrides[keyId] ?? null))
     setModelsUnit(unitName)
     setModelsLoading(true)
     try {
       let encrypted: string | undefined
-      // 火山方舟：取该账号密钥负载，供主进程读取每模型免费 token 额度
-      if (providerId === 'volcengine') {
+      // 火山方舟 / 阿里云百炼：取该账号密钥负载，供主进程读取每模型免费额度（火山 token / 百炼 freeTiers）
+      if (providerId === 'volcengine' || providerId === 'bailian') {
         const svc = getProviderService()
         if (svc && user) {
           const secret = await svc.getProviderKeySecret(user.id, keyId)
@@ -487,6 +487,7 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
                         onViewModels={(keyId, accountName) => handleViewModels(p.providerId, keyId, accountName, p.unitName)}
                         zhipuQuotaOverrides={zhipuQuotaOverrides}
                         volcTokenOverrides={volcTokenOverrides}
+                        bailianQuotaOverrides={bailianQuotaOverrides}
                         currentUserId={user?.id ?? ''}
                         team={team}
                       />
@@ -613,6 +614,7 @@ function ProviderRow({
   onViewModels,
   zhipuQuotaOverrides,
   volcTokenOverrides,
+  bailianQuotaOverrides,
   currentUserId,
   team
 }: {
@@ -634,15 +636,17 @@ function ProviderRow({
   onViewModels: (keyId: string, accountName: string) => Promise<void>
   zhipuQuotaOverrides: Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
   volcTokenOverrides: Record<string, { remaining: number; total: number } | null>
+  bailianQuotaOverrides: Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
   currentUserId: string
   team: { id: string } | null
 }) {
   const isApiKeyProvider = agg.authType === 'apikey'
   const activeBindings = agg.bindings.filter((b) => b.enabled)
   const totalUsed = activeBindings.reduce((s, b) => s + b.used, 0)
-  // API 型厂商：额度以平台真实资源包余额 / token 汇总为准，而非静态默认日额度；汇总只累计有可用数据的账号
+  // API 型厂商：额度以平台真实资源包余额 / token 汇总 / 账号级免费额度聚合为准，而非静态默认日额度；汇总只累计有可用数据的账号
   const isApiQuota = agg.providerId === 'zhipu'
   const isVolc = agg.providerId === 'volcengine'
+  const isBailian = agg.providerId === 'bailian'
   const quotaOf = (keyId: string) =>
     isApiQuota
       ? zhipuQuotaOverrides[keyId] && zhipuQuotaOverrides[keyId].available
@@ -652,13 +656,17 @@ function ProviderRow({
         ? volcTokenOverrides[keyId] && volcTokenOverrides[keyId]!.total > 0
           ? volcTokenOverrides[keyId]
           : undefined
-        : undefined
+        : isBailian
+          ? bailianQuotaOverrides[keyId] && bailianQuotaOverrides[keyId].available
+            ? bailianQuotaOverrides[keyId]
+            : undefined
+          : undefined
   const remaining = activeBindings.reduce(
-    (s, b) => s + (isApiQuota || isVolc ? quotaOf(b.keyId)?.remaining ?? 0 : b.remaining),
+    (s, b) => s + (isApiQuota || isVolc || isBailian ? quotaOf(b.keyId)?.remaining ?? 0 : b.remaining),
     0
   )
   const totalQuota = activeBindings.reduce(
-    (s, b) => s + (isApiQuota || isVolc ? quotaOf(b.keyId)?.total ?? 0 : b.dailyTotal),
+    (s, b) => s + (isApiQuota || isVolc || isBailian ? quotaOf(b.keyId)?.total ?? 0 : b.dailyTotal),
     0
   )
   // 火山方舟：所有启用账号都未拿到真实 token 汇总时，厂商行总计显示占位（避免展示假的 0/0 或账本日额度）
@@ -795,6 +803,13 @@ function ProviderRow({
                             // 拉取中：短暂沿用旧值避免闪烁
                             return <span>{acc.remaining} / {acc.dailyTotal} {agg.unitName}</span>
                           })()
+                        ) : agg.providerId === 'bailian' ? (
+                          (() => {
+                            const q = bailianQuotaOverrides[acc.keyId]
+                            return (
+                              <span>{q?.available ? `${q.remaining} / ${q.total} ${agg.unitName}` : '—'}</span>
+                            )
+                          })()
                         ) : (
                           `${acc.remaining} / ${acc.dailyTotal} ${agg.unitName}`
                         )}
@@ -825,7 +840,7 @@ function ProviderRow({
                         )}
                       </td>
                       <td>
-                        {!isApiKeyProvider || agg.providerId === 'zhipu' || agg.providerId === 'volcengine' ? (
+                        {!isApiKeyProvider || agg.providerId === 'zhipu' || agg.providerId === 'volcengine' || agg.providerId === 'bailian' ? (
                           <>
                             <button
                               className="btn-sm"

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -187,6 +187,8 @@ export interface ProvidersResult {
   >
   /** 火山方舟账号真实 token 汇总覆盖（keyId -> remaining/total；null 表示已拉取但未拿到真实额度） */
   volcTokenOverrides: Record<string, { remaining: number; total: number } | null>
+  /** 阿里云百炼各账号真实免费额度聚合覆盖（keyId -> 账号级剩余/总量），随绑定时的控制台会话捕获落库 */
+  bailianQuotaOverrides: Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
   /** 火山方舟额度同步：后台静默抓取该账号最新免费模型额度/开通状态并落库；命中返回新加密负载，未抓到返回 false */
   refreshVolcengineModelsOnce: (keyId: string, opts?: { maxStaleMs?: number }) => Promise<string | false>
 }
@@ -210,6 +212,10 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
   // 值为 null 表示已拉取但未拿到真实 token 汇总（用于展示占位，避免误显示账本假额度 50/50）。
   const [volcTokenOverrides, setVolcTokenOverrides] = useState<
     Record<string, { remaining: number; total: number } | null>
+  >({})
+  // 阿里云百炼各账号真实免费额度聚合覆盖（keyId -> 账号级剩余/总量），随绑定时的控制台会话捕获落库
+  const [bailianQuotaOverrides, setBailianQuotaOverrides] = useState<
+    Record<string, { available: boolean; total: number; remaining: number; expired?: boolean }>
   >({})
 
   // 单次拉取智谱某账号真实额度（平台资源包余额）并写入覆盖；返回剩余次数（查询失败返回 null）
@@ -403,6 +409,27 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     [user]
   )
 
+  // 单次拉取阿里云百炼某账号真实免费额度聚合（payload 中的账号级快照）并写入覆盖；未取到返回 false
+  const fetchBailianQuotaOnce = useCallback(
+    async (keyId: string): Promise<boolean> => {
+      const svc = getProviderService()
+      if (!svc || !user) return false
+      try {
+        const secret = await svc.getProviderKeySecret(user.id, keyId)
+        if (!secret) return false
+        const res = await window.api.providers.fetchQuota('bailian', secret.encrypted_key)
+        if (res.ok && res.quota) {
+          setBailianQuotaOverrides((prev) => ({ ...prev, [keyId]: res.quota! }))
+          return true
+        }
+        return false
+      } catch {
+        return false
+      }
+    },
+    [user]
+  )
+
   // 对单个火山账号做一次静默续期：成功则用新加密负载落库并重拉真实额度；全局一次只续一个（共享会话分区）
   const renewVolcSessionOnce = useCallback(
     async (keyId: string, encrypted: string): Promise<boolean> => {
@@ -515,6 +542,14 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     if (volcKeys.length === 0) return
     volcKeys.forEach((key) => void fetchVolcTokenSummaryOnce(key.id))
   }, [user?.id, keys, fetchVolcTokenSummaryOnce])
+
+  // 初始化 / 刷新时主动拉取阿里云百炼各账号真实免费额度聚合（payload 账号级快照）
+  useEffect(() => {
+    if (!user || keys.length === 0) return
+    const bailianKeys = keys.filter((k) => k.provider_id === 'bailian')
+    if (bailianKeys.length === 0) return
+    bailianKeys.forEach((key) => void fetchBailianQuotaOnce(key.id))
+  }, [user?.id, keys, fetchBailianQuotaOnce])
 
   // 会话内覆盖某账号健康状态（API Key 测试成功/失败后即时反映，不落库）
   const setKeyHealth = useCallback((keyId: string, status: string) => {
@@ -902,6 +937,7 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     zhipuSessionStatuses,
     volcSessionStatuses,
     volcTokenOverrides,
+    bailianQuotaOverrides,
     refreshVolcengineModelsOnce
   }
 }

--- a/docs/厂商与API平台接入/阿里云百炼接入方案.md
+++ b/docs/厂商与API平台接入/阿里云百炼接入方案.md
@@ -90,7 +90,7 @@
 2. `decodeBailianPayload(decrypted): { apiKey; consoleJwt? }`——与 `decodeZhipuPayload` 同构，兼容纯 key 旧格式。导出。
 3. `testBailianApiKey(apiKey): Promise<{ok; error?}>`——调 §5.3 只读校验。导出。
 4. `bailianAccountFingerprint(payload): Promise<string|null>`——有 WorkspaceId（或账号标识）时按账号指纹；否则回退 key 哈希。导出。
-> 额度函数（`fetchBailianQuota`）与 WorkspaceId 探测本期不做，注释预留。
+> 会话捕获升级（2026-08-20）后，该文件已补 `parseBailianFreeTierPayload`、`aggregateBailianFreeQuota`，账户级指纹走 payload `accountId`，见 §5.9。
 
 ### 5.3 测试 Key 只读校验路径（开放风险，实施时实测定稿）
 候选（需 curl 实测区分 401/404/200）：
@@ -105,7 +105,7 @@
 1. import `testBailianApiKey`、`bailianAccountFingerprint`。
 2. `provider:encrypt`：在 zhipu/volcengine 分支旁加 `providerId === 'bailian' ? await bailianAccountFingerprint(plain):...`。
 3. `provider:test-api-key`：按 `_providerId` 路由加 `bailian → testBailianApiKey`。
-4. （后续迭代）`provider:fetch-quota` 按 `_providerId` 路由 `bailian`；本轮走 `daily_total` 兜底，不新增。
+4. （会话捕获升级，已实施）`provider:fetch-quota` 按 `_providerId` 路由 `bailian`：由 payload `freeTiers` 聚合返回；`provider:capture-bailian-session` 捕获账号 + 免费额度整表。见 §5.9。
 
 ### 5.6 渲染层 `apps/desktop/src/renderer/src/components/Modals.tsx`
 复用 `saveApiKey`，仅把 `(providerId === 'zhipu' || providerId === 'volcengine') && consoleJwt` 的兜底分支扩展为 `bailian`（本期无 consoleJwt，纯 apikey 保存）。去重提示逻辑无需改（换指纹）。
@@ -117,6 +117,40 @@
 ### 5.8 账号明细/额度展示
 - `Providers.tsx` L420 `isApiQuota` 展示分支从 `zhipu`/`volcengine` 扩为含 `bailian`；额度单位/默认日额度/等效除数字段对 apikey 厂商隐藏（bailian 同 zhipu）。
 - 本期无真实额度接口 → 展示走 `daily_total` 本地账本（与智谱 cogvideox-flash 现状一致），UI 不做「— 未知」特殊态。
+
+**（已升级）** §5.8 的「无真实额度」已在 2026-08-20 完成的**会话捕获升级**中解决，展示改为账号级聚合总额，见 §5.9。
+
+### 5.9 会话捕获升级（已实施 2026-08-20）：去重 + 额度一起
+实现范围：**绑定 + 去重 + 真实额度（账号级聚合总额）**。免费额度为一次性 90 天、按模型独立、按阿里云账号共享，故用**账号 PK** 做去重键、按**账号级聚合总额**做展示口径。
+
+**payload 结构升级**（原先纯 API Key → 结构化 JSON，随 `safeStorage` 加密落库）：
+```json
+{ "v": 1, "apiKey": "<sk-...>", "accountId": "<阿里云账号PK>",
+  "freeTiers": [ { "model": "wan2.7-t2v-2026-06-12", "total": 20, "remaining": 4, "expired": false, "expiredAtMs": <ms>, "status": "VALID" } ] }
+```
+
+**改动清单**：
+1. `packages/providers/src/bailian.ts`：`decodeBailianPayload` 兼容 `accountId/freeTiers`；`bailianAccountFingerprint` 有 `accountId` 时按账号级指纹（`bailian-account:<PK>`）否则退化 key 哈希；`parseBailianFreeTierPayload`（宽松多字段解析响应/缓存整表）+ `aggregateBailianFreeQuota`（账号级聚合剩余/总量）。
+2. 主进程 `apps/desktop/src/main/providers.ts`：
+   - `captureBailianConsoleSession`（静默/显式）：**双窗口**——主窗口落 API Key 管理页（用户熟悉，登录并复制 Key）；隐藏捕获窗口落免费额度页 modelType=Vision，与主窗口**同一 partition 共用登录态**，页面 SDK 自动计算 sec_token 并发起 `queryFreeTierQuotaAsyn`，注入脚本 hook fetch/XHR + 兜底扫 localStorage `free_quota_*` 缓存，自动抓到额度快照（用户无需手动切页）；登录前捕获窗口周期 reload 以在登录后带 cookie 重请求。
+   - `provider:capture-bailian-session`：调捕获内核并把 `freeTiersRaw` 经 `parseBailianFreeTierPayload` 归一化返回。
+   - `provider:fetch-quota`：`bailian` 分支直接由 payload `freeTiers` 聚合返回（无需网络，快照驱动）。
+   - 诊断日志 `[qf-bailian] ENC fp_level=account|key-hash`、`CAPTURE parsed ...` 打印到控制台。
+3. 渲染层 `useProviders`：`bailianQuotaOverrides`（keyId → 聚合）；`fetchBailianQuotaOnce` 初始化/刷新拉取；`Modals` 绑定流程接入 `captureBailianSession`，保存时并入 `accountId/freeTiers` 进 payload，提供「已捕获账号免费额度：N 个模型，剩余合计 X 次」提示。Dashboard / Providers 厂商行与账号明细按账号级聚合总额展示。
+4. preload：新增 `captureBailianSession` + `BailianFreeTier` 类型。
+
+> 说明：免费额度为一次性 90 天快照，额度展示读的是绑定时所捕获快照；如需刷新可重跑捕获。真实生成计费不在此快照内扣减（百炼 gen 走后续迭代）。
+
+### 5.10 「进入官网」登录态跨重启持久化（已实施 2026-08-20）⚠️注意点
+- **现象**：绑定「获取 API Key」登录后，当场点「进入官网」正常；但重启桌面端后再点「进入官网」掉登录，需重新登录。
+- **根因**：控制台登录态依赖 `persist:qf-bailian-console:<keyId>` 持久分区的 cookie。其中**真正的登录票据（`login_aliyunid_ticket`、`sec_token` 等）是会话型 cookie，应用重启后分区会话数据被丢弃**，仅剩 `login_aliyunid_pk/id/current_pk` 等非票据 cookie，不足以保持登录。只靠持久分区不足，必须把登录 cookie 随账号加密负载一并持久化。
+- **方案（三层）**：
+  1. 绑定捕获（`captureBailianConsoleSession`）成功后，用 `collectBailianConsoleCookies(keyId)` 读该账号控制台分区的全部 cookie，随捕获结果返回渲染层，保存时并入负载 `cookies` 字段落库。
+  2. `openProviderSite` 百炼分支：打开官网前用 `decodeBailianPayload(encrypted)` 读出负载 `cookies`，`injectBailianConsoleCookies(keyId, cookies)` 重新注入到该账号控制台分区，重建登录态（只补缺、不覆盖目标分区已有 cookie）。每次「进入官网」都注入，故会话型 cookie 即便重启不存盘也能恢复。
+  3. **兜底**（防渲染层丢 cookies）：主进程在捕获时按 `accountId` 缓存最近一次 cookies（`bailianCapturedCookies`）；`provider:encrypt` 加密百炼负载时若发现负载无 `cookies` 且缓存命中，自动合并再加密，保证登录 cookie 一定随负载落库。实测负载 cookie=39。
+- **第 2 层依赖分区名一致**：绑定捕获与「进入官网」都必须用同一 `bailianConsolePartitionFor(keyId)`（`persist:qf-bailian-console:<keyId>`），`keyId` = 该账号 provider key 的记录 id（新绑定 = 绑定时的临时 id）。
+- **payload 扩展**：`{v,apiKey,accountId,freeTiers,cookies?}`，`cookies` 为 `[{name,value,domain?,path?,httpOnly?,secure?,expires?}]`。
+- **调试日志**：`[qf-bailian] CAPTURE cookies=N`（绑定抓到数）、`[qf-bailian] OPEN-SITE-INJECT payloadCookies=A before=B after=C`（打开官网时负载/注入前后分区 cookie 数）、`[qf-bailian] ENC mergeCapturedCookies`（兜底合并生效）。判断要点：`payloadCookies=0` 说明 cookie 未落库，问题在保存环节；>0 但登录仍失败才需怀疑注入或登录态本身。
 
 ---
 

--- a/packages/providers/src/bailian.ts
+++ b/packages/providers/src/bailian.ts
@@ -1,13 +1,14 @@
 // 阿里云百炼（Model Studio）API Key 型厂商适配器
 //
-// 本轮只实现「绑定」所需的能力（API Key 校验、账号级指纹、payload 解码），额度/视频生成延后：
+// API Key 型（apikey），会话捕获/真实免费额度（控制台 costing-balance 页）复用智谱/火山内核：
 //   - 数据面为 Bearer Token 鉴权（Authorization: Bearer <sk-api-key> + X-DashScope-Async: enable），
 //     与智谱/火山同为 API Key 型，见 docs/厂商与API平台接入/阿里云百炼接入方案.md §3.2。
-//   - 真实免费额度在百炼控制台 costing-balance/free-quota 页（按业务空间维度，见方案 §3.3），API Key
-//     能否直读需实测；不可时走控制台会话捕获（复用智谱/火山会话内核）作为后续迭代，本期实际额度走每日账本 daily_total。
-//   - decodeBailianPayload 与智谱同构（兼容纯 key 旧格式）：{v:1,apiKey,consoleJwt}。
+//   - 真实免费额度在百炼控制台 costing-balance/free-quota 页（按阿里云账号维度，见方案 §3.3/§6.1），
+//     API Key 无法携带控制台会话 sec_token，故不可由本文件直连，需走桌面端 captureBailianConsoleSession
+//     捕获内核拿到 accountId + freeTierQuotas 快照，随加密 payload 落库。
+//   - decodeBailianPayload 与智谱同构（兼容纯 key 旧格式）：{v:1,apiKey,consoleJwt?,accountId?,freeTiers?}。
 //
-// 日志埋点统一前缀 [qf-bailian]（含 test / fp 子阶段，便于排障）。
+// 日志埋点统一前缀 [qf-bailian]（含 test / fp / free-tier 子阶段，便于排障）。
 
 import { createHash } from "node:crypto";
 
@@ -22,13 +23,64 @@ export const BAILIAN_TASK_BASE_URL = "https://dashscope.aliyuncs.com/api/v1/task
 export const BAILIAN_CONSOLE_URL = "https://bailian.console.aliyun.com/cn-beijing?tab=api#/api-key";
 
 /**
+ * 阿里云百炼免费额度单模型条目（捕获快照，供聚合展示）。
+ * 字段与 control console 实测响应对齐（见方案 §6.1）：
+ *   quotaTotal            剩余额度         （×quotaTotalPercentage%）
+ *   quotaInitTotal        初始免费额度
+ *   quotaTotalPercentage  剩余百分比（100=满）
+ *   quotaValidityPeriod   过期时间戳 ms
+ *   quotaStatus           VALID / UNKNOWN（无免费额度，或带日期版才有）
+ */
+export interface BailianFreeTierSlim {
+  /** 模型名，如 wan2.7-t2v-2026-06-12 */
+  model: string;
+  /** 初始免费额度 */
+  total: number;
+  /** 剩余额度 */
+  remaining: number;
+  /** 是否已过期 */
+  expired: boolean;
+  /** 过期时间戳 ms，无则 null */
+  expiredAtMs: number | null;
+  /** 原始状态：VALID / UNKNOWN */
+  status: string;
+}
+
+/** 账号级聚合免费额度（账号维度展示口径，见方案 §6.1）。 */
+export interface BailianFreeQuota {
+  /** 是否抓到至少一条有效视频额度 */
+  available: boolean;
+  /** 聚合剩余 */
+  remaining: number;
+  /** 聚合初始总量 */
+  total: number;
+  /** 是否有任一条已过期（提示用户） */
+  expired: boolean;
+}
+
+/** 百炼控制台登录 cookie（随加密负载持久化，供「进入官网」在 persist 分区丢失会话后重新注入以重建登录态）。 */
+export interface BailianStoredCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  httpOnly?: boolean;
+  secure?: boolean;
+  /** 过期时间戳 ms；0 表示会话 cookie */
+  expires?: number;
+}
+
+/**
  * 解阿里云百炼加密负载（兼容多种格式）：
- * - 新版：{ v: 1; apiKey: string; consoleJwt?: string | null } JSON 字符串
+ * - 新版：{ v:1; apiKey:string; consoleJwt?; accountId?; freeTiers?; cookies? } JSON 字符串
  * - 旧版：纯 API Key 字符串（非 `{` 开头）
  */
 export function decodeBailianPayload(decrypted: string): {
   apiKey: string;
   consoleJwt?: string | null;
+  accountId?: string | null;
+  freeTiers?: BailianFreeTierSlim[] | null;
+  cookies?: BailianStoredCookie[] | null;
 } {
   const trimmed = (decrypted ?? "").trim();
   if (!trimmed.startsWith("{")) return { apiKey: trimmed };
@@ -37,8 +89,9 @@ export function decodeBailianPayload(decrypted: string): {
       v?: number;
       apiKey?: string;
       consoleJwt?: string | null;
-      // 兼容后续会话捕获写入的占位字段（本轮为空）
-      workspaceId?: string | null;
+      accountId?: string | null;
+      freeTiers?: BailianFreeTierSlim[] | null;
+      cookies?: BailianStoredCookie[] | null;
     };
     const apiKey = parsed.apiKey?.trim() ?? "";
     let consoleJwt = parsed.consoleJwt ?? null;
@@ -47,7 +100,13 @@ export function decodeBailianPayload(decrypted: string): {
         consoleJwt = decodeURIComponent(consoleJwt);
       } catch {}
     }
-    return { apiKey, consoleJwt };
+    return {
+      apiKey,
+      consoleJwt,
+      accountId: typeof parsed.accountId === "string" ? parsed.accountId : null,
+      freeTiers: Array.isArray(parsed.freeTiers) ? parsed.freeTiers : null,
+      cookies: Array.isArray(parsed.cookies) ? parsed.cookies : null,
+    };
   } catch {
     return { apiKey: trimmed };
   }
@@ -62,23 +121,121 @@ function fingerprintFor(providerId: string, raw: string): string {
 
 /**
  * 阿里云百炼账号级指纹。
- * 百炼免费额度按「业务空间（WorkspaceId）」与阿里云账号维度划分，AccountId/Workspace 为更优去重键；
- * 但本期未接控制台会话（拿不到 WorkspaceId），按 API Key 明文哈希回退（与智谱 customerId 兜底策略一致）。
- * payload 为「加密前明文」，可能是 `{v:1,apiKey,consoleJwt}` 或纯 API Key。
+ * 免费额度按「阿里云账号」维度共享（主账号与 RAM 子账号、全国业务空间共享），权威去重键为账号 PK；
+ * payload 携带 accountId（捕获内核从控制台取得）时按账号指纹，否则回退 API Key 明文哈希（同智谱 customerId 兜底）。
+ * payload 为「加密前明文」，可能是 `{v:1,apiKey,accountId,...}` 或纯 API Key。
  */
 export async function bailianAccountFingerprint(payload: string): Promise<string | null> {
-  const { apiKey } = decodeBailianPayload(payload);
+  const { apiKey, accountId } = decodeBailianPayload(payload);
   if (!apiKey) return null;
-  // TODO: 后续接入控制台会话（costing-balance）后可从中解析 WorkspaceId，按
-  //     fingerprintFor("bailian", "bailian-account:" + workspaceId) 生成账号级指纹，对齐智谱 customerId 策略。
+  if (accountId) return fingerprintFor("bailian", "bailian-account:" + accountId);
   return fingerprintFor("bailian", apiKey);
 }
 
+/** 深度遍历 JSON，返回第一个「自由命名」的模型额度和数组（宽松找 freeTierQuotas，兼容字段命名差异）。 */
+function deepFindFreeTierQuotas(node: unknown): Array<Record<string, unknown>> | null {
+  if (node && typeof node === "object") {
+    if (Array.isArray(node)) {
+      for (const it of node) {
+        const hit = deepFindFreeTierQuotas(it);
+        if (hit) return hit;
+      }
+      return null;
+    }
+    const obj = node as Record<string, unknown>;
+    // 命中「数组且元素含模型标识字段」即视为 freeTierQuotas 容器
+    for (const k of Object.keys(obj)) {
+      const v = obj[k];
+      if (Array.isArray(v)) {
+        const first = v[0];
+        if (
+          first &&
+          typeof first === "object" &&
+          !Array.isArray(first) &&
+          (typeof (first as Record<string, unknown>).model === "string" ||
+            typeof (first as Record<string, unknown>).quotaTotal !== "undefined")
+        ) {
+          return v as Array<Record<string, unknown>>;
+        }
+      }
+      const hit = deepFindFreeTierQuotas(v);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
 /**
- * 校验阿里云百炼 API Key 是否有效（不产生任何生成费用）：
+ * 解析百炼控制台真实免费额度响应文本 → 归一化条目列表。
+ * 来自 captureBailianConsoleSession 捕获的 queryFreeTierQuotaAsyn 响应（或页面 localStorage 缓存整表）。
+ * 采用「宽松多字段」容错读取：任意字段缺失时以 0/未知兜底，避免抓到的响应字段与文档有出入就整条丢弃。
+ */
+export function parseBailianFreeTierPayload(
+  text: string,
+  nowMs: number = Date.now(),
+): BailianFreeTierSlim[] | null {
+  if (typeof text !== "string" || !text) return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const arr = deepFindFreeTierQuotas(json);
+  if (!arr || arr.length === 0) return null;
+  const out: BailianFreeTierSlim[] = [];
+  for (const it of arr) {
+    const model = String(it.model ?? it.Model ?? "");
+    if (!model) continue;
+    const total = Number(it.quotaInitTotal ?? it.initQuota ?? it.total ?? 0) || 0;
+    const remaining = Number(it.quotaTotal ?? it.remaining ?? it.balance ?? total) || 0;
+    const expiredAtMsRaw = Number(it.quotaValidityPeriod ?? it.expiry ?? 0) || 0;
+    const expiredAtMs = expiredAtMsRaw > 0 ? expiredAtMsRaw : null;
+    const status = String(it.quotaStatus ?? it.status ?? (remaining > 0 ? "VALID" : "UNKNOWN"));
+    const expired = expiredAtMs !== null ? expiredAtMs <= nowMs : remaining <= 0;
+    out.push({
+      model,
+      total,
+      remaining,
+      expired,
+      expiredAtMs,
+      status,
+    });
+  }
+  return out.length > 0 ? out : null;
+}
+
+/** 账号级聚合：把多模型免费额度汇总为单一「剩余/总量」，供账号明细口径展示。 */
+export function aggregateBailianFreeQuota(
+  tiers: BailianFreeTierSlim[] | null | undefined,
+): BailianFreeQuota {
+  if (!tiers || tiers.length === 0) {
+    return { available: false, remaining: 0, total: 0, expired: false };
+  }
+  let total = 0;
+  let remaining = 0;
+  let expired = false;
+  for (const t of tiers) {
+    total += t.total;
+    remaining += Math.max(0, t.remaining);
+    if (t.expired) expired = true;
+  }
+  return { available: true, remaining, total, expired };
+}
+
+/** 视频生成模型判定：阿里云百炼 Vision 缓存里含大量图片/嵌入/检测类模型，展示时需只保留视频生成模型。
+ * 2026-08-20 实测 Vision free_quota 缓存命名规范：视频模型含 t2v/i2v/r2v/kf2v/it2v/2video/video/
+ * videoretalk/liveportrait/animate-anyone/start-end 等特征；图片类（qwen-image、*t2i、*2image 等）均不含这些特征。
+ */
+const BAILIAN_VIDEO_MODEL_PATTERN =
+  /(t2v|i2v|r2v|kf2v|it2v|a2v|2video|videoretalk|liveportrait|animate-anyone|start-end)/i;
+export function isBailianVideoFreeModel(model: string): boolean {
+  return BAILIAN_VIDEO_MODEL_PATTERN.test(model || "");
+}
+
+/** 校验阿里云百炼 API Key 是否有效（不产生任何生成费用）：
  * 请求一个不存在的只读任务查询端点，用状态码区分鉴权——无效 key 返回 401，有效 key 返回业务错误(404 等)。
  * 仅把 401 视为"无效"，其余 HTTP 响应视为鉴权已通过（Key 有效）。
- * ⚠️ 探测端点待实测确认（见方案 §5.3）；若该域对该格式请求行为异常，按 401 之外均视有效即可。
  */
 export async function testBailianApiKey(
   apiKey: string,
@@ -86,7 +243,6 @@ export async function testBailianApiKey(
   const key = (apiKey ?? "").trim();
   if (!key) return { ok: false, error: "请先输入 API Key" };
   try {
-    // 用一个不可能存在的任务 id 触发查询：有效 key 不会因此扣费，且能区分鉴权是否通过
     const res = await fetch(`${BAILIAN_TASK_BASE_URL}/qf-invalid-key-check-nonexistent`, {
       method: "GET",
       headers: { Authorization: `Bearer ${key}` },


### PR DESCRIPTION
## 修改内容

### 1. API Branch 架构
- api-branch.ts：新增 bailian 分支，支持阿里云百炼生成模式
- providers.ts：新增 bailian 相关 IPC 处理（captureSession/encrypt/healthCheck）

### 2. 前端 UI 适配
- Providers.tsx：新增阿里云百炼账号绑定入口
- Modals.tsx：新增阿里云百炼 API Key 输入弹窗
- Dashboard.tsx：新增阿里云百炼任务状态展示
- useProviders.ts：新增阿里云百炼数据加载
- preload/index.ts：新增 bailian IPC 桥接

### 3. Provider 实现增强
- bailian.ts：完善阿里云百炼 API 适配（额度查询、生成、轮询）

### 4. 文档更新
- 阿里云百炼接入方案.md 更新