### PR TITLE
feat: 音频参考裁剪弹窗 + 百炼音视频生成增强 + Dashboard 重构

### DIFF
--- a/apps/desktop/src/main/api-branch.ts
+++ b/apps/desktop/src/main/api-branch.ts
@@ -16,6 +16,7 @@ import {
   decodeVolcenginePayload,
   decodeBailianPayload,
   isBailianVideoFreeModel,
+  bailianModelCap,
   bailianGenerateWithKey,
   bailianVideoImageCount,
   fetchZhipuQuota,
@@ -52,6 +53,10 @@ export interface ApiGenerateParams {
   prompt: string
   /** 图片 https URL（单图或数组，按模型能力透传 image_url） */
   images?: string[]
+  /** 参考生（r2v）视频 https URL 数组（bailian 等模型合入 input.media reference_video） */
+  videos?: string[]
+  /** 文生视频音频参考的 https URL（bailian 等模型透传 input.audio_url） */
+  audioUrl?: string
   durationSec: number
   /** 生成过程实时回调（限流重试等），供调度台推送 UI 提示 */
   onProgress?: (message: string) => void
@@ -343,7 +348,7 @@ const BAILIAN_VIDEO_MODELS: Array<{
     model: 'wan2.7-r2v-2026-06-12',
     type: 'r2v',
     free: true,
-    durations: [5],
+    durations: [5, 10],
     priceLabel: '免费',
     cost: 0,
     modes: [{ value: 'multi_ref', label: '参考生视频' }]
@@ -367,7 +372,8 @@ function makeBailianBranch(): ApiGenerationBranch {
       return BAILIAN_VIDEO_MODELS.find((m) => m.model === model)?.cost ?? 1
     },
     supportedDurations(model = 'wan2.7-t2v-2026-06-12') {
-      return BAILIAN_VIDEO_MODELS.find((m) => m.model === model)?.durations ?? [5]
+      // 时长档位以 bailianModelCap 的能力卡为准（含 r2v 参考生支持 5/10s），与「查看模型」目录口径一致
+      return bailianModelCap(model).durations
     },
     async remaining() {
       // 真实按次免费额度随账号 payload freeTiers 快照展示；此处返回 null 表示未知（不做公开 API 实时查询）。
@@ -385,14 +391,15 @@ function makeBailianBranch(): ApiGenerationBranch {
         const live = tiers.filter((t) => isBailianVideoFreeModel(t.model) && !t.expired)
         if (live.length > 0) {
           return live.map((t) => {
-            const meta = BAILIAN_VIDEO_MODELS.find((m) => m.model === t.model)
+            // 能力按官方命名归纳（文生/图生/参考/关键帧/检测/专用），免费额度项本身免费
+            const cap = bailianModelCap(t.model)
             return {
               model: t.model,
-              priceLabel: meta?.priceLabel ?? '免费',
-              cost: meta?.cost ?? 0,
-              durations: meta?.durations ?? [5],
+              priceLabel: '免费',
+              cost: 0,
+              durations: cap.durations,
               size: null,
-              modes: meta?.modes ?? [{ value: 'text2video', label: '文生视频' }],
+              modes: cap.modes,
               activated: true,
               freeQuota: { remaining: t.remaining, total: t.total }
             }
@@ -412,15 +419,24 @@ function makeBailianBranch(): ApiGenerationBranch {
     },
     async generate(input, creds, params) {
       const imgs = (params.images ?? []).filter((u) => /^https?:\/\//i.test(u))
+      const vids = (params.videos ?? []).filter((u) => /^https?:\/\//i.test(u))
       const needed = bailianVideoImageCount(params.mode)
-      if (needed > 0 && imgs.length < needed) {
+      // 参考生（multi_ref）：实测当前 r2v 快照 image.media[] 仅收图片格式、不收 mp4，
+      // 故需至少 1 张图片；不再允许仅上传视频（视频入口已从前端移除）。
+      const needOk =
+        params.mode === 'multi_ref'
+          ? imgs.length >= 1
+          : needed > 0
+            ? imgs.length >= needed
+            : true
+      if (!needOk) {
         return {
           ok: false,
           error:
             needed === 2
               ? '首尾帧生成需要上传首帧和尾帧共 2 张图片'
               : params.mode === 'multi_ref'
-                ? '参考生视频需要至少上传 1 张参考图'
+                ? '参考生视频需要至少上传 1 张参考图或参考视频'
                 : '图生视频需要至少上传 1 张首帧图片'
         }
       }
@@ -440,10 +456,12 @@ function makeBailianBranch(): ApiGenerationBranch {
         model: params.model,
         prompt,
         images: imgs,
+        videos: vids,
         durationSec: params.durationSec,
         resolution: input.resolution,
         ratio: input.ratio,
-        audio: input.audio === 'off' ? 'off' : 'on'
+        audio: input.audio === 'off' ? 'off' : 'on',
+        promptAudioUrl: params.audioUrl
       }
       const r = await bailianGenerateWithKey(creds.apiKey, opts, params.onProgress)
       return {
@@ -600,19 +618,24 @@ export function registerApiIpc(): void {
         const { freeTiers } = decodeBailianPayload(plain)
         const models: ApiModelInfo[] = (freeTiers ?? [])
           .filter((t) => isBailianVideoFreeModel(t.model) && !t.expired)
-          .map((t) => ({
-            model: t.model,
-            priceLabel: '免费',
-            cost: 0,
-            durations: [5],
-            size: null,
-            modes: [{ value: 'text2video', label: '文生视频' }],
-            activated: true,
-            freeQuota: {
-              remaining: t.remaining,
-              total: t.total
+          .map((t) => {
+            // 按模型名归纳实际能力（文生/图生/参考/关键帧/检测/专用），替换旧的「统一文生视频」口径
+            const cap = bailianModelCap(t.model)
+            return {
+              model: t.model,
+              priceLabel: '免费',
+              cost: 0,
+              durations: cap.durations,
+              size: null,
+              // direct 模型给出可选择模式；检测/专用模型 modes 为空，仅展示能力名（弹窗用 note 呈现）
+              modes: cap.modes,
+              activated: true,
+              ...(cap.direct
+                ? { freeQuota: { remaining: t.remaining, total: t.total } }
+                : {}),
+              ...(cap.direct ? {} : { unavailableLabel: cap.label, unavailable: 'no_endpoint' as const })
             }
-          }))
+          })
         return { ok: true, models }
       } catch {
         return { ok: false, error: '解析百炼免费额度失败' }

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -42,6 +42,14 @@ export interface GenerateInput {
   images?: string[]
   /** 厂商 API 用的参考图公网 https URL（仅 API 型厂商上传；历史展示不依赖它） */
   imageUrls?: string[]
+  /** 参考生（r2v）本地视频参考副本：本地路径会复制到 userData/videos 供历史回显 */
+  videos?: string[]
+  /** 参考生（r2v）公网 https 视频 URL 数组（bailian 等合入 input.media reference_video） */
+  videoUrls?: string[]
+  /** 文生视频音频参考的公网 https URL（bailian 等透传 input.audio_url） */
+  audioUrl?: string
+  /** 音频本地副本路径（历史回显/重新生成回填）；公网 http(s) URL 原样保留 */
+  audioLocalPath?: string
   /** 测试开关：显示豆包 WebView 窗口（默认隐藏） */
   showWebview?: boolean
 }
@@ -131,6 +139,32 @@ function persistJobImages(images: string[], jobId: string): string[] {
     } catch {}
   }
   return jobImages
+}
+
+/**
+ * 参考生（r2v）参考视频本地副本持久化为历史上存储（供历史详情回显，不依赖外网）：
+ *  - 本地路径 → 复制一份到 userData/videos 存本地路径；
+ *  - http(s) 公网 URL → 原样保留。
+ * 沿用 persistJobImages 模式，仅扩展名为 mp4 时走视频目录。
+ */
+function persistJobVideos(videos: string[], jobId: string): string[] {
+  const jobVideos: string[] = []
+  if (!videos || videos.length === 0) return jobVideos
+  const videoDir = join(app.getPath('userData'), 'videos')
+  mkdirSync(videoDir, { recursive: true })
+  for (let i = 0; i < videos.length; i++) {
+    const vid = videos[i]
+    try {
+      if (/^https?:\/\//i.test(vid)) {
+        jobVideos.push(vid)
+        continue
+      }
+      const dest = join(videoDir, `${jobId}-${i}.mp4`)
+      copyFileSync(vid, dest)
+      jobVideos.push(dest)
+    } catch {}
+  }
+  return jobVideos
 }
 
 /** 下载视频到 userData/videos/<jobId>.mp4（生成后立即落盘，避免签名 URL 过期） */
@@ -667,12 +701,18 @@ async function runApiBranch(
 
   // 图片本地副本随任务持久化，历史详情离线回显；公网 http(s) URL 原样保留（兼容旧记录）
   const jobImages = persistJobImages(input.images ?? [], job.id)
+  // 参考生（r2v）参考视频本地副本随任务持久化，历史详情离线回显；公网 http(s) URL 原样保留
+  const jobVideos = persistJobVideos(input.videos ?? [], job.id)
   const jobOptions: Record<string, unknown> = {
     mode: input.mode,
     model,
     durationSec: input.durationSec
   }
   if (jobImages.length > 0) jobOptions.images = jobImages
+  if (jobVideos.length > 0) jobOptions.videos = jobVideos
+  // 音频本地副本/公网 URL 记录进 options，历史回显与重新生成回填用（本地路径与公网 URL 均原样保留）
+  if (input.audioLocalPath) jobOptions.audioLocalPath = input.audioLocalPath
+  if (input.audioUrl) jobOptions.audioUrl = input.audioUrl
 
   // 按厂商把密钥过滤下推到 SQL，只回传该厂商行，避免整表拉取 encrypted_key 大字段
   const keys = input.teamId
@@ -783,6 +823,9 @@ async function runApiBranch(
     prompt: input.prompt,
     // 图生/首尾/参考生图片为前端上传后的公网 https URL（imageUrls）；厂商不依赖历史本地展示路径
     images: input.imageUrls ?? input.images ?? [],
+    // 参考生（r2v）视频为前端上传后的公网 https URL（videoUrls）；厂商不依赖历史本地展示路径
+    videos: input.videoUrls ?? input.videos ?? [],
+    audioUrl: input.audioUrl,
     durationSec: input.durationSec,
     onProgress: (msg) => emit({ jobId: job.id, status: 'running', stage: 'progress', message: msg })
   }
@@ -811,9 +854,9 @@ async function runApiBranch(
       completedAt: new Date().toISOString()
     })
     emit({ jobId: job.id, status: 'failed', message: err })
-    // 生成失败也延迟清理参考图公网 URL：厂商已不会再拉取，避免残留撑大 GitHub 仓库
+    // 生成失败也延迟清理参考图/音频公网 URL：厂商已不会再拉取，避免残留撑大 GitHub 仓库
     setTimeout(() => {
-      void deleteImages(input.imageUrls ?? []).catch(() => {})
+      void deleteImages([...(input.imageUrls ?? []), ...(input.audioUrl ? [input.audioUrl] : [])]).catch(() => {})
     }, 10 * 60 * 1000)
     return { ok: false, jobId: job.id, error: err }
   }
@@ -850,10 +893,10 @@ async function runApiBranch(
     data: { resultUrl, cost, localPath, accountId: cand.id }
   })
 
-  // 参考图公网 URL 仅供生成瞬间给厂商拉取；生成成功后延迟清理，避免日积月累撑大 GitHub 仓库。
+  // 参考图/音频公网 URL 仅供生成瞬间给厂商拉取；生成成功后延迟清理，避免日积月累撑大 GitHub 仓库。
   // 本地历史副本（userData/images）不受影响；延迟给用户留出「成功后再点一次生成」的窗口。
   setTimeout(() => {
-    void deleteImages(input.imageUrls ?? []).catch(() => {})
+    void deleteImages([...(input.imageUrls ?? []), ...(input.audioUrl ? [input.audioUrl] : [])]).catch(() => {})
   }, 10 * 60 * 1000)
 
   // 火山方舟生成成功 → 自愈清除该模型的历史不可用标记（平台恢复可用即重新放行）

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -84,6 +84,41 @@ function startMediaServer(): Promise<number> {
       }
       const server = createServer((req, res) => {
         const path = (req.url || '').split('?')[0]
+        // 参考生（r2v）参考视频副本：userData/videos/<jobId>-<i>.mp4，Range 支持
+        const serveVideo = (file: string): void => {
+          if (!existsSync(file)) {
+            res.writeHead(404)
+            res.end()
+            return
+          }
+          const size = statSync(file).size
+          res.setHeader('Content-Type', 'video/mp4')
+          res.setHeader('Accept-Ranges', 'bytes')
+          const range = req.headers.range
+          if (range) {
+            const m = /bytes=(\d*)-(\d*)/.exec(range)
+            const start = m && m[1] ? parseInt(m[1], 10) : 0
+            const end = m && m[2] ? parseInt(m[2], 10) : size - 1
+            res.writeHead(206, {
+              'Content-Range': `bytes ${start}-${end}/${size}`,
+              'Content-Length': end - start + 1
+            })
+            createReadStream(file, { start, end }).pipe(res)
+          } else {
+            res.writeHead(200, { 'Content-Length': size })
+            createReadStream(file).pipe(res)
+          }
+        }
+        if (path.startsWith('/ref-videos/')) {
+          const name = path.slice('/ref-videos/'.length)
+          if (!/^[0-9a-fA-F-]+-\d+\.mp4$/.test(name)) {
+            res.writeHead(400)
+            res.end()
+            return
+          }
+          serveVideo(join(videosDir, name))
+          return
+        }
         if (path.startsWith('/images/')) {
           const name = path.slice('/images/'.length)
           if (!/^[0-9a-fA-F-]+-\d+\.(png|jpe?g|gif|webp)$/i.test(name)) {
@@ -286,6 +321,14 @@ app.whenReady().then(() => {
     }
     const port = await startMediaServer()
     return `http://127.0.0.1:${port}/images/${name}`
+  })
+
+  ipcMain.handle('media:get-ref-video-url', async (_e, name: unknown) => {
+    if (typeof name !== 'string' || !/^[0-9a-fA-F-]+-\d+\.mp4$/.test(name)) {
+      throw new Error('invalid ref video name')
+    }
+    const port = await startMediaServer()
+    return `http://127.0.0.1:${port}/ref-videos/${name}`
   })
 
   ipcMain.handle('media:show-in-folder', (_e, filePath: unknown) => {

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -1395,6 +1395,8 @@ export async function captureZhipuConsoleSession(opts?: {
   })()`
 
   const inject = (): void => {
+    // 定时器可能迟于窗口关闭触发：销毁后跳过，避免主进程 uncaught
+    if (win.isDestroyed() || win.webContents.isDestroyed()) return
     void win.webContents.executeJavaScript(INJECT).catch(() => {})
   }
   win.webContents.on('did-finish-load', () => {
@@ -2002,6 +2004,8 @@ export async function captureVolcEngineConsoleSession(opts?: {
   })()`
 
   const inject = (): void => {
+    // 定时器可能迟于窗口关闭触发：销毁后跳过，避免主进程 uncaught
+    if (win.isDestroyed() || win.webContents.isDestroyed()) return
     void win.webContents.executeJavaScript(INJECT).catch(() => {})
   }
   win.webContents.on('did-finish-load', () => {
@@ -2536,6 +2540,8 @@ export async function captureBailianConsoleSession(opts?: {
     scanStorage();
   })()`
   const injectCap = (): void => {
+    // 定时器可能迟于捕获窗口关闭触发：销毁后跳过，避免主进程 uncaught
+    if (capWin.isDestroyed() || capWin.webContents.isDestroyed()) return
     void capWin.webContents.executeJavaScript(CAPTURE_INJECT).catch(() => {})
   }
   capWin.webContents.on('did-finish-load', () => {
@@ -2572,11 +2578,14 @@ export async function captureBailianConsoleSession(opts?: {
     document.addEventListener('mousemove', (e) => { if (!dragging) return; const x = Math.max(4, Math.min(window.innerWidth - barEl.offsetWidth - 4, e.clientX - offX)); const y = Math.max(4, Math.min(window.innerHeight - barEl.offsetHeight - 4, e.clientY - offY)); barEl.style.left = x + 'px'; barEl.style.top = y + 'px'; });
     document.addEventListener('mouseup', () => { dragging = false; barEl.style.cursor = 'grab'; });
   })()`
-  const injectUI = (): void => {
-    void win.webContents.executeJavaScript(UI_INJECT).catch(() => {})
-  }
+
   win.webContents.on('did-finish-load', () => {
-    setTimeout(injectUI, 500)
+    // 注入延后于加载完成执行，但定时器可能迟于窗口关闭触发：
+    // webContents 已销毁时直接跳过，避免主进程 uncaught（Object has been destroyed）报错
+    setTimeout(() => {
+      if (win.isDestroyed() || win.webContents.isDestroyed()) return
+      void win.webContents.executeJavaScript(UI_INJECT).catch(() => {})
+    }, 500)
   })
 
   return new Promise<{

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -204,6 +204,14 @@ export interface GenerateRequest {
   images?: string[]
   /** 厂商 API 用的参考图公网 https URL（仅 API 型厂商上传） */
   imageUrls?: string[]
+  /** 参考生（r2v）本地视频参考副本：本地路径或公网 URL */
+  videos?: string[]
+  /** 参考生（r2v）公网 https 视频 URL 数组（bailian 合入 input.media reference_video） */
+  videoUrls?: string[]
+  /** 文生视频音频参考的公网 https URL（bailian 透传 input.audio_url） */
+  audioUrl?: string
+  /** 音频本地副本路径（历史回显/重新生成回填） */
+  audioLocalPath?: string
   /** 测试开关：显示豆包 WebView 窗口（默认隐藏） */
   showWebview?: boolean
 }
@@ -385,6 +393,7 @@ export interface DesktopApi {
   media: {
     getUrl: (name: string) => Promise<string>
     getImageUrl: (name: string) => Promise<string>
+    getRefVideoUrl: (name: string) => Promise<string>
     showInFolder: (filePath: string) => Promise<{ ok: boolean; error?: string }>
   }
   watermark: {
@@ -582,6 +591,7 @@ const api: DesktopApi = {
   media: {
     getUrl: (name) => ipcRenderer.invoke('media:get-url', name) as Promise<string>,
     getImageUrl: (name) => ipcRenderer.invoke('media:get-image-url', name) as Promise<string>,
+    getRefVideoUrl: (name) => ipcRenderer.invoke('media:get-ref-video-url', name) as Promise<string>,
     showInFolder: (filePath) =>
       ipcRenderer.invoke('media:show-in-folder', filePath) as Promise<{ ok: boolean; error?: string }>
   },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -190,7 +190,9 @@ function MainApp({
       audio: p?.audio ?? 'on',
       ratio: p?.ratio ?? '9:16',
       mode: p?.mode ?? 'text2video',
-      images: r.images ?? []
+      images: r.images ?? [],
+      audioLocalPath: r.audioLocalPath ?? null,
+      audioUrl: r.audioUrl ?? null
     })
     setTab('dispatch')
     location.hash = 'tab=dispatch'

--- a/apps/desktop/src/renderer/src/components/AudioCropModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AudioCropModal.tsx
@@ -1,0 +1,327 @@
+// 音频参考裁剪弹窗：文件时长超过厂商上限（百炼 30s）时，让用户直接在波形上拖选起止区间，
+// 选中片段强制 ≤ 上限，确认后裁剪为 WAV 回传给调用方上传。纯浏览器实现，无第三方依赖。
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const MAX_SEC = 30
+
+interface AudioCropModalProps {
+  file: File
+  duration: number
+  onCancel: () => void
+  onConfirm: (bytes: ArrayBuffer, startSec: number, endSec: number) => void | Promise<void>
+}
+
+/** PCM 采样（多声道）序列化为标准 16bit WAV。 */
+function encodeWav(channelData: Float32Array[], sampleRate: number): ArrayBuffer {
+  const channels = channelData.length
+  const bytesPerSample = 2
+  const dataLength = channelData[0].length * channels * bytesPerSample
+  const buffer = new ArrayBuffer(44 + dataLength)
+  const view = new DataView(buffer)
+  const writeStr = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i++) view.setUint8(o + i, s.charCodeAt(i))
+  }
+  writeStr(0, 'RIFF'); view.setUint32(4, 36 + dataLength, true); writeStr(8, 'WAVE')
+  writeStr(12, 'fmt '); view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true); view.setUint16(22, channels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true)
+  view.setUint16(32, channels * bytesPerSample, true); view.setUint16(34, 16, true)
+  writeStr(36, 'data'); view.setUint32(40, dataLength, true)
+
+  let offset = 44
+  const n = channelData[0].length
+  for (let i = 0; i < n; i++) {
+    for (let c = 0; c < channels; c++) {
+      let s = channelData[c][i]
+      s = Math.max(-1, Math.min(1, s))
+      view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true)
+      offset += 2
+    }
+  }
+  return buffer
+}
+
+function fmtTime(s: number): string {
+  if (!Number.isFinite(s) || s < 0) return '0:00'
+  const m = Math.floor(s / 60)
+  const sec = Math.floor(s % 60)
+  return `${m}:${sec.toString().padStart(2, '0')}`
+}
+
+export default function AudioCropModal({ file, duration, onCancel, onConfirm }: AudioCropModalProps) {
+  const [buffer, setBuffer] = useState<AudioBuffer | null>(null)
+  const [peaks, setPeaks] = useState<number[]>([])
+  const [start, setStart] = useState(0)
+  const [end, setEnd] = useState(Math.min(duration, MAX_SEC))
+  const [busy, setBusy] = useState(false)
+  const [playing, setPlaying] = useState(false)
+  // 试听播放头（秒）：>=0 表示正在播放中的当前位置
+  const [playhead, setPlayhead] = useState<number>(-1)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  // 拖拽状态：null 未拖，start/end 表示正在拖动对应手柄
+  const draggingRef = useRef<'start' | 'end' | null>(null)
+  // 试听播放相关：独立 AudioContext（解码用的已 close），source / RAF 句柄
+  const playCtxRef = useRef<AudioContext | null>(null)
+  const sourceRef = useRef<AudioBufferSourceNode | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const playStartRef = useRef(0) // 播放起始（源时间轴秒）
+  const playCtxT0Ref = useRef(0) // 播放开始时的 ctx.currentTime
+
+  // 解码音频并计算单声道峰值（用于波形绘制）
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const raw = await file.arrayBuffer()
+        const AC: typeof AudioContext =
+          window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+        const ctx = new AC()
+        const b = await ctx.decodeAudioData(raw)
+        await ctx.close()
+        if (cancelled) return
+        const data = b.getChannelData(0)
+        const width = 600
+        const block = Math.max(1, Math.floor(data.length / width))
+        const p: number[] = []
+        for (let x = 0; x < width; x++) {
+          let max = 0
+          const s = x * block
+          const e = Math.min(data.length, s + block)
+          for (let i = s; i < e; i++) { const v = Math.abs(data[i]); if (v > max) max = v }
+          p.push(max)
+        }
+        setBuffer(b)
+        setPeaks(p)
+      } catch { /* 解码失败：交由调用方直传原文件兜底 */ }
+    })()
+    return () => { cancelled = true }
+  }, [file])
+
+  // 绘制波形：未选中区浅色，选中区高亮，边界显示左右手柄
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio || 1
+    const w = canvas.clientWidth
+    const h = canvas.clientHeight
+    canvas.width = w * dpr
+    canvas.height = h * dpr
+    const g = canvas.getContext('2d')
+    if (!g) return
+    g.scale(dpr, dpr)
+    const cs = getComputedStyle(document.documentElement)
+    const fg = cs.getPropertyValue('--fg-secondary') || '#999'
+    const accent = cs.getPropertyValue('--accent') || '#4f8cff'
+    const waveH = h - 36 // 底部留拖拽手柄区 + 时间刻度
+    g.clearRect(0, 0, w, h)
+    if (peaks.length === 0) return
+    const barW = w / peaks.length
+    const xOf = (sec: number): number => (sec / duration) * w
+    // 未选中区域（浅色全量波形）
+    g.fillStyle = fg
+    g.globalAlpha = 0.35
+    peaks.forEach((p, i) => {
+      const bh = Math.max(1, p * waveH)
+      g.fillRect(i * barW, (waveH - bh) / 2, Math.max(1, barW), bh)
+    })
+    // 选中区高亮覆盖
+    const sx = xOf(start); const ex = xOf(end)
+    // 选中区高亮底
+    g.fillStyle = accent
+    g.globalAlpha = 0.22
+    g.fillRect(sx, 0, ex - sx, waveH)
+    // 起止手柄：顶宽底窄的三角把手 + 竖线
+    g.globalAlpha = 1
+    const handleColor = accent
+    const drawHandle = (x: number): void => {
+      g.fillStyle = handleColor
+      g.fillRect(x - 1.5, 0, 3, waveH)
+      g.beginPath()
+      g.moveTo(x - 6, 18); g.lineTo(x + 6, 18); g.lineTo(x, 6)
+      g.closePath(); g.fill()
+    }
+    drawHandle(sx)
+    drawHandle(ex)
+    g.globalAlpha = 1
+    // 起止时间刻度
+    g.fillStyle = fg
+    g.font = '11px sans-serif'
+    g.textAlign = 'center'
+    g.fillText(fmtTime(start), Math.max(10, sx), h - 8)
+    g.fillText(fmtTime(end), Math.max(10, ex), h - 8)
+    // 试听播放头：当前播放位置白色/亮色竖线
+    if (playhead >= 0 && playhead >= start && playhead <= end) {
+      const px = xOf(playhead)
+      g.fillStyle = '#fff'
+      g.fillRect(px, 0, 1.5, waveH)
+    }
+  }, [peaks, start, end, duration, playhead])
+
+  // 指针交互：拖左右手柄改起止。端点强制 start<end 且 end-start≤MAX_SEC
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas || !duration) return
+    const rect = canvas.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    const pxStart = (start / duration) * rect.width
+    const pxEnd = (end / duration) * rect.width
+    const TH = 8 // 手柄吸附半径(px)
+    if (Math.abs(x - pxStart) <= TH) draggingRef.current = 'start'
+    else if (Math.abs(x - pxEnd) <= TH) draggingRef.current = 'end'
+    else if (x > pxStart && x < pxEnd) { /* 点击选中区不动 */ }
+    else { const s = Math.max(0, Math.min(duration, (x / rect.width) * duration)); setStart(s); setEnd(Math.min(duration, s + MAX_SEC)) }
+  }, [start, end, duration])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    const mode = draggingRef.current
+    const canvas = canvasRef.current
+    if (!mode || !canvas || !duration) return
+    const rect = canvas.getBoundingClientRect()
+    const sec = Math.max(0, Math.min(duration, ((e.clientX - rect.left) / rect.width) * duration))
+    if (mode === 'start') {
+      const next = Math.max(0, Math.min(end - 1, sec))
+      setStart(next)
+      if (end - next > MAX_SEC) setEnd(next + MAX_SEC)
+    } else {
+      const next = Math.max(start + 1, Math.min(duration, sec))
+      setEnd(next)
+      if (next - start > MAX_SEC) setStart(next - MAX_SEC)
+    }
+  }, [start, end, duration])
+
+  const stopDrag = useCallback(() => { draggingRef.current = null }, [])
+
+  // 停止试听（释放 context / source / RAF）
+  const stopPlayback = useCallback(() => {
+    try { sourceRef.current?.stop() } catch { /* 已停止 */ }
+    sourceRef.current = null
+    try { playCtxRef.current?.close() } catch { /* 已关闭 */ }
+    playCtxRef.current = null
+    if (rafRef.current != null) { cancelAnimationFrame(rafRef.current); rafRef.current = null }
+    setPlaying(false)
+    setPlayhead(-1)
+  }, [])
+
+  // 从区间的 fromSec 起播放到 end 为止（用独立 AudioContext + BufferSource）
+  const playRange = useCallback((fromSec: number, toSec: number) => {
+    if (!buffer || toSec <= fromSec) return
+    const AC: typeof AudioContext =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    const ctx = new AC()
+    const src = ctx.createBufferSource()
+    src.buffer = buffer
+    src.connect(ctx.destination)
+    src.onended = (): void => stopPlayback()
+    src.start(0, fromSec, toSec - fromSec)
+    playCtxRef.current = ctx
+    sourceRef.current = src
+    playStartRef.current = fromSec
+    playCtxT0Ref.current = ctx.currentTime
+    setPlaying(true)
+    setPlayhead(fromSec)
+    const tick = (): void => {
+      const now = playCtxRef.current?.currentTime ?? 0
+      const pos = fromSec + (now - playCtxT0Ref.current)
+      if (pos >= toSec) { stopPlayback(); return }
+      setPlayhead(pos)
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+  }, [buffer, stopPlayback])
+
+  // 试听或暂停选中片段 [start, end]
+  const togglePlay = useCallback(() => {
+    if (playing) { stopPlayback(); return }
+    playRange(start, end)
+  }, [playing, stopPlayback, start, end, playRange])
+
+  // 拖拽改变起止期间：若正在播放且播放头越界，停止试听（避免撕裂区间外的声音）
+  useEffect(() => {
+    if (playing && (playhead < start || playhead >= end)) stopPlayback()
+  }, [start, end, playing, playhead, stopPlayback])
+
+  // 卸载时清理
+  useEffect(() => () => stopPlayback(), [stopPlayback])
+
+  const confirm = useCallback(async () => {
+    if (!buffer || busy) return
+    setBusy(true)
+    try {
+      const sampleRate = buffer.sampleRate
+      const chans: Float32Array[] = []
+      for (let c = 0; c < buffer.numberOfChannels; c++) {
+        const data = buffer.getChannelData(c)
+        const s = Math.floor(start * sampleRate)
+        const e = Math.min(data.length, Math.floor(end * sampleRate))
+        chans.push(data.slice(s, e))
+      }
+      const bytes = encodeWav(chans, sampleRate)
+      await onConfirm(bytes, start, end)
+    } finally {
+      setBusy(false)
+    }
+  }, [buffer, busy, start, end, onConfirm])
+
+  const selectedLen = end - start
+
+  return createPortal(
+    <div
+      className="modal-overlay"
+      style={{ zIndex: 500 }}
+      onClick={(e) => { if (e.target === e.currentTarget && !busy) onCancel() }}
+    >
+      <div className="modal-card" style={{ width: 'min(92vw, 680px)', padding: 18, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>音频裁剪</div>
+          <div style={{ fontSize: 12, color: 'var(--fg-secondary)', wordBreak: 'break-all' }}>{file.name}</div>
+        </div>
+
+        <div style={{ fontSize: 13, color: 'var(--fg-secondary)', lineHeight: 1.6 }}>
+          该音频共 <b>{fmtTime(duration)}</b>，厂商仅支持 ≤ {MAX_SEC}s 的参考音频。
+          请拖动下方波形左右手柄，选择要保留的片段（自动限制在 {MAX_SEC}s 内）。
+        </div>
+
+        <canvas
+          ref={canvasRef}
+          style={{ width: '100%', height: 130, touchAction: 'none', cursor: duration ? 'ew-resize' : 'default' }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={stopDrag}
+          onPointerLeave={stopDrag}
+        />
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 13, gap: 10 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <button
+              className="btn-sm"
+              onClick={togglePlay}
+              disabled={!buffer || busy}
+              title={playing ? '暂停试听' : '播放选中片段试听'}
+              style={{ padding: '2px 10px' }}
+            >
+              {playing ? '暂停' : '试听'}
+            </button>
+            <span>
+              选中 <b style={{ color: 'var(--accent)' }}>{fmtTime(start)}</b> ~ <b style={{ color: 'var(--accent)' }}>{fmtTime(end)}</b>
+              ({selectedLen.toFixed(1)}s)
+            </span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            {playing && playhead >= 0 && <span style={{ color: 'var(--accent)' }}>{fmtTime(playhead)}</span>}
+            <span style={{ color: selectedLen > MAX_SEC ? 'var(--danger, #e5484d)' : 'var(--fg-secondary)' }}>上限 {MAX_SEC}s</span>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button className="btn-sm" onClick={() => { if (!busy) onCancel() }} disabled={busy}>取消</button>
+          <button className="btn-sm primary" onClick={confirm} disabled={busy || !buffer}>
+            {busy ? '裁剪中...' : `确认裁剪（${selectedLen.toFixed(1)}s）`}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import type { ClipboardEvent as ReactClipboardEvent } from 'react'
+import type { ChangeEvent as ReactChangeEvent, ClipboardEvent as ReactClipboardEvent } from 'react'
 import { createPortal } from 'react-dom'
 import {
   DEFAULT_SUPPORTED_DURATIONS,
@@ -11,7 +11,8 @@ import {
   resolutionOptions,
   uploadHint,
   zhipuModelDurations,
-  bailianModelDurations
+  bailianModelDurations,
+  bailianModelInputs
 } from '../spec'
 import { IconInfo, IconMaximize, IconPlay, IconUpload, ProviderIconMark } from './icons'
 import { EmptyState } from './EmptyState'
@@ -28,11 +29,66 @@ import { getInitialShowWebview } from './Modals'
 import type { DesktopFeatureFlags } from '../hooks/useDesktopPermissions'
 import type { ProviderCaps, ProviderCapsMap } from '../hooks/useProviderCaps'
 import { imageContentType, prepareReferenceImage } from '../utils/uploadImage'
+import AudioCropModal from './AudioCropModal'
 
 const VIP = false
 
 /** 需要通过公网 https URL 才能做图生/参考的 API 型厂商（历史图生记录重新生成时需重传本地图取新 URL） */
-const API_IMAGE_PROVIDERS = ['zhipu', 'volcengine']
+const API_IMAGE_PROVIDERS = ['zhipu', 'volcengine', 'bailian']
+
+// 文生视频音频参考：扩展名 → MIME（与 github-upload 的 EXT_RE 及本地副本保存共用）
+const AUDIO_TYPES: Record<string, string> = {
+  mp3: 'audio/mpeg', m4a: 'audio/mp4', wav: 'audio/wav', ogg: 'audio/ogg',
+  aac: 'audio/aac', webm: 'audio/webm', flac: 'audio/flac', mp4: 'audio/mp4'
+}
+
+function audioExt(name: string): string {
+  const m = /\.([A-Za-z0-9]{1,8})$/.exec(name)
+  return m ? m[1].toLowerCase() : 'm4a'
+}
+
+/** 探测本地音频文件时长（秒）。利用浏览器 <audio> 解码头信息，避免上传后才因超限报错。
+ *  对无法解析的格式返回 null（由后端兜底），返回值可直接与厂商上限比较。 */
+async function probeAudioDuration(file: File): Promise<number | null> {
+  return new Promise<number | null>((resolve) => {
+    try {
+      const url = URL.createObjectURL(file)
+      const audio = new Audio()
+      audio.preload = 'metadata'
+      audio.src = url
+      audio.onloadedmetadata = () => {
+        const d = Number.isFinite(audio.duration) ? audio.duration : null
+        URL.revokeObjectURL(url)
+        resolve(d)
+      }
+      audio.onerror = () => {
+        URL.revokeObjectURL(url)
+        resolve(null)
+      }
+      // 兜底：最多等 3s，防止极端格式卡死
+      setTimeout(() => { URL.revokeObjectURL(url); resolve(null) }, 3000)
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** PCM 采样数据（含声道/采样率信息）序列化为标准 WAV 字节流（16bit PCM）——已迁移至 AudioCropModal */
+// （原 encodeWav/clipAudioTo30s 已移除，裁剪交互由 AudioCropModal 承担）
+
+// 参考生（r2v）参考视频：扩展名 → MIME（与 github-upload 的 EXT_RE 及本地副本保存共用）
+const VIDEO_TYPES: Record<string, string> = {
+  mp4: 'video/mp4', mov: 'video/quicktime', m4v: 'video/x-m4v',
+  webm: 'video/webm', mkv: 'video/x-matroska', avi: 'video/x-msvideo'
+}
+
+function videoExt(name: string): string {
+  const m = /\.([A-Za-z0-9]{1,8})$/.exec(name)
+  return m ? m[1].toLowerCase() : 'mp4'
+}
+
+/** 参考生（r2v）可上传的参考视频上限（官方媒体合计 ≤5，预留图片并行，固定给 3 个视频位） */
+const MAX_REF_VIDEOS = 3
 
 function maxImageUploadCount(provider: string, model: string): number {
   // 智谱按模型能力限制图片上传数量：图生视频1张、首尾帧2张、Vidu 2参考生视频最多5张
@@ -121,6 +177,10 @@ export interface RegenerateDraft {
   ratio: string
   mode: string
   images: string[]
+  /** 文生视频音频参考的本地副本路径（重新生成时用于重传取新公网 URL） */
+  audioLocalPath?: string | null
+  /** 文生视频音频参考的公网 https URL（旧记录兼容，地址如已删则按本地副本重传） */
+  audioUrl?: string | null
 }
 
 function normalizeRegenerateMode(providerId: string, rawMode?: string): string {
@@ -145,8 +205,8 @@ function visibleModeOptions(
   caps?: ProviderCaps
 ): Array<{ value: string; label: string }> {
   const base = providerModeOptions(provider, model).filter((option) => {
-    if (option.value === 't2v') return features['dispatch.text2video']
-    if (option.value === 'img') return features['dispatch.img2video']
+    if (option.value === 't2v' || option.value === 'text2video') return features['dispatch.text2video']
+    if (option.value === 'img' || option.value === 'img2video') return features['dispatch.img2video']
     if (option.value === 'multi_ref') return features['dispatch.multi_ref']
     if (option.value === 'first_last') return features['dispatch.first_last']
     if (option.value === 'first_frame') return features['dispatch.first_frame']
@@ -184,7 +244,7 @@ export default function Dashboard({
   const { items: jobItems, reload: reloadJobs } = jobs
   const [provider, setProvider] = useState('doubao')
   const [model, setModel] = useState(MODELS.doubao[0])
-  const [mode, setMode] = useState('t2v')
+  const [mode, setMode] = useState('text2video')
   const [duration, setDuration] = useState(5)
   const [resolution, setResolution] = useState('720')
   const [audio, setAudio] = useState('on')
@@ -196,6 +256,34 @@ export default function Dashboard({
   const [apiImageUrls, setApiImageUrls] = useState<string[]>([])
   // 开放平台 API 型厂商（智谱/火山）图片异步上传计数：>0 表示尚有图片在上传，禁用「开始生成」
   const [uploadingCount, setUpLoadingCount] = useState(0)
+  // 文生视频（bailian）音频参考：公网 https URL 透传厂商 + 本地副本供历史回显/重新生成回填
+  const [audioName, setAudioName] = useState('')
+  const [audioUrl, setAudioUrl] = useState<string | null>(null)
+  const [audioLocalPath, setAudioLocalPath] = useState<string | null>(null)
+  const [audioUploading, setAudioUploading] = useState(false)
+  // 音频裁剪弹窗：文件时长超过厂商上限时弹出，让用户自行拖选起止区间后上传
+  const [cropAudio, setCropAudio] = useState<{ file: File; duration: number } | null>(null)
+  // 参考生（r2v）参考视频：仅 multi_ref 的百炼 r2v 模型开放。
+  //   refVideoPreviews   展示用 URL（新选=blob；重新生成回填=本地媒体服务 URL）
+  //   refVideoLocalPaths 本地副本路径（随任务入库，历史回显/重新生成回填）
+  //   refVideoUrls       公网 https URL（透传厂商 input.media reference_video）
+  //   refVideoNames      文件名（供展示/删除）
+  const [refVideoPreviews, setRefVideoPreviews] = useState<string[]>([])
+  const [refVideoLocalPaths, setRefVideoLocalPaths] = useState<string[]>([])
+  const [refVideoUrls, setRefVideoUrls] = useState<string[]>([])
+  const [refVideoNames, setRefVideoNames] = useState<string[]>([])
+  const [refVideoUploading, setRefVideoUploading] = useState(false)
+  const [refVideoPreviewing, setRefVideoPreviewing] = useState<string | null>(null)
+  // 参考生（r2v）统一上传框的素材添加顺序：把图片（img）与视频（vid）交错排列成一行，保证点击顺序与视觉一致。
+  //   每个条目记录 {k: 'img' | 'vid', i: 在该类型数组内的下标}；删除时会自动重排同类条目下标。
+  type RefOrderEntry = { k: 'img'; i: number } | { k: 'vid'; i: number }
+  const [refItemOrder, setRefItemOrder] = useState<RefOrderEntry[]>([])
+  const totalRefItemCount = savedImagePaths.length + refVideoLocalPaths.length
+  // 自定义深色音频播放器状态（替换原生 <audio controls> 白底风格）
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const [audioPlaying, setAudioPlaying] = useState(false)
+  const [audioCurrentTime, setAudioCurrentTime] = useState(0)
+  const [audioDuration, setAudioDuration] = useState(0)
   const [prompt, setPrompt] = useState('')
   const [generating, setGenerating] = useState(false)
   const [genError, setGenError] = useState<string | null>(null)
@@ -213,6 +301,7 @@ export default function Dashboard({
   const [preview, setPreview] = useState<{ id: string; src: string } | null>(null)
   const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const refVideoInputRef = useRef<HTMLInputElement>(null)
 
   // Admin 厂商级生成能力：命中 provider_caps 时该厂商模式/模型以配置为准，缺省回退硬编码默认
   const caps = providerCaps[provider]
@@ -237,7 +326,7 @@ export default function Dashboard({
     const nextModes = visibleModeOptions(nextProvider, nextModel, features, providerCaps[nextProvider])
     const nextMode = nextModes.some((m) => m.value === normalizedMode)
       ? normalizedMode
-      : (nextModes[0]?.value ?? 't2v')
+      : (nextModes[0]?.value ?? 'text2video')
 
     setProvider(nextProvider)
     setModel(nextModel)
@@ -251,6 +340,10 @@ export default function Dashboard({
     setSavedImagePaths(regenerateDraft.images ?? [])
     setApiImageUrls([])
     setImages([])
+    // 音频回填：本地副本路径就地保留；公网 https URL 若记录存在则直接复用，供重传判定
+    setAudioName('')
+    setAudioUrl(regenerateDraft.audioUrl ?? null)
+    setAudioLocalPath(regenerateDraft.audioLocalPath ?? null)
     setGenError(null)
     setGenFailed(false)
 
@@ -286,6 +379,22 @@ export default function Dashboard({
         })
         .catch(() => {})
     }
+    // 百炼文生音频参考：有本地副本则重传取新公网 URL（原 https URL 生成后已删），供生成时透传 input.audio_url
+    const audioLocal = regenerateDraft.audioLocalPath ?? null
+    if (nextProvider === 'bailian' && normalizedMode === 't2v' && audioLocal) {
+      const aExt = audioExt(audioLocal)
+      window.api.storage
+        .readImageLocal(audioLocal)
+        .then(async (bytes) => {
+          const { url } = await window.api.storage.uploadImage({ bytes, contentType: AUDIO_TYPES[aExt] ?? 'audio/mpeg', ext: aExt })
+          if (cancelled) return
+          setAudioUrl(url)
+          setAudioName(audioLocal.split(/[\\/]/).pop() || '')
+        })
+        .catch(() => {
+          // 本地副本不可读（已被清理）时保持无音频状态，不阻断重新生成
+        })
+    }
     onRegenerateConsumed?.()
     return () => {
       cancelled = true
@@ -300,7 +409,7 @@ export default function Dashboard({
     // 素材图是本地路径；仅当素材给了公开 https URL 时才可作 API 厂商参考图透传（否则生成走本地路径）
     setApiImageUrls((prev) => [...prev, ...materialImages.filter((m) => /^https?:\/\//i.test(m.url)).map((m) => m.url)])
     const validModes = visibleModeOptions(provider, model, features, caps)
-    const imageMode = validModes.find((m) => ['multi_ref', 'img', 'first_last', 'first_frame'].includes(m.value))
+    const imageMode = validModes.find((m) => ['multi_ref', 'img', 'img2video', 'first_last', 'first_frame'].includes(m.value))
     if (imageMode && imageMode.value !== mode) setMode(imageMode.value)
     onMaterialImagesConsumed?.()
   }, [materialImages, provider, model, features, caps, mode, onMaterialImagesConsumed])
@@ -359,7 +468,11 @@ export default function Dashboard({
           const secret = await svc.getProviderKeySecret(user.id, b.keyId)
           if (!secret) continue
           const res = await window.api.providers.apiModels('bailian', secret.encrypted_key)
-          if (res.ok && res.models) res.models.forEach((m) => m && m.model && union.add(m.model))
+          if (res.ok && res.models)
+            res.models.forEach((m) => {
+              // detect/专用模型（unavailable='no_endpoint'）只进「查看模型」，不进调度台可生成列表
+              if (m && m.model && m.unavailable !== 'no_endpoint') union.add(m.model)
+            })
         } catch {
           // 单个账号抓取失败不影响整体目录
         }
@@ -388,6 +501,238 @@ export default function Dashboard({
   const ratios = ratioOptions(provider)
   const cost = computeCost(provider, model, duration, resolution)
   const upload = uploadHint(provider, mode)
+  // 文生视频（bailian）音频参考能力：仅当属百炼且当前为文生视频（text2video）模型且能力卡含 Audio 时开放音频上传
+  // 注意：mode 用长键（text2video/img2video），而非短键（t2v/img），与 providerModeOptions 下拉 value 一致
+  const t2vSupportsAudio = provider === 'bailian' && mode === 'text2video' && bailianModelInputs(model).includes('Audio')
+  // 参考生（r2v）视频参考：仅当属百炼且当前为 multi_ref（参考生）且模型能力卡含 Video 时开放视频上传
+  const r2vVideoActive = provider === 'bailian' && mode === 'multi_ref' && bailianModelInputs(model).includes('Video')
+
+  // 音频上传：走与图片一致的 GitHub+jsDelivr https 链，公网 URL 供生成时透传厂商，本地副本供历史回显/回填
+  const uploadAudio = useCallback(
+    async (bytes: ArrayBuffer, ext: string): Promise<{ url: string; localPath: string }> => {
+      const { url } = await window.api.storage.uploadImage({
+        bytes,
+        contentType: AUDIO_TYPES[ext] ?? 'audio/mpeg',
+        ext: ext || 'm4a'
+      })
+      const { path } = await window.api.storage.saveImageLocal({ bytes, ext: ext || 'm4a' })
+      return { url, localPath: path }
+    },
+    []
+  )
+  const onPickAudio = useCallback(
+    async (e: ReactChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      e.target.value = ''
+      if (!file) return
+      const ext = audioExt(file.name)
+      // 立即设置文件名 + 进入上传中状态，让用户马上看到 loading UI（而非等上传完成才显示）
+      setAudioName(file.name)
+      setAudioUrl(null)
+      setAudioLocalPath(null)
+      setAudioUploading(true)
+      try {
+        // 超长音频：弹出裁剪窗让用户自行拖选起止区间（自动限制在 30s 内），确认后再上传
+        const dur = await probeAudioDuration(file)
+        if (dur != null && dur > 30) {
+          setCropAudio({ file, duration: dur })
+          return
+        }
+        const bytes = await file.arrayBuffer()
+        const { url, localPath } = await uploadAudio(bytes, ext)
+        setAudioUrl(url)
+        setAudioLocalPath(localPath)
+      } catch (err) {
+        setAudioName('')
+        setGenError('音频上传失败：' + (err instanceof Error ? err.message : String(err)))
+      } finally {
+        setAudioUploading(false)
+      }
+    },
+    [uploadAudio]
+  )
+  const handleCropDone = useCallback(
+    async (bytes: ArrayBuffer, _start: number, _end: number): Promise<void> => {
+      setAudioUploading(true)
+      try {
+        const { url, localPath } = await uploadAudio(bytes, 'wav')
+        setAudioUrl(url)
+        setAudioLocalPath(localPath)
+        setCropAudio(null)
+      } catch (err) {
+        setAudioName('')
+        setGenError('音频上传失败：' + (err instanceof Error ? err.message : String(err)))
+      } finally {
+        setAudioUploading(false)
+      }
+    },
+    [uploadAudio]
+  )
+  const handleCropCancel = useCallback((): void => {
+    setCropAudio(null)
+    if (audioUploading) setAudioUploading(false)
+  }, [audioUploading])
+  const onRemoveAudio = useCallback((): void => {
+    setAudioName('')
+    setAudioUrl(null)
+    setAudioLocalPath(null)
+    setAudioPlaying(false)
+    setAudioCurrentTime(0)
+    setAudioDuration(0)
+  }, [])
+
+  // 参考视频（r2v）上传：与图片/音频一致走 GitHub+jsDelivr https 链，
+  // 公网 URL（refVideoUrls）透传厂商 input.media，本地副本（refVideoLocalPaths）供历史回显/重新生成回填
+  const uploadRefVideo = useCallback(
+    async (file: File): Promise<{ url: string; localPath: string }> => {
+      const ext = videoExt(file.name)
+      const bytes = await file.arrayBuffer()
+      const { url } = await window.api.storage.uploadImage({
+        bytes,
+        contentType: VIDEO_TYPES[ext] ?? 'video/mp4',
+        ext: ext === 'm4v' ? 'm4v' : 'mp4'
+      })
+      const { path } = await window.api.storage.saveImageLocal({ bytes, ext: 'mp4' })
+      return { url, localPath: path }
+    },
+    []
+  )
+  const onPickRefVideo = useCallback(
+    async (e: ReactChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      e.target.value = ''
+      if (!file) return
+      const remaining = Math.max(0, MAX_REF_VIDEOS - refVideoLocalPaths.length)
+      if (remaining <= 0) return
+      // 先展示本地预览 + 进入上传态，避免等 HTTPS 完成才有反馈
+      setRefVideoPreviews((prev) => [...prev, URL.createObjectURL(file)])
+      setRefVideoLocalPaths((prev) => [...prev, ''])
+      setRefVideoUrls((prev) => [...prev, ''])
+      setRefVideoNames((prev) => [...prev, file.name])
+      setRefVideoUploading(true)
+      try {
+        const { url, localPath } = await uploadRefVideo(file)
+        setRefVideoLocalPaths((prev) => prev.map((p, i) => (i === prev.length - 1 ? localPath : p)))
+        setRefVideoUrls((prev) => prev.map((u, i) => (i === prev.length - 1 ? url : u)))
+      } catch (err) {
+        setGenError('参考视频上传失败：' + (err instanceof Error ? err.message : String(err)))
+        setRefVideoPreviews((prev) => prev.slice(0, -1))
+        setRefVideoLocalPaths((prev) => prev.slice(0, -1))
+        setRefVideoUrls((prev) => prev.slice(0, -1))
+        setRefVideoNames((prev) => prev.slice(0, -1))
+      } finally {
+        setRefVideoUploading(false)
+      }
+    },
+    [refVideoLocalPaths.length, uploadRefVideo]
+  )
+  const onRemoveRefVideo = useCallback((idx: number): void => {
+    setRefVideoPreviews((prev) => prev.filter((_, i) => i !== idx))
+    setRefVideoLocalPaths((prev) => prev.filter((_, i) => i !== idx))
+    setRefVideoUrls((prev) => prev.filter((_, i) => i !== idx))
+    setRefVideoNames((prev) => prev.filter((_, i) => i !== idx))
+  }, [])
+  const clearRefVideos = useCallback((): void => {
+    setRefVideoPreviews([])
+    setRefVideoLocalPaths([])
+    setRefVideoUrls([])
+    setRefVideoNames([])
+  }, [])
+  // 清空所有参考素材（图片 + 视频 + 顺序），用于切厂商/切模型/重置
+  const clearAllRefAssets = useCallback((): void => {
+    setImages([])
+    setImageFiles([])
+    setSavedImagePaths([])
+    setApiImageUrls([])
+    clearRefVideos()
+    setRefItemOrder([])
+  }, [clearRefVideos])
+
+  // ===== 参考生（r2v）统一素材框：图片 + 视频 混合上传、一行预览 =====
+  const refMixedInputRef = useRef<HTMLInputElement>(null)
+
+  // 视频上传辅助（独立于图片上传，避免依赖 appendApiImages 声明位置）
+  const appendVideoAsRef = useCallback(async (file: File): Promise<void> => {
+    // 先登记占位条目（下标为当前 refVideoLocalPaths.length，即即将追加的位置）
+    const newIdx = refVideoLocalPaths.length
+    setRefVideoPreviews((prev) => [...prev, URL.createObjectURL(file)])
+    setRefVideoLocalPaths((prev) => [...prev, ''])
+    setRefVideoUrls((prev) => [...prev, ''])
+    setRefVideoNames((prev) => [...prev, file.name])
+    setRefItemOrder((prev) => [...prev, { k: 'vid', i: newIdx }])
+    setRefVideoUploading(true)
+    try {
+      const { url, localPath } = await uploadRefVideo(file)
+      setRefVideoLocalPaths((prev) => prev.map((p, i) => (i === newIdx ? localPath : p)))
+      setRefVideoUrls((prev) => prev.map((u, i) => (i === newIdx ? url : u)))
+    } catch (err) {
+      setGenError('参考视频上传失败：' + (err instanceof Error ? err.message : String(err)))
+      setRefVideoPreviews((prev) => prev.filter((_, i) => i !== newIdx))
+      setRefVideoLocalPaths((prev) => prev.filter((_, i) => i !== newIdx))
+      setRefVideoUrls((prev) => prev.filter((_, i) => i !== newIdx))
+      setRefVideoNames((prev) => prev.filter((_, i) => i !== newIdx))
+      setRefItemOrder((prev) => prev.filter((e) => !(e.k === 'vid' && e.i === newIdx)))
+    } finally {
+      setRefVideoUploading(false)
+    }
+  }, [refVideoLocalPaths.length, uploadRefVideo])
+
+  // 音频播放器控制：用隐藏 <audio> 实现深色自定义 UI（替换原生白底控件）
+  const toggleAudioPlay = useCallback(() => {
+    const el = audioRef.current
+    if (!el) return
+    if (el.paused) {
+      el.play().catch(() => { /* ignore */ })
+    } else {
+      el.pause()
+    }
+  }, [])
+
+  const seekAudio = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const el = audioRef.current
+    if (!el || !audioDuration) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
+    el.currentTime = pct * audioDuration
+  }, [audioDuration])
+
+  // 音频事件同步 React 状态
+  useEffect(() => {
+    const el = audioRef.current
+    if (!el) return
+    const onPlay = () => setAudioPlaying(true)
+    const onPause = () => setAudioPlaying(false)
+    const onTime = () => setAudioCurrentTime(el.currentTime)
+    const onLoaded = () => setAudioDuration(el.duration || 0)
+    const onEnded = () => { setAudioPlaying(false); setAudioCurrentTime(0) }
+    el.addEventListener('play', onPlay)
+    el.addEventListener('pause', onPause)
+    el.addEventListener('timeupdate', onTime)
+    el.addEventListener('loadedmetadata', onLoaded)
+    el.addEventListener('ended', onEnded)
+    return () => {
+      el.removeEventListener('play', onPlay)
+      el.removeEventListener('pause', onPause)
+      el.removeEventListener('timeupdate', onTime)
+      el.removeEventListener('loadedmetadata', onLoaded)
+      el.removeEventListener('ended', onEnded)
+    }
+  }, [audioUrl])
+
+  // 音频 URL 变化时重置播放状态
+  useEffect(() => {
+    setAudioPlaying(false)
+    setAudioCurrentTime(0)
+    setAudioDuration(0)
+  }, [audioUrl])
+
+  // 音频时间格式化
+  const fmtTime = (s: number): string => {
+    if (!isFinite(s) || s <= 0) return '0:00'
+    const m = Math.floor(s / 60)
+    const sec = Math.floor(s % 60)
+    return `${m}:${sec.toString().padStart(2, '0')}`
+  }
 
   // 调度台状态面板不展示后台已停用的厂商，避免出现置灰/停用态干扰调度信息。
   const visibleAggs = useMemo(() => provAggs.filter((p) => p.enabled !== false), [provAggs])
@@ -408,12 +753,10 @@ export default function Dashboard({
       setProvider(next)
       setModel(nextModel)
       const nextModes = visibleModeOptions(next, nextModel, features, providerCaps[next])
-      setMode(nextModes[0]?.value ?? 't2v')
-      setImages([])
-      setImageFiles([])
-      setSavedImagePaths([])
+      setMode(nextModes[0]?.value ?? 'text2video')
+      clearAllRefAssets()
     }
-  }, [providerOptions, provider, features, providerCaps])
+  }, [providerOptions, provider, features, providerCaps, clearAllRefAssets])
 
   useEffect(() => {
     if (!durations.some((d) => d.value === duration)) {
@@ -440,10 +783,8 @@ export default function Dashboard({
   useEffect(() => {
     const validModes = visibleModeOptions(provider, model, features, caps).map((m) => m.value)
     if (!validModes.includes(mode)) {
-      setMode(validModes[0] ?? 't2v')
-      setImages([])
-      setImageFiles([])
-      setSavedImagePaths([])
+      setMode(validModes[0] ?? 'text2video')
+      clearAllRefAssets()
     }
   }, [provider, model, mode, features, caps])
 
@@ -542,17 +883,18 @@ export default function Dashboard({
 
   // 预览浮层：Esc 关闭
   useEffect(() => {
-    if (!preview && !imagePreview && !promptPreview) return
+    if (!preview && !imagePreview && !promptPreview && !refVideoPreviewing) return
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
         setPreview(null)
         setImagePreview(null)
         setPromptPreview(false)
+        setRefVideoPreviewing(null)
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [preview, imagePreview, promptPreview])
+  }, [preview, imagePreview, promptPreview, refVideoPreviewing])
 
   const handleGenerate = useCallback(async (): Promise<void> => {
     const currentMode = provider === 'dola' ? 'multi_ref' : mode
@@ -560,6 +902,16 @@ export default function Dashboard({
     // 开放平台 API 型厂商（智谱/火山）：图生/多参考/首尾帧需公网 https 图片，上传未完成时禁用，避免提交空图报错
     if ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0) {
       setGenError('图片正在上传中，请稍候再生成')
+      return
+    }
+    // 文生视频音频参考上传中：避免空参提交（透传 input.audio_url 需要其公网 URL 就绪）
+    if (audioUploading) {
+      setGenError('音频正在上传中，请稍候再生成')
+      return
+    }
+    // 参考生（r2v）参考视频上传中：避免空参提交（透传 input.media 需要公网 URL 就绪）
+    if (refVideoUploading) {
+      setGenError('参考视频正在上传中，请稍候再生成')
       return
     }
     if (fresh && step === 1) {
@@ -581,13 +933,13 @@ export default function Dashboard({
       return
     }
     const imageCount = savedImagePaths.length + imageFiles.length
-    // 文生视频需图片：排除 t2v（网页厂商）与 text2video（智谱 API）两种文案枚举
-    if (currentMode !== 't2v' && currentMode !== 'text2video' && imageCount === 0) {
+    // 文生视频需图片：排除 t2v（网页厂商）与 text2video（智谱 API）两种文案枚举；参考生（r2v）允许视频替代图片故一并放行
+    if (currentMode !== 't2v' && currentMode !== 'text2video' && imageCount === 0 && !(r2vVideoActive && refVideoLocalPaths.length > 0)) {
       const modeLabel = visibleModeOptions(provider, model, features, caps).find((m) => m.value === currentMode)?.label ?? '多参考'
       setGenError(`${modeLabel}需要至少上传一张素材图片`)
       return
     }
-    if (currentMode === 'img' && imageCount === 0) {
+    if ((currentMode === 'img' || currentMode === 'img2video') && imageCount === 0) {
       setGenError('图生视频需要先上传图片')
       return
     }
@@ -641,11 +993,20 @@ export default function Dashboard({
         resolution,
         audio,
         ratio,
-        images: currentMode === 't2v' && provider !== 'yuanbao'
+        images: (currentMode === 'text2video' || currentMode === 't2v') && provider !== 'yuanbao'
           ? []
           : [...savedImagePaths, ...imageFiles.map((f) => window.api.files.getPath(f)).filter(Boolean)].slice(0, maxImageUploadCount(provider, model)),
         // 厂商 API 用图片仅取公网 https URL（API 型厂商图生参考图）；WebView 厂商不传，主进程回退 images
         imageUrls: apiImageUrls.filter((u): u is string => typeof u === 'string' && /^https?:\/\//i.test(u)),
+        // 文生视频音频参考：公网 https URL 透传厂商（input.audio_url）+ 本地副本供历史回显/重新生成回填。
+        // 仅当当前模型能力卡明确暴露 Audio 时才随生成下发，避免残留音频状态误发到不支持（或字段未确认）的模型。
+        audioUrl: t2vSupportsAudio ? (audioUrl ?? undefined) : undefined,
+        audioLocalPath: t2vSupportsAudio ? (audioLocalPath ?? undefined) : undefined,
+        // 参考生（r2v）参考视频：videos=本地副本路径（历史回显/回填），videoUrls=公网 https URL（透传厂商 input.media reference_video）。
+        videos: r2vVideoActive ? refVideoLocalPaths.filter(Boolean) : undefined,
+        videoUrls: r2vVideoActive
+          ? refVideoUrls.filter((u): u is string => typeof u === 'string' && /^https?:\/\//i.test(u))
+          : undefined,
         showWebview: getInitialShowWebview()
       })
       activeJobIdRef.current = res.jobId ?? null
@@ -665,7 +1026,7 @@ export default function Dashboard({
       cancellingRef.current = false
       submittedRef.current = false
     }
-  }, [generating, fresh, step, prompt, mode, provider, model, features, caps, providerCaps, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, apiImageUrls, uploadingCount, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
+  }, [generating, fresh, step, prompt, mode, provider, model, features, caps, providerCaps, duration, durations, resolution, audio, ratio, imageFiles, savedImagePaths, apiImageUrls, uploadingCount, audioUploading, audioUrl, audioLocalPath, t2vSupportsAudio, r2vVideoActive, refVideoLocalPaths, refVideoUrls, refVideoUploading, user, team, usageScope, onGenerate, reloadJobs, onGoProviders, providerOptions])
 
   /** 终止生成：发送前有效；点击后按钮锁定「正在终止…」直到任务真正结束，防止连点 */
   const handleCancel = useCallback(async (): Promise<void> => {
@@ -703,29 +1064,31 @@ export default function Dashboard({
     const nextModel = modelList(value)[0] ?? MODELS.doubao[0]
     setModel(nextModel)
     const nextModes = visibleModeOptions(value, nextModel, features, providerCaps[value])
-    setMode(nextModes[0]?.value ?? 't2v')
-    setImages([])
-    setImageFiles([])
-    setSavedImagePaths([])
+    setMode(nextModes[0]?.value ?? 'text2video')
+    clearAllRefAssets()
   }
 
   const onModeChange = (value: string): void => {
     setMode(value)
-    if (value === 't2v' && provider !== 'yuanbao') {
+    // 文生视频（text2video）模式清空图片：图片上传区已隐藏，残留图片需一并清掉
+    if ((value === 'text2video' || value === 't2v') && provider !== 'yuanbao') {
       setImages([])
       setImageFiles([])
       setSavedImagePaths([])
+      setRefItemOrder((prev) => prev.filter((e) => e.k !== 'img'))
     }
+    // 非参考生（multi_ref）模式清空参考视频，避免切走后残留视频参考串场
+    if (value !== 'multi_ref') clearRefVideos()
+    // 切走参考生时同时清空整个素材顺序，避免遗留跨模式的旧顺序条目
+    if (value !== 'multi_ref' && r2vVideoActive) setRefItemOrder([])
   }
 
   const onModelChange = (value: string): void => {
     setModel(value)
     const nextModes = visibleModeOptions(provider, value, features, caps)
     if (!nextModes.some((m) => m.value === mode)) {
-      setMode(nextModes[0]?.value ?? 't2v')
-      setImages([])
-      setImageFiles([])
-      setSavedImagePaths([])
+      setMode(nextModes[0]?.value ?? 'text2video')
+      clearAllRefAssets()
     }
   }
 
@@ -774,7 +1137,7 @@ export default function Dashboard({
     const files = Array.from(e.target.files ?? [])
     const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
     const picked = files.slice(0, remaining)
-    if (provider === 'zhipu' || provider === 'volcengine') {
+    if (API_IMAGE_PROVIDERS.includes(provider)) {
       void appendApiImages(picked)
       e.target.value = ''
       return
@@ -791,7 +1154,7 @@ export default function Dashboard({
     e.preventDefault()
     const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
     const picked = files.slice(0, remaining)
-    if (provider === 'zhipu' || provider === 'volcengine') {
+    if (API_IMAGE_PROVIDERS.includes(provider)) {
       void appendApiImages(picked)
       return
     }
@@ -809,6 +1172,115 @@ export default function Dashboard({
       return prev.filter((_, i) => i !== idx - savedImagePaths.length)
     })
   }, [savedImagePaths])
+
+  // ===== 参考生（r2v）统一素材框：图片 + 视频 混合上传、一行预览（依赖 appendApiImages 声明在此之后）=====
+
+  // 单张图片 → 追加到图片数组并登记为 img 条目
+  //   关键：refItemOrder 条目必须在 savedImagePaths 占位符推入的**同一帧**登记，
+  //   否则 loading 判断 savedImagePaths[i]==='' 会因上传已完成而为 false
+  const appendImageAsRef = useCallback(async (file: File): Promise<void> => {
+    const beforeCount = savedImagePaths.length
+    if (!API_IMAGE_PROVIDERS.includes(provider)) {
+      // 非 API 厂商：直接走本地预览路径
+      const url = URL.createObjectURL(file)
+      setImages((prev) => [...prev, url])
+      setImageFiles((prev) => [...prev, file])
+      setRefItemOrder((prev) => [...prev, { k: 'img', i: images.length }])
+      return
+    }
+    // API 厂商（如 bailian）：appendApiImages 的前三 setState（images/savedImagePaths/apiImageUrls）
+    //   在**首次 await 之前同步执行**，所以这里紧接其后同步登记 refItemOrder 条目即可拿到占位符帧
+    void appendApiImages([file])
+    setRefItemOrder((prev) => {
+      if (prev.some((e) => e.k === 'img' && e.i === beforeCount)) return prev
+      return [...prev, { k: 'img', i: beforeCount }]
+    })
+  }, [provider, savedImagePaths.length, images.length, appendApiImages])
+
+  // 统一 pick 入口：按 MIME 分类分发到图片/视频上传
+  const onPickRefMixed = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    e.target.value = ''
+    let remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+    const picked = files.slice(0, remaining)
+    for (const f of picked) {
+      if (remaining <= 0) break
+      if (f.type.startsWith('video/')) {
+        await appendVideoAsRef(f)
+        remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+      } else if (f.type.startsWith('image/')) {
+        await appendImageAsRef(f)
+        remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+      }
+    }
+  }, [provider, model, totalRefItemCount, appendVideoAsRef, appendImageAsRef])
+
+  // 统一 paste 入口
+  const onPasteRefMixed = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
+    const files = Array.from(e.clipboardData.files ?? [])
+    if (files.length === 0) return
+    e.preventDefault()
+    void (async () => {
+      let remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+      for (const f of files) {
+        if (remaining <= 0) break
+        if (f.type.startsWith('video/')) {
+          await appendVideoAsRef(f)
+        } else if (f.type.startsWith('image/')) {
+          await appendImageAsRef(f)
+        } else {
+          continue
+        }
+        remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+      }
+    })()
+  }, [provider, model, totalRefItemCount, appendVideoAsRef, appendImageAsRef])
+
+  // 统一 drop 入口
+  const handleRefMixedDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+    const files = Array.from(e.dataTransfer.files ?? [])
+    if (files.length === 0) return
+    let remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+    for (const f of files) {
+      if (remaining <= 0) break
+      if (f.type.startsWith('video/')) {
+        await appendVideoAsRef(f)
+      } else if (f.type.startsWith('image/')) {
+        await appendImageAsRef(f)
+      } else {
+        continue
+      }
+      remaining = Math.max(0, MAX_REF_VIDEOS + maxImageUploadCount(provider, model) - totalRefItemCount)
+    }
+  }, [provider, model, totalRefItemCount, appendVideoAsRef, appendImageAsRef])
+
+  // 从统一素材框按顺序删除一个条目（自动维护同类条目下标）
+  const onRemoveRefMixed = useCallback((orderIdx: number): void => {
+    setRefItemOrder((prev) => {
+      const entry = prev[orderIdx]
+      if (!entry) return prev
+      if (entry.k === 'img') {
+        const i = entry.i
+        setImages((p) => p.filter((_, j) => j !== i))
+        setImageFiles((p) => p.filter((_, j) => j !== i))
+        setSavedImagePaths((p) => p.filter((_, j) => j !== i))
+        setApiImageUrls((p) => p.filter((_, j) => j !== i))
+      } else {
+        const i = entry.i
+        setRefVideoPreviews((p) => p.filter((_, j) => j !== i))
+        setRefVideoLocalPaths((p) => p.filter((_, j) => j !== i))
+        setRefVideoUrls((p) => p.filter((_, j) => j !== i))
+        setRefVideoNames((p) => p.filter((_, j) => j !== i))
+      }
+      // 从顺序数组里删除该条目，并把同类后续条目下标 -1
+      return prev
+        .filter((_, idx) => idx !== orderIdx)
+        .map((e) => {
+          if (e.k === entry.k && e.i > entry.i) return { ...e, i: e.i - 1 }
+          return e
+        })
+    })
+  }, [])
 
   return (
     <div className={'dashboard-wrap' + (banner ? ' has-banner' : '')}>
@@ -990,7 +1462,156 @@ export default function Dashboard({
             ) : null}
           </div>
 
-          {(mode !== 't2v' || provider === 'yuanbao') && (
+          {t2vSupportsAudio && (
+            <div className={'audio-upload' + (audioName ? ' has-audio' : '')}>
+              {audioUploading ? (
+                // 上传中占位：立即显示文件名 + loading 动效，避免用户看到空白无反馈
+                <div className="audio-player audio-loading">
+                  <div className="audio-play-btn" style={{ background: 'var(--border)', cursor: 'wait' }}>
+                    <span className="thumb-loading-spinner" />
+                  </div>
+                  <div className="audio-info">
+                    <span className="audio-name" title={audioName || ''}>{audioName || '上传中...'}</span>
+                    <div className="audio-progress">
+                      <div className="audio-progress-bar" style={{ width: '30%', animation: 'audio-loading 1.4s ease-in-out infinite' }} />
+                    </div>
+                    <span className="audio-time">上传中</span>
+                  </div>
+                </div>
+              ) : audioName && audioUrl ? (
+                <>
+                  {/* 隐藏原生 audio 元素，用自定义深色 UI 控制播放，避免白底控件破坏暗色主题 */}
+                  <audio ref={audioRef} src={audioUrl} preload="metadata" style={{ display: 'none' }} />
+                  <div className="audio-player" onClick={(e) => e.stopPropagation()}>
+                    <button
+                      className={'audio-play-btn' + (audioPlaying ? ' playing' : '')}
+                      onClick={toggleAudioPlay}
+                      title={audioPlaying ? '暂停' : '播放'}
+                    >
+                      {audioPlaying ? (
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                          <rect x="6" y="4" width="4" height="16" rx="1" />
+                          <rect x="14" y="4" width="4" height="16" rx="1" />
+                        </svg>
+                      ) : (
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      )}
+                    </button>
+                    <div className="audio-info">
+                      <span className="audio-name" title={audioName}>{audioName}</span>
+                      <div className="audio-progress" onClick={seekAudio}>
+                        <div
+                          className="audio-progress-bar"
+                          style={{ width: `${audioDuration > 0 ? (audioCurrentTime / audioDuration) * 100 : 0}%` }}
+                        />
+                      </div>
+                      <span className="audio-time">
+                        {fmtTime(audioCurrentTime)} / {fmtTime(audioDuration)}
+                      </span>
+                    </div>
+                    <button className="audio-remove-btn" onClick={onRemoveAudio} title="移除音频">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <label className="upload-zone audio-zone">
+                  <IconUpload size={14} />
+                  <span className="upload-text">仅支持上传音频作为参考</span>
+                  {audioUploading && <span className="thumb-loading-spinner" />}
+                  <input
+                    type="file"
+                    accept="audio/*"
+                    style={{ display: 'none' }}
+                    onChange={onPickAudio}
+                  />
+                </label>
+              )}
+            </div>
+          )}
+
+          {/* 参考生（r2v）且模型含 Video 能力：合并图片/视频上传为**一个**统一素材框，预览一行按添加顺序排列。
+          其余场景继续沿用默认图片上传框 */}
+          {r2vVideoActive ? (
+            <div
+              className={'upload-zone ref-mixed-zone' + (totalRefItemCount > 0 ? ' has-images' : '')}
+              onClick={() => refMixedInputRef.current?.click()}
+              onPaste={onPasteRefMixed}
+              onDragOver={(e) => { e.preventDefault() }}
+              onDrop={(e) => { e.preventDefault(); void handleRefMixedDrop(e) }}
+            >
+              {totalRefItemCount > 0 ? (
+                <div className="thumb-strip">
+                  {refItemOrder.map((entry, orderIdx) => {
+                    if (entry.k === 'img') {
+                      const src = images[entry.i]
+                      const uploading = entry.i < savedImagePaths.length && savedImagePaths[entry.i] === ''
+                      return (
+                        <div
+                          className="thumb-item"
+                          key={'img-' + orderIdx}
+                          title="点击预览图片"
+                          style={{ cursor: 'pointer' }}
+                          onClick={(e) => { e.stopPropagation(); if (src) setImagePreview(src) }}
+                        >
+                          <img src={src} alt="" />
+                          {uploading && (
+                            <div className="thumb-loading" title="图片上传中…">
+                              <span className="thumb-loading-spinner" />
+                            </div>
+                          )}
+                          <button className="remove-thumb" onClick={(e) => { e.stopPropagation(); onRemoveRefMixed(orderIdx) }}>×</button>
+                        </div>
+                      )
+                    }
+                    // video
+                    const vIdx = entry.i
+                    const vSrc = refVideoPreviews[vIdx]
+                    const vUploading = refVideoUploading && refVideoLocalPaths[vIdx] === ''
+                    return (
+                      <div
+                        className="thumb-item ref-video-item"
+                        key={'vid-' + orderIdx}
+                        title="点击预览视频"
+                        style={{ cursor: 'pointer' }}
+                        onClick={(e) => { e.stopPropagation(); if (vSrc) setRefVideoPreviewing(vSrc) }}
+                      >
+                        <video src={vSrc} muted preload="metadata" />
+                        {vUploading && (
+                          <div className="thumb-loading" title="视频上传中…">
+                            <span className="thumb-loading-spinner" />
+                          </div>
+                        )}
+                        <span className="thumb-play-mask"><IconPlay size={18} /></span>
+                        <button className="remove-thumb" onClick={(e) => { e.stopPropagation(); onRemoveRefMixed(orderIdx) }}>×</button>
+                      </div>
+                    )
+                  })}
+                  {totalRefItemCount < MAX_REF_VIDEOS + maxImageUploadCount(provider, model) && (
+                    <div className="thumb-add">+</div>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <IconUpload size={16} />
+                  <span className="upload-text">拖拽图片 / 视频到此处（多参考生成，最多 {MAX_REF_VIDEOS + maxImageUploadCount(provider, model)} 个）</span>
+                </>
+              )}
+              <input
+                ref={refMixedInputRef}
+                type="file"
+                accept="image/*,video/*"
+                multiple
+                style={{ display: 'none' }}
+                onChange={onPickRefMixed}
+              />
+            </div>
+          ) : ((mode !== 'text2video' || provider === 'yuanbao') && !t2vSupportsAudio && (
             <div
               className={'upload-zone' + (images.length > 0 ? ' has-images' : '')}
               onClick={onPickFiles}
@@ -1037,7 +1658,7 @@ export default function Dashboard({
                 onChange={onFilesSelected}
               />
             </div>
-          )}
+          ))}
 
           <div className="generate-actions">
             {genError && (
@@ -1056,7 +1677,7 @@ export default function Dashboard({
             )}
             <button
               className="btn-primary"
-              disabled={(generating && cancelling) || ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0)}
+              disabled={(generating && cancelling) || ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0) || audioUploading || refVideoUploading}
               onClick={() => {
                 if (generating) void handleCancel()
                 else void handleGenerate()
@@ -1323,6 +1944,16 @@ export default function Dashboard({
           document.body
         )}
 
+      {/* 音频裁剪弹窗：超长参考音频让用户自行拖选起止区间 */}
+      {cropAudio && (
+        <AudioCropModal
+          file={cropAudio.file}
+          duration={cropAudio.duration}
+          onCancel={handleCropCancel}
+          onConfirm={async (bytes) => { await handleCropDone(bytes, 0, 0) }}
+        />
+      )}
+
       {/* 预览浮层：网格不动，仅浮层内播放（避免竖屏视频撑高整行卡片） */}
       {preview && (
         <div
@@ -1348,6 +1979,50 @@ export default function Dashboard({
             />
             <button
               onClick={() => setPreview(null)}
+              style={{
+                position: 'absolute',
+                top: -40,
+                right: 0,
+                color: '#fff',
+                background: 'rgba(255,255,255,0.16)',
+                border: 'none',
+                borderRadius: 6,
+                padding: '4px 10px',
+                cursor: 'pointer',
+                fontSize: 13
+              }}
+            >
+              ✕ 关闭
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 参考视频预览浮层 */}
+      {refVideoPreviewing && (
+        <div
+          className="video-preview-overlay"
+          onClick={() => setRefVideoPreviewing(null)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 9999,
+            background: 'rgba(0,0,0,0.78)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24
+          }}
+        >
+          <div style={{ position: 'relative' }} onClick={(e) => e.stopPropagation()}>
+            <video
+              src={refVideoPreviewing}
+              controls
+              autoPlay
+              style={{ maxWidth: 'min(92vw, 860px)', maxHeight: '82vh', display: 'block', borderRadius: 10 }}
+            />
+            <button
+              onClick={() => setRefVideoPreviewing(null)}
               style={{
                 position: 'absolute',
                 top: -40,

--- a/apps/desktop/src/renderer/src/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/src/hooks/useJobs.ts
@@ -102,6 +102,8 @@ function toJobItem(row: JobListItem): JobItem {
       watermarkBBox,
       watermarkBBoxes,
       params,
+      audioLocalPath: readString(row.audioLocalPath),
+      audioUrl: readString(row.audioUrl),
       images,
       errorMessage: row.error ?? null
     }

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -68,16 +68,129 @@ export function volcModelDurations(model: string): number[] {
   return VOLC_MODEL_DURATIONS[model] ?? DEFAULT_SUPPORTED_DURATIONS
 }
 
-/** 阿里云百炼各模型固定生成时长（秒）；与主进程 api-branch 静态表保持一致 */
+/**
+ * 阿里云百炼各模型有效时长档（秒）；与主进程 bailianModelCap 能力卡口径保持一致。
+ * 来源：官网能力卡（wan2.6 最高 15s / wan2.5 10s / 参考生 5/10s / 其余默认 5/10s）。
+ */
 export const BAILIAN_MODEL_DURATIONS: Record<string, number[]> = {
+  'wan2.7-t2v': [5, 10],
+  'wan2.7-t2v-2026-04-25': [5, 10],
   'wan2.7-t2v-2026-06-12': [5, 10],
+  'wan2.7-i2v': [5, 10],
   'wan2.7-i2v-2026-04-25': [5, 10],
-  'wan2.7-r2v-2026-06-12': [5]
+  'wan2.7-r2v': [5, 10],
+  'wan2.7-r2v-2026-06-12': [5, 10],
+  'wan2.6-t2v': [5, 10, 15],
+  'wan2.6-i2v': [5, 10, 15],
+  'wan2.6-i2v-flash': [5, 10, 15],
+  'wan2.6-r2v': [5, 10],
+  'wan2.6-r2v-flash': [5, 10],
+  'wan2.5-t2v-preview': [5, 10],
+  'wan2.5-i2v-preview': [5, 10],
+  'wan2.2-t2v-plus': [5],
+  'wan2.2-i2v-plus': [5],
+  'wan2.2-i2v-flash': [5],
+  'wan2.2-kf2v-flash': [5],
+  'wanx2.1-t2v-plus': [5],
+  'wanx2.1-t2v-turbo': [5],
+  'wanx2.1-i2v-plus': [5],
+  'wanx2.1-i2v-turbo': [5],
+  'wanx2.1-kf2v-plus': [5],
+  'happyhorse-1.0-t2v': [5, 10],
+  'happyhorse-1.1-t2v': [5, 10],
+  'happyhorse-1.0-i2v': [5, 10],
+  'happyhorse-1.1-i2v': [5, 10],
+  'happyhorse-1.0-r2v': [5, 10],
+  'happyhorse-1.1-r2v': [5, 10]
 }
 
-/** 阿里云百炼按模型取有效时长；未收录模型回退默认档 */
+/** 阿里云百炼按模型名取有效时长档；未收录模型回退默认档（统一按官方能力卡，不再按 r2v 特殊 5s） */
 export function bailianModelDurations(model: string): number[] {
-  return BAILIAN_MODEL_DURATIONS[model] ?? DEFAULT_SUPPORTED_DURATIONS
+  return BAILIAN_MODEL_DURATIONS[model ?? ''] ?? DEFAULT_SUPPORTED_DURATIONS
+}
+
+/**
+ * 阿里云百炼各模型可用的生成模式（渲染层能力卡）。
+ * 与主进程 bailianModelCap 的 BAILIAN_VERIFIED_CAP.modes 口径完全一致：
+ * 依据官网能力卡「输入模态/输出模态」逐模型标注，而非仅看 t2v/i2v 命名段，
+ * 避免模式下拉落到裸 value 't2v' 或对同名家族快照（如 wan2.7-t2v=Audio+Text、
+ * wan2.7-t2v-2026-06-12=Text+Image）误判。detect/special 专用模型不做直接生成入口。
+ */
+const BAILIAN_MODEL_MODES: Record<string, Array<{ value: string; label: string }>> = {
+  // ---- wan2.7（Audio+Text→Video；2026-06-12 快照为 Text+Image→Video）----
+  'wan2.7-t2v': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.7-t2v-2026-04-25': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.7-t2v-2026-06-12': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.7-i2v': [
+    { value: 'img2video', label: '图生视频(首帧)' },
+    { value: 'first_last', label: '首尾帧生成' }
+  ],
+  'wan2.7-i2v-2026-04-25': [
+    { value: 'img2video', label: '图生视频(首帧)' },
+    { value: 'first_last', label: '首尾帧生成' }
+  ],
+  'wan2.7-r2v': [{ value: 'multi_ref', label: '多参考模式' }],
+  'wan2.7-r2v-2026-06-12': [{ value: 'multi_ref', label: '多参考模式' }],
+  // ---- wan2.6（Text/Image+Audio→Video+Audio，最高 15s；图生官方为「基于首帧」，不做首尾帧）----
+  'wan2.6-t2v': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.6-i2v': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wan2.6-i2v-flash': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wan2.6-r2v': [{ value: 'multi_ref', label: '多参考模式' }],
+  'wan2.6-r2v-flash': [{ value: 'multi_ref', label: '多参考模式' }],
+  // ---- wan2.5 preview ----
+  'wan2.5-t2v-preview': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.5-i2v-preview': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  // ---- wan2.2 ----
+  'wan2.2-t2v-plus': [{ value: 'text2video', label: '文生视频' }],
+  'wan2.2-i2v-plus': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wan2.2-i2v-flash': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wan2.2-kf2v-flash': [{ value: 'first_last', label: '首尾帧生成' }],
+  // ---- wanx2.1 ----
+  'wanx2.1-t2v-plus': [{ value: 'text2video', label: '文生视频' }],
+  'wanx2.1-t2v-turbo': [{ value: 'text2video', label: '文生视频' }],
+  'wanx2.1-i2v-plus': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wanx2.1-i2v-turbo': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'wanx2.1-kf2v-plus': [{ value: 'first_last', label: '首尾帧生成' }],
+  // ---- happyhorse ----
+  'happyhorse-1.0-t2v': [{ value: 'text2video', label: '文生视频' }],
+  'happyhorse-1.1-t2v': [{ value: 'text2video', label: '文生视频' }],
+  'happyhorse-1.0-i2v': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'happyhorse-1.1-i2v': [{ value: 'img2video', label: '图生视频(首帧)' }],
+  'happyhorse-1.0-r2v': [{ value: 'multi_ref', label: '多参考模式' }],
+  'happyhorse-1.1-r2v': [{ value: 'multi_ref', label: '多参考模式' }]
+}
+
+/**
+ * 阿里云百炼 t2v（文生视频）模型可对外暴露的输入能力（渲染层唯一口径）。
+ * 口径 =「用户可见的能力 = 能正确传参的模型」（measure-before-hardcode）：
+ * 与主进程 BAILIAN_VERIFIED_CAP 的 input 一致，但剔除字段未实测确认的模态
+ * （未确认就下发会把错误字段发给厂商）：
+ *   - wan2.7 系列音频已确认 `input.audio_url`（官方文生视频 API 参考 + SDK 示例）→ 暴露 'Audio'；
+ *   - wan2.7-t2v-2026-06-12 能力卡虽标 Text+Image，但官方「文生视频 API 参考」仅 input.audio_url，
+ *     无图片 media 传参字段 → 不暴露 'Image'（t2v 图片本轮不做）；其音频同样走 audio_url → 暴露 'Audio'；
+ *   - wan2.6-t2v / wan2.5-t2v-preview 旧协议音频字段未确认 → 不暴露 'Audio'。
+ * 用于驱动音频/图片上传区显隐；未收录 t2v 默认 ['Text']，不误开放任何上传入口。
+ */
+export function bailianModelInputs(model: string): string[] {
+  switch (model ?? '') {
+    case 'wan2.7-t2v':
+    case 'wan2.7-t2v-2026-04-25':
+    case 'wan2.7-t2v-2026-06-12':
+      return ['Audio', 'Text']
+    // 参考生（r2v）：实测（2026-08-21）确认当前账号/地域的 r2v 快照其 media[]
+    // 仅接受图片格式（jpeg/jpg/png/bmp/webp），不接受 mp4 视频（报「format mp4 is not supported」）。
+    // 因此只暴露 Image，驱动 multi_ref 上传区仅开放「参考图片」（多图），不开放视频入口。
+    // 说明：官方通用文档示例含 reference_video，但与本实测口径冲突，以实测为准（见 measure-before-hardcode）。
+    case 'wan2.7-r2v':
+    case 'wan2.7-r2v-2026-06-12':
+    case 'wan2.6-r2v':
+    case 'wan2.6-r2v-flash':
+    case 'happyhorse-1.0-r2v':
+    case 'happyhorse-1.1-r2v':
+      return ['Text', 'Image']
+    default:
+      return ['Text']
+  }
 }
 
 export interface DurationOption {
@@ -125,19 +238,28 @@ export function providerModeOptions(provider: string, model = ''): Array<{ value
     }
   }
   if (provider === 'bailian') {
-    switch (model) {
-      case 'wan2.7-t2v-2026-06-12':
-        return [{ value: 'text2video', label: '文生视频' }]
-      case 'wan2.7-i2v-2026-04-25':
-        return [
-          { value: 'img2video', label: '图生视频(首帧)' },
-          { value: 'first_last', label: '首尾帧生成' }
-        ]
-      case 'wan2.7-r2v-2026-06-12':
-        return [{ value: 'multi_ref', label: '参考生视频' }]
-      default:
-        return []
+    // 调度台模型来自账号免费额度快照，模式优先按 BAILIAN_MODEL_MODES 能力卡精确匹配，
+    // 未收录模型再按命名段回溯（r2v·refer=参考生 / kf2v=首尾帧 / i2v=图生 / t2v=文生）。
+    // 归属与主进程 bailianModelCap 完全一致，避免下拉落到裸 value 't2v'。
+    const m = model ?? ''
+    // t2v 标签动态附加能力提示：暴露 Audio 的模型（当前 wan2.7 系列，见 bailianModelInputs）
+    // 显示「支持音频参考」，与音频上传区和主进程能力卡口径一致，避免用户误以为文生视频不能传音频。
+    const t2vSuffix = bailianModelInputs(m).includes('Audio') ? '（支持音频参考）' : ''
+    const t2v = () => ({ value: 'text2video', label: `文生视频${t2vSuffix}` })
+    const exact = BAILIAN_MODEL_MODES[m]
+    if (exact) return exact.map((o) => (o.value === 'text2video' ? t2v() : o))
+    if (/(^|[_-])r2v([_-]|$)/i.test(m) || /refer/i.test(m)) {
+      return [{ value: 'multi_ref', label: '多参考模式' }]
     }
+    if (/(^|[_-])kf2v([_-]|$)/i.test(m) || /start-end/i.test(m)) {
+      return [{ value: 'first_last', label: '首尾帧生成' }]
+    }
+    if (/(^|[_-])i2v([_-]|$)/i.test(m)) {
+      return [{ value: 'img2video', label: '图生视频(首帧)' }]
+    }
+    if (/(^|[_-])t2v([_-]|$)/i.test(m)) return [t2v()]
+    // 兜底：识别不出类型的百炼视频模型统一按「文生视频」，避免下拉落到裸 value 't2v'
+    return [t2v()]
   }
   if (provider === 'qwenwan') {
     if (model === '万相 2.7') {
@@ -265,11 +387,23 @@ export function uploadHint(provider: string, mode: string): string {
     }
     return map[mode] ?? '文生视频无需上传素材'
   }
+  if (provider === 'bailian') {
+    // 百炼各模式显式映射，避免默认「文生视频无需上传素材」误导用户
+    const map: Record<string, string> = {
+      text2video: '文生视频无需上传素材',
+      img2video: '图生视频需上传 1 张首帧图片',
+      first_last: '首尾帧生成需上传首帧和尾帧共 2 张图片',
+      multi_ref: '多参考模式最多上传 5 张参考图',
+    }
+    return map[mode] ?? '拖拽图片到此处，最多 5 张'
+  }
   if (provider === 'yuanbao') return '上传图片作为参考（最多 10 张，Ctrl+V 可粘贴）'
   if (provider === 'dola') return '上传图片作为参考（最多 10 张，Ctrl+V 可粘贴）'
   if (provider === 'doubao' && mode === 'multi_ref') return '上传图片作为参考（最多 10 张）'
   if (mode === 'multi_ref') return '拖拽图片 / 视频到此处（多参考生成，最多 5 个）'
-  if (mode === 'img' || mode === 'first_last' || mode === 'first_frame') return '拖拽图片到此处，最多 5 张，或点击选择文件'
+  // 图生视频/首尾帧/首帧：提示需要图片素材
+  if (mode === 'img' || mode === 'img2video' || mode === 'first_last' || mode === 'first_frame')
+    return '拖拽图片到此处，最多 5 张，或点击选择文件'
   return '文生视频无需上传素材'
 }
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1037,6 +1037,170 @@ body {
   color: var(--accent);
 }
 
+/* 参考生（r2v）参考视频上传区 */
+.upload-zone .upload-zone-label {
+  white-space: nowrap;
+  color: var(--fg-muted);
+}
+.upload-zone .thumb-item.ref-video-item video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.upload-zone .thumb-item .thumb-play-mask {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+}
+
+/* 文生视频（bailian）音频参考上传区 */
+.audio-upload {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+}
+.audio-upload .audio-zone {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 40px;
+  max-height: 56px;
+  padding: 5px 10px;
+  box-sizing: border-box;
+}
+
+/* 自定义深色音频播放器 —— 替换原生 <audio controls> 白底风格，与暗色主题统一 */
+.audio-player {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 14px;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  box-sizing: border-box;
+  box-shadow: var(--shadow-inset);
+  color: var(--fg);
+  font-size: 0.88em;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.audio-player:hover {
+  border-color: var(--accent);
+}
+
+/* 播放/暂停按钮 —— 圆形 accent 色，呼应主按钮配色 */
+.audio-play-btn {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+.audio-play-btn:hover {
+  transform: scale(1.06);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.35);
+}
+.audio-play-btn:active {
+  transform: scale(0.94);
+}
+.audio-play-btn.playing {
+  background: var(--accent);
+}
+
+/* 音频信息区：文件名 + 进度条 + 时间 */
+.audio-info {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.audio-info .audio-name {
+  flex: 0 0 auto;
+  max-width: 160px;
+  min-width: 0;
+  font-size: 0.92em;
+  font-weight: 500;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.audio-info .audio-progress {
+  flex: 1 1 auto;
+  min-width: 40px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  cursor: pointer;
+  position: relative;
+  transition: height 0.15s ease;
+}
+.audio-info .audio-progress:hover {
+  height: 6px;
+}
+.audio-info .audio-progress-bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.1s linear;
+  min-width: 0;
+}
+.audio-info .audio-time {
+  flex: 0 0 auto;
+  font-size: 0.82em;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* 移除按钮 —— 与播放器配色协调，hover 时变红 */
+.audio-remove-btn {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: all 0.15s ease;
+}
+.audio-remove-btn:hover {
+  color: var(--error);
+  border-color: var(--error);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+/* 音频上传中动画：进度条脉冲效果 */
+@keyframes audio-loading {
+  0%   { margin-left: 0%;    width: 30%; }
+  50%  { margin-left: 35%;   width: 30%; }
+  100% { margin-left: 70%;   width: 30%; }
+}
+.audio-loading .audio-progress {
+  cursor: wait;
+}
+
   .generate-actions {
     display: flex;
     align-items: center;

--- a/apps/desktop/src/shared/history.ts
+++ b/apps/desktop/src/shared/history.ts
@@ -42,6 +42,10 @@ export interface JobRecord {
   watermarkBBoxes: WatermarkBBox[] | null
   /** 生成参数（模式/时长/比例/配音/分辨率），无记录时为 null */
   params: { mode?: string; durationSec?: number; ratio?: string; audio?: string; resolution?: string } | null
+  /** 文生视频音频参考的本地副本路径（历史回显/重新生成回填时重传取新 URL） */
+  audioLocalPath?: string | null
+  /** 文生视频音频参考的公网 https URL（旧记录兼容） */
+  audioUrl?: string | null
   /** 上传的本地图片副本路径（userData/images/<jobId>-<n>.<ext>），无图片时为空数组 */
   images: string[]
   errorMessage: string | null

--- a/docs/厂商与API平台接入/阿里云百炼视频生成接入方案.md
+++ b/docs/厂商与API平台接入/阿里云百炼视频生成接入方案.md
@@ -53,6 +53,38 @@
 
 - 免费额度（实测，见接入方案 §6.1）：`wan2.7-t2v-2026-06-12` 50、`wan2.7-r2v-2026-06-12` 50；`wan2.7-i2v-2026-04-25` **无免费**（`quotaStatus: UNKNOWN`）。
 
+### 3.1.1 模型能力判定准则（官方输入/输出模态，非命名段）
+> **定调**：一套模型的生成能力（模式、时长、分辨率）一律以官网能力卡的「输入模态 / 输出模态 / 输出规格」为准，**不得仅凭模型名里的 `t2v/i2v/r2v` 命名段推断**。同名模型家族常存在输入模态不同的快照版（如 `wan2.7-t2v`=Audio+Text，而 `wan2.7-t2v-2026-06-12`=Text+Image）。
+
+| 模型 | 输入模态 | 输出模态 | 生成模式（modes） | 时长(s) | 分辨率 |
+|---|---|---|---|---|---|
+| `wan2.7-t2v` | Audio + Text | Video | 文生视频 | 5 / 10 | 720P/1080P |
+| `wan2.7-t2v-2026-04-25` | Audio + Text | Video | 文生视频 | 5 / 10 | 720P/1080P |
+| `wan2.7-t2v-2026-06-12` | Text + Image | Video | 文生视频（支持图片参考） | 5 / 10 | 720P/1080P |
+| `wan2.7-i2v` / `-2026-04-25` | 文本/图像/音频/视频 | Video | 图生视频(首帧) + 首尾帧 | 5 / 10 | 720P/1080P |
+| `wan2.7-r2v` / `-2026-06-12` | 文本/图像/视频/音频 | Video | 参考生视频 | 5 / 10 | 720P/1080P |
+| `wan2.6-t2v` | Text + Audio | Video | 文生视频 | 5 / 10 / 15 | 720P/1080P |
+| `wan2.6-i2v` / `wan2.6-i2v-flash` | Text + Image + Audio | Video | 图生视频(首帧) **仅首帧** | 5 / 10 / 15 | 720P/1080P |
+| `wan2.6-r2v` / `wan2.6-r2v-flash` | Text + Image + Video | Video | 参考生视频 | 5 / 10 | 720P/1080P |
+| `wan2.5-t2v-preview` | Text + Audio | Video | 文生视频 | 5 / 10 | 480P/720P/1080P |
+| `wan2.5-i2v-preview` | Text + Image + Audio | Video | 图生视频(首帧) | 5 / 10 | 480P/720P/1080P |
+| `wan2.2-t2v-plus` | Text | Video | 文生视频 | **5** | 480P/1080P |
+| `wan2.2-i2v-plus` / `wan2.2-i2v-flash` | Text + Image | Video | 图生视频(首帧) | **5** | 480P/720P/1080P |
+| `wan2.2-kf2v-flash` | Text + Image | Video | 首尾帧生成 | **5** | 480P/720P/1080P |
+| `wanx2.1-t2v-plus` / `wanx2.1-t2v-turbo` | Text | Video | 文生视频 | **5** | 480P/720P/1080P |
+| `wanx2.1-i2v-plus` | Text + Image | Video | 图生视频(首帧) | **5** | 720P |
+| `wanx2.1-i2v-turbo` | Text + Image | Video | 图生视频(首帧) | **5**（官方 3/4/5，UI 取 5） | 480P/720P |
+| `wanx2.1-kf2v-plus` | Text + Image | Video | 首尾帧生成 | **5** | 720P |
+| `happyhorse-1.0/1.1-t2v` | Text | Video | 文生视频 | 5 / 10 | 720P/1080P |
+| `happyhorse-1.0/1.1-i2v` | Text + Image | Video | 图生视频(首帧) | 5 / 10 | 720P/1080P |
+| `happyhorse-1.0/1.1-r2v` | Text + Image | Video | 参考生视频 | 5 / 10 | 720P/1080P |
+
+要点：
+- **wan2.6 图生**官方归属「图生视频-基于首帧」专区，**只支持首帧、不支持首尾帧**；首尾帧仅 `wan2.7-i2v` 提供，故 `wan2.6-i2v[-flash]` 不暴露 `first_last` 模式。
+- **wan2.2 / wanx2.1 系官方固定 5s**，不得向这些模型传 10s；`wanx2.1-i2v-turbo` 官方为 3/4/5s，因项目时长档位仅 5/10/15，统一按 5s 可选。
+- detected/adaptation 类（`liveportrait*`、`videoretalk`、`animate-anyone*`）非直接生成入口，不暴露生成模式。
+- 实现落点：主进程 `bailianModelCap` 的 `BAILIAN_VERIFIED_CAP`（[bailian.ts](file:///d:/project/quota-flow/packages/providers/src/bailian.ts#L295-L320)）与渲染层 `spec.ts` 的 `BAILIAN_MODEL_MODES / BAILIAN_MODEL_DURATIONS` 两张能力卡口径完全一致，均以本文表为准。
+
 ### 3.2 协议骨架（DashScope 异步视频生成，字段以实测为准）
 - 提交：`POST {BASE}/api/v1/services/aigc/video-generation/video-synthesis`，Header `Authorization: Bearer <sk-...>` + `X-DashScope-Async: enable`。
 - body（示意，字段名待实测）：
@@ -84,8 +116,8 @@
 - 新增 `makeBailianBranch(): ApiGenerationBranch` 并注册 `API_BRANCHES.bailian`（对齐 zhipu/volcengine）：
   - `parseCredentials`：`decodeBailianPayload(decrypted)` → `{ apiKey }`（生成用 API Key，`consoleJwt/cookies` 不需要）。
   - `cost(model)`：t2v/r2v = 0（免费，但需防 403）；i2v = 1（付费按次，仅作展示，真钱按量）；按模型返回。
-  - `supportedDurations(model)`：t2v/i2v → `[5, 10]`；r2v → `[5]`（官方 2–10/2–15，UI 档位取 `[5,10]`，r2v `[5]`）。**是否加入其它档位由调度台 resolution 与免费额度过寿，实现时定死并在 UI 一致。**
-  - `modes`（`ApiModelInfo.modes`）：t2v=`[文生视频]`；i2v=`[图生视频(首帧), 首尾帧]`；r2v=`[参考生视频]`。
+  - `supportedDurations(model)`：统一交由 `bailianModelCap(model).durations`（能力卡，见 §3.1.1）返回，**不得**在分支内对 r2v/i2v 硬编码 `[5]/[5,10]`——wan2.2/wanx2.1 系官方固定 5s、wan2.6 支持 15s，均以能力卡为准并在 UI 一致。
+  - `modes`（`ApiModelInfo.modes`）：由 `bailianModelCap(model).modes`（能力卡）取，口径与渲染层 `BAILIAN_MODEL_MODES` 完全一致；wan2.6-i2v[-flash] 仅「图生视频(首帧)」，不暴露首尾帧。
   - `catalog()`：优先用账号 `freeTiers`（payload）过滤出未过期视频模型（复用 `isBailianVideoFreeModel` + 不 expired），补足免费额度；i2v 无免费额度走付费，展示「付费/按量」标签；回退内置静态目录（§4.1 静态表）。
   - `preflight?(model, plain)`：i2v 无免费额度 → 生成前返回 `{ ok: false, reason: '该模型按量付费，将扣账号余额，是否继续？' }` 或放行标记；实现时确认 dispatch 是否对 preflight 拦截有 UI 确认入口，若无则改为提示。
   - `generate(input, creds, params)`：

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -1015,7 +1015,12 @@ export interface JobListItem {
   ratio: string | null
   audio: string | null
   resolution: string | null
+  /** 文生视频音频参考的本地副本路径 / 公网 https URL（从 options 读取，重新生成回填用） */
+  audioLocalPath: string | null
+  audioUrl: string | null
   images: string[] | null
+  /** 参考生（r2v）参考视频的本地副本路径 / 公网 https URL（从 options 读取，重新生成回填用） */
+  videos: string[] | null
   status: JobStatus
   trace_id: string | null
   result_url: string | null
@@ -1093,7 +1098,7 @@ export class JobService {
     const to = from + pageSize - 1
     let builder = this.client
       .from('jobs')
-      .select('id, team_id, provider_id, mode, prompt, model:options->model, accountName:options->accountName, localPath:options->localPath, cleanLocalPath:options->cleanLocalPath, watermarkStatus:options->watermarkStatus, watermarkMethod:options->watermarkMethod, watermarkError:options->watermarkError, watermarkBBox:options->watermarkBBox, watermarkBBoxes:options->watermarkBBoxes, durationSec:options->durationSec, ratio:options->ratio, audio:options->audio, resolution:options->resolution, images:options->images, status, trace_id, result_url, error, cost_unit, cost_amount, created_at', { count: 'exact' })
+      .select('id, team_id, provider_id, mode, prompt, model:options->model, accountName:options->accountName, localPath:options->localPath, cleanLocalPath:options->cleanLocalPath, watermarkStatus:options->watermarkStatus, watermarkMethod:options->watermarkMethod, watermarkError:options->watermarkError, watermarkBBox:options->watermarkBBox, watermarkBBoxes:options->watermarkBBoxes, durationSec:options->durationSec, ratio:options->ratio, audio:options->audio, resolution:options->resolution, audioLocalPath:options->audioLocalPath, audioUrl:options->audioUrl, images:options->images, videos:options->videos, status, trace_id, result_url, error, cost_unit, cost_amount, created_at', { count: 'exact' })
       .eq('user_id', userId)
       .order('created_at', { ascending: false })
     const search = query.search?.trim()

--- a/packages/providers/src/bailian.ts
+++ b/packages/providers/src/bailian.ts
@@ -184,6 +184,9 @@ export function parseBailianFreeTierPayload(
   const arr = deepFindFreeTierQuotas(json);
   if (!arr || arr.length === 0) return null;
   const out: BailianFreeTierSlim[] = [];
+  // 同一模型可能因业务空间分区/缓存拼接出现多条快照；按 model 归一化去重，
+  // 同模型只保留「有效额度（remaining 大者）」的一条，避免聚合时把同一模型重复累加（表现为额度翻倍）。
+  const byModel = new Map<string, BailianFreeTierSlim>();
   for (const it of arr) {
     const model = String(it.model ?? it.Model ?? "");
     if (!model) continue;
@@ -193,29 +196,46 @@ export function parseBailianFreeTierPayload(
     const expiredAtMs = expiredAtMsRaw > 0 ? expiredAtMsRaw : null;
     const status = String(it.quotaStatus ?? it.status ?? (remaining > 0 ? "VALID" : "UNKNOWN"));
     const expired = expiredAtMs !== null ? expiredAtMs <= nowMs : remaining <= 0;
-    out.push({
-      model,
-      total,
-      remaining,
-      expired,
-      expiredAtMs,
-      status,
-    });
+    const slim: BailianFreeTierSlim = { model, total, remaining, expired, expiredAtMs, status };
+    const prev = byModel.get(model);
+    if (!prev) { byModel.set(model, slim); continue; }
+    // 同模型多快照：优先取「未过期且有效额度」的一条，其次取剩余更多者
+    const keep =
+      slim.expired && !prev.expired ? prev
+      : !slim.expired && prev.expired ? slim
+      : slim.remaining > prev.remaining ? slim
+      : prev;
+    byModel.set(model, keep);
   }
+  for (const slim of byModel.values()) out.push(slim);
   return out.length > 0 ? out : null;
 }
 
-/** 账号级聚合：把多模型免费额度汇总为单一「剩余/总量」，供账号明细口径展示。 */
+/** 账号级聚合：把多模型免费额度汇总为单一「剩余/总量」，供账号明细口径展示。
+ *  聚合前按 model 归一化去重（同一模型多快照只取价值最合适的一条），避免重复快照被累加导致额度翻倍。
+ */
 export function aggregateBailianFreeQuota(
   tiers: BailianFreeTierSlim[] | null | undefined,
 ): BailianFreeQuota {
   if (!tiers || tiers.length === 0) {
     return { available: false, remaining: 0, total: 0, expired: false };
   }
+  // 同模型取「未过期优先、其次剩余更大」的一条
+  const dedup = new Map<string, BailianFreeTierSlim>();
+  for (const t of tiers) {
+    const prev = dedup.get(t.model);
+    if (!prev) { dedup.set(t.model, t); continue; }
+    const keep =
+      t.expired && !prev.expired ? prev
+      : !t.expired && prev.expired ? t
+      : t.remaining > prev.remaining ? t
+      : prev;
+    dedup.set(t.model, keep);
+  }
   let total = 0;
   let remaining = 0;
   let expired = false;
-  for (const t of tiers) {
+  for (const t of dedup.values()) {
     total += t.total;
     remaining += Math.max(0, t.remaining);
     if (t.expired) expired = true;
@@ -245,6 +265,141 @@ export const BAILIAN_VIDEO_SYNTH_BASE_URL =
 
 /** 视频生成模型类型枚举。 */
 export type BailianVideoMode = "text2video" | "img2video" | "first_last" | "multi_ref";
+
+/**
+ * 单一模型的能力元数据（按官方视频生成文档 + 控制台实测命名归纳，属稳定元数据，可入常量）。
+ * kind：t2v 文生 / i2v 图生(首帧含首尾帧) / r2v 参考生 / kf2v 关键帧生 / detect 检测 / special 专用。
+ * direct=false 表示该模型是检测/专用模型（需要专属输入或前置），不能复用现有 4 模式直接生成，仅做展示标注。
+ */
+export interface BailianModelCap {
+  kind: "t2v" | "i2v" | "r2v" | "kf2v" | "detect" | "special";
+  /** 能力展示名 */
+  label: string;
+  /** 官方能力卡声明的输入模态（Text/Image/Video/Audio） */
+  input: string[];
+  /** 官方能力卡声明的输出模态（Video/Audio 等） */
+  output: string[];
+  /** 可选的生成模式（按需取子集；detect/special 可能为空，仅展示） */
+  modes: Array<{ value: BailianVideoMode; label: string }>;
+  /** 支持时长档位（秒） */
+  durations: number[];
+  /** 分辨率（API 写法，720P/1080P） */
+  resolutions: string[];
+  /** 是否可直接复用现有生成链路。false 时不做生成入口，仅展示能力 */
+  direct: boolean;
+}
+
+/** 单个模型的模式标签（用于模式下拉选项）。 */
+export const BAILIAN_MODE_T2V = { value: "text2video" as BailianVideoMode, label: "文生视频" };
+export const BAILIAN_MODE_I2V = { value: "img2video" as BailianVideoMode, label: "图生视频(首帧)" };
+export const BAILIAN_MODE_FIRST_LAST = {
+  value: "first_last" as BailianVideoMode,
+  label: "首尾帧生成"
+};
+export const BAILIAN_MODE_REF = { value: "multi_ref" as BailianVideoMode, label: "参考生视频" };
+
+const BAILIAN_CAP_RES = ['720P', '1080P'];
+const BAILIAN_CAP_DEFAULT_DUR = [5, 10];
+
+/**
+ * 按模型名逐一核实的能力卡（来源：阿里云百炼官网 help.aliyun.com/zh/model-studio/<模型> 的「模型能力/输入模态」表，
+ * 更新时间 2026-07~08，属稳定元数据，可入常量）。
+ *
+ * 关键：同名家族的不同快照版本，输入模态会因快照而异（如 wan2.7-t2v=Audio+Text，而其 2026-06-12 快照=Text+Image），
+ * 因此不能仅凭 t2v/i2v 命名段猜能力，必须逐模型对照官方「输入模态/输出模态」。
+ */
+const BAILIAN_VERIFIED_CAP: Record<string, Omit<BailianModelCap, 'resolutions'>> = {
+  // ---- wan2.7 ----
+  // 注：wan2.7-t2v-2026-06-12 官方能力卡标注 Text+Image，但其文生视频 SDK 示例同样使用 input.audio_url（官方文档确认），
+  // 故 Audio 一并纳入。Image 为能力卡声明但 HTTP 文生视频 API 无图片传参字段，实际下发仅走 audio_url，图片不误发。
+  'wan2.7-t2v': { kind: 't2v', label: '文生视频', input: ['Audio', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-t2v-2026-04-25': { kind: 't2v', label: '文生视频', input: ['Audio', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-t2v-2026-06-12': { kind: 't2v', label: '文生视频（支持音频参考）', input: ['Audio', 'Text', 'Image'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-i2v': { kind: 'i2v', label: '图生视频', input: ['Audio', 'Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V, BAILIAN_MODE_FIRST_LAST], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-i2v-2026-04-25': { kind: 'i2v', label: '图生视频', input: ['Audio', 'Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V, BAILIAN_MODE_FIRST_LAST], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-r2v': { kind: 'r2v', label: '参考生视频', input: ['Audio', 'Image', 'Text', 'Video'], output: ['Video'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.7-r2v-2026-06-12': { kind: 'r2v', label: '参考生视频', input: ['Text', 'Image', 'Video', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  // ---- wan2.6 ----
+  'wan2.6-t2v': { kind: 't2v', label: '文生视频', input: ['Text', 'Audio'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_T2V], durations: [5, 10, 15], direct: true },
+  // wan2.6 图生视频官方归属「图生视频-基于首帧」（仅首帧，不做首尾帧），故只暴露 i2v 模式
+  'wan2.6-i2v': { kind: 'i2v', label: '图生视频(首帧)', input: ['Text', 'Image', 'Audio'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_I2V], durations: [5, 10, 15], direct: true },
+  'wan2.6-i2v-flash': { kind: 'i2v', label: '图生视频(首帧)', input: ['Text', 'Image', 'Audio'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_I2V], durations: [5, 10, 15], direct: true },
+  'wan2.6-r2v': { kind: 'r2v', label: '参考生视频', input: ['Image', 'Video', 'Text'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'wan2.6-r2v-flash': { kind: 'r2v', label: '参考生视频', input: ['Image', 'Video', 'Text'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  // ---- wan2.5 ----
+  'wan2.5-t2v-preview': { kind: 't2v', label: '文生视频', input: ['Text', 'Audio'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_T2V], durations: [5, 10], direct: true },
+  'wan2.5-i2v-preview': { kind: 'i2v', label: '图生视频(首帧)', input: ['Text', 'Image', 'Audio'], output: ['Video', 'Audio'], modes: [BAILIAN_MODE_I2V], durations: [5, 10], direct: true },
+  // ---- wan2.2（官方固定 5s；图生仅首帧，kf2v 为首尾帧）----
+  'wan2.2-t2v-plus': { kind: 't2v', label: '文生视频', input: ['Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: [5], direct: true },
+  'wan2.2-i2v-plus': { kind: 'i2v', label: '图生视频(首帧)', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: [5], direct: true },
+  'wan2.2-i2v-flash': { kind: 'i2v', label: '图生视频(首帧)', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: [5], direct: true },
+  'wan2.2-kf2v-flash': { kind: 'kf2v', label: '首尾帧生成', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_FIRST_LAST], durations: [5], direct: true },
+  // ---- wanx2.1（官方固定 5s；i2v-turbo 为 3/4/5s，因 UI 长档仅 5/10/15 与 5s 档，统一按 5s 可选）----
+  'wanx2.1-t2v-plus': { kind: 't2v', label: '文生视频', input: ['Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: [5], direct: true },
+  'wanx2.1-t2v-turbo': { kind: 't2v', label: '文生视频', input: ['Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: [5], direct: true },
+  'wanx2.1-i2v-plus': { kind: 'i2v', label: '图生视频(首帧)', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: [5], direct: true },
+  'wanx2.1-i2v-turbo': { kind: 'i2v', label: '图生视频(首帧)', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: [5], direct: true },
+  'wanx2.1-kf2v-plus': { kind: 'kf2v', label: '首尾帧生成', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_FIRST_LAST], durations: [5], direct: true },
+  // ---- happyhorse ----
+  'happyhorse-1.0-t2v': { kind: 't2v', label: '文生视频', input: ['Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'happyhorse-1.1-t2v': { kind: 't2v', label: '文生视频', input: ['Text'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'happyhorse-1.0-i2v': { kind: 'i2v', label: '图生视频', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'happyhorse-1.1-i2v': { kind: 'i2v', label: '图生视频', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_I2V], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'happyhorse-1.0-r2v': { kind: 'r2v', label: '参考生视频', input: ['Image', 'Video', 'Text', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  'happyhorse-1.1-r2v': { kind: 'r2v', label: '参考生视频', input: ['Image', 'Video', 'Text', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, direct: true },
+  // ---- 对口型 / 数字人 / 动作驱动 / 检测（专用，不可直接生成）----
+  'videoretalk': { kind: 'special', label: '视频口型替换·声动人像（人物视频+人声音频）', input: ['Video', 'Audio'], output: ['Video'], modes: [], durations: [5, 10], direct: false },
+  'liveportrait': { kind: 'special', label: '图生播报·灵动人像（肖像图片+人声音频）', input: ['Image', 'Audio'], output: ['Video'], modes: [], durations: [5, 10], direct: false },
+  'liveportrait-detect': { kind: 'detect', label: '灵动人像·图片合规检测（前置检测）', input: ['Image'], output: ['判定结果'], modes: [], durations: [5], direct: false },
+  'animate-anyone-gen2': { kind: 'special', label: '舞动人像动作视频(人物图片+动作模板ID)', input: ['Image'], output: ['Video'], modes: [], durations: [5], direct: false },
+  'animate-anyone-template-gen2': { kind: 'special', label: '舞动人像·动作模板提取（从其成视频）', input: ['Video'], output: ['模板ID'], modes: [], durations: [5], direct: false },
+  'animate-anyone-detect-gen2': { kind: 'detect', label: '舞动人像·图片合规检测（前置检测）', input: ['Image'], output: ['判定结果'], modes: [], durations: [5], direct: false }
+};
+
+/**
+ * 按模型名归纳能力（官方能力卡实测 + 命名段兜底）。
+ * 先精确匹配 BAILIAN_VERIFIED_CAP（逐模型对照官方输入/输出模态，准确）；未收录的模型再按 t2v/i2v/r2v/kf2v 命名段回溯。
+ */
+export function bailianModelCap(model: string): BailianModelCap {
+  const m = (model || '').trim();
+  const lower = m.toLowerCase();
+
+  const verified = BAILIAN_VERIFIED_CAP[m];
+  if (verified) {
+    return { ...verified, resolutions: BAILIAN_CAP_RES };
+  }
+
+  // ---- 命名段兜底（未收录模型；能力可能随版本演进，尽可能走上面精确表）----
+  if (/(^|[_-])detect([_-]|$)/.test(lower) || /-detect\b|detection/i.test(lower)) {
+    return { kind: 'detect', label: '检测/预处理模型（不可直接生成，需配套主模型）', input: ['Image'], output: ['判定结果'], modes: [], durations: [5], resolutions: BAILIAN_CAP_RES, direct: false };
+  }
+  if (/videoretalk/i.test(lower)) {
+    return { kind: 'special', label: '视频口型替换·声动人像（人物视频+人声音频）', input: ['Video', 'Audio'], output: ['Video'], modes: [], durations: [5, 10], resolutions: BAILIAN_CAP_RES, direct: false };
+  }
+  if (/liveportrait/i.test(lower)) {
+    return { kind: 'special', label: '图生播报·灵动人像（肖像图片+人声音频）', input: ['Image', 'Audio'], output: ['Video'], modes: [], durations: [5, 10], resolutions: BAILIAN_CAP_RES, direct: false };
+  }
+  if (/animate-anyone|^animate-/i.test(lower)) {
+    return { kind: 'special', label: '舞动人像 AnimateAnyone（需配套 detect/template 前置）', input: ['Image', 'Video'], output: ['Video'], modes: [], durations: [5], resolutions: BAILIAN_CAP_RES, direct: false };
+  }
+
+  // 标准视频生成模型（未逐个核实，按官方命名段回溯）
+  if (/(^|[_-])r2v([_-]|$)/i.test(lower)) {
+    return { kind: 'r2v', label: '参考生视频', input: ['Image', 'Video', 'Text', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_REF], durations: BAILIAN_CAP_DEFAULT_DUR, resolutions: BAILIAN_CAP_RES, direct: true };
+  }
+  if (/(^|[_-])kf2v([_-]|$)/i.test(lower)) {
+    return { kind: 'kf2v', label: '首尾帧生成', input: ['Image', 'Text'], output: ['Video'], modes: [BAILIAN_MODE_FIRST_LAST], durations: BAILIAN_CAP_DEFAULT_DUR, resolutions: BAILIAN_CAP_RES, direct: true };
+  }
+  if (/(^|[_-])i2v([_-]|$)/i.test(lower)) {
+    return { kind: 'i2v', label: '图生视频', input: ['Image', 'Text', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_I2V, BAILIAN_MODE_FIRST_LAST], durations: BAILIAN_CAP_DEFAULT_DUR, resolutions: BAILIAN_CAP_RES, direct: true };
+  }
+  if (/(^|[_-])t2v([_-]|$)/i.test(lower)) {
+    return { kind: 't2v', label: '文生视频', input: ['Text', 'Audio'], output: ['Video'], modes: [BAILIAN_MODE_T2V], durations: BAILIAN_CAP_DEFAULT_DUR, resolutions: BAILIAN_CAP_RES, direct: true };
+  }
+
+  // 兜底：未识别类型的视频模型，仅展示、不可直接生成
+  return { kind: 'special', label: '视频模型（模式未识别）', input: ['Text'], output: ['Video'], modes: [], durations: [5], resolutions: BAILIAN_CAP_RES, direct: false };
+}
 
 /** 生成模式 → 单元统一值（0=文生, 1=图生首帧, 2=首尾帧；参考映射到图生/参考语义） */
 export function bailianVideoImageCount(mode: BailianVideoMode): number {
@@ -282,6 +437,8 @@ export interface BailianGenerateOptions {
   prompt?: string;
   /** 图生/首尾/参考：公网 https 图片 URL 数组（首帧 1 / 首尾 2 / 参考 1+） */
   images?: string[];
+  /** 参考生（r2v）：公网 https 视频 URL 数组，与 images 合入 input.media[]（reference_video） */
+  videos?: string[];
   /** 视频时长（秒，整数） */
   durationSec?: number;
   /** 分辨率：'720' | '1080'（调度台写法），落 API 时映射为 '720P' / '1080P' */
@@ -320,7 +477,10 @@ export async function bailianGenerateWithKey(
   const { mode, model } = opts;
   const imgs = (opts.images ?? []).filter((u) => /^https?:\/\//i.test(String(u).trim()));
   const need = bailianVideoImageCount(mode);
-  if (need > 0 && imgs.length < need) {
+  // 参考生（multi_ref）：实测当前 r2v 快照 media[] 仅收图片、不收 mp4，故按图片数校验（至少 1 张）；其余模式按图片数校验
+  const needOk =
+    mode === "multi_ref" ? imgs.length >= 1 : need > 0 ? imgs.length >= need : true;
+  if (!needOk) {
     return {
       ok: false,
       model,
@@ -328,7 +488,7 @@ export async function bailianGenerateWithKey(
         need === 2
           ? "首尾帧生成需要上传首帧和尾帧共 2 张图片"
           : mode === "multi_ref"
-            ? "参考生视频需要至少上传 1 张参考图"
+            ? "参考生视频需要至少上传 1 张参考图或参考视频"
             : "图生视频需要至少上传 1 张首帧图片",
     };
   }
@@ -340,7 +500,24 @@ export async function bailianGenerateWithKey(
     input["img_url"] = imgs[0];
     input["img2_url"] = imgs[1];
   }
-  if (mode === "multi_ref" && imgs.length >= 1) input["img_url"] = imgs[0];
+  // 参考生（r2v）：官方「参考生视频 API 参考」确认使用 input.media[]（公网 http/https）。
+  // 实测（2026-08-21）：当前账号/地域的 r2v 快照，其 media[].type 只接受 "reference_image"，
+  // 且媒体内容仅支持图片格式（jpeg/jpg/png/bmp/webp），不接受 mp4 视频
+  // （传视频/标 reference_video 均报错，见 bailianModelInputs 注释）。故此处仅按图片组装。
+  // 图片合计 ≤5；与图片类 img_url（仅 i2v 首帧字段）不同，r2v 不得沿用 img_url。
+  if (mode === "multi_ref" && imgs.length > 0) {
+    const media = imgs
+      .slice(0, 5)
+      .map((url) => ({ type: "reference_image" as const, url }));
+    if (media.length > 0) input["media"] = media;
+  }
+
+  // 文生视频支持音频参考：官方「万相2.7-文生视频 API 参考」确认 input.audio_url（公网 http/https）。
+  // 仅当模型能力含 Audio 且传入合法 https URL 时才下发，避免对不支持音频的模型发出无效传参。
+  if (mode === "text2video" && bailianModelCap(model).input.includes("Audio")) {
+    const audioUrl = (opts.promptAudioUrl ?? "").trim();
+    if (/^https?:\/\//i.test(audioUrl)) input["audio_url"] = audioUrl;
+  }
 
   const parameters: Record<string, unknown> = {};
   const resMap: Record<string, string> = { "720": "720P", "1080": "1080P" };
@@ -498,9 +675,10 @@ export async function pollBailianTask(
       };
     }
     if (isFail(uuidStatus)) {
-      const reasonRaw = output["message"] ?? data["message"] ?? output["error"] ?? data["error"] ?? uuidStatus;
+      const rawMsg = String(output["message"] ?? data["message"] ?? output["error"] ?? data["error"] ?? "");
+      const userMsg = translateBailianFailMessage(rawMsg);
       genLog(`terminal fail status=${uuidStatus}`, data);
-      return { ok: false, model, error: `阿里云百炼任务${String(reasonRaw)}` };
+      return { ok: false, model, error: userMsg };
     }
     if (polls >= BAILIAN_POLL_MAX) {
       return { ok: false, model, error: `阿里云百炼任务轮询超时（约 ${Math.round((Date.now() - startedAt) / 1000)} 秒）` };
@@ -530,4 +708,53 @@ export async function testBailianApiKey(
   } catch {
     return { ok: false, error: "校验失败（网络错误或超时）" };
   }
+}
+
+/** 将阿里云百炼任务失败消息翻译为用户可读的中文提示。
+ *  仅覆盖常见/高频业务错误，其余回退为精简版原始信息。
+ */
+function translateBailianFailMessage(raw: string): string {
+  if (!raw) return "阿里云百炼任务失败（未知原因）";
+  const msg = raw.trim();
+
+  // 参考音频时长超限（t2v 场景最常见）
+  if (/duration.*at most 30s|duration.*should be at most 30|audio.*duration.*30/i.test(msg)) {
+    const m = msg.match(/got ([\d.]+)s?/i);
+    const got = m ? `（当前 ${m[1]}s）` : "";
+    return `参考音频时长需 ≤ 30 秒${got}，请裁剪后重试`;
+  }
+  // 图片格式/尺寸不支持
+  if (/format.*not supported|image.*format/i.test(msg)) {
+    return "图片格式或尺寸不符合要求（支持 jpg/png/bmp/webp，单边 ≤ 8000px）";
+  }
+  if (/image.*resolution|resolution.*invalid|image.*size.*exceed/i.test(msg)) {
+    return "图片分辨率或大小不符合要求（单边 240–8000px，≤20MB）";
+  }
+  // 视频格式/时长问题
+  if (/video.*duration|video.*format|mp4.*not supported/i.test(msg)) {
+    return "视频文件格式或时长不符合要求（支持 mp4/mov，时长 1–30s）";
+  }
+  // 图片数量/总数超限
+  if (/at most \d+.*images|exceed.*\d+.*images|total.*exceed/i.test(msg)) {
+    return "参考图片数量超出限制（最多 5 张）";
+  }
+  // 角色/主体超限
+  if (/at most \d+.*characters|exceed.*character|too many.*character/i.test(msg)) {
+    return "参考主体数量超出限制（每个参考素材建议只包含单一主体）";
+  }
+  // 免费额度用尽
+  if (/quota|allocation|free.*tier|exhaust/i.test(msg)) {
+    return "免费额度已用完，请更换账号或等待次日额度刷新";
+  }
+  // Prompt 问题
+  if (/prompt.*length|prompt.*exceed|prompt.*too long/i.test(msg)) {
+    return "提示词过长（上限 5000 字符），请精简后重试";
+  }
+  // URL 无法访问
+  if (/url.*invalid|url.*not.*accessible|url.*error|cannot.*download/i.test(msg)) {
+    return "素材 URL 无法被厂商访问（需为公网 https 链接，建议使用 CDN）";
+  }
+  // 回退：去掉 URL 等干扰信息，保留核心
+  const clean = msg.replace(/https?:\/\/\S+/gi, "[URL]");
+  return `阿里云百炼任务失败：${clean}`;
 }


### PR DESCRIPTION
## 修改内容

### 1. 音频参考裁剪弹窗（AudioCropModal 新增）
- 新增 AudioCropModal.tsx：上传音频参考文件时，若超过限制（如 30s）提示用户裁剪
- 支持在波形上直接选择起止区间，确认后裁剪为 WAV 重新上传
- 纯前端实现（Web Audio API），不依赖外部服务

### 2. 百炼音视频生成增强（bailian.ts +257 行）
- 支持音频参考视频生成（参考音轨 + 画面提示词）
- 额度查询、生成提交、轮询状态逻辑完善
- spec.ts：新增音视频模型与参数配置（+168 行）

### 3. Dashboard 重构（+753 行）
- 视频/音频生成表单重构：支持音频参考、时长、分辨率等参数
- 新增音频裁剪交互入口
- styles.css：新增相关样式（+164 行）
- App.tsx：路由/组件挂载调整

### 4. 桌面端核心改动
- api-branch.ts（+67）：百炼音视频分支逻辑
- dispatch.ts（+51）：调度适配音频参考任务
- index.ts（main, +43）：注册音频裁剪/上传相关 IPC
- preload/index.ts（+10）：对应 IPC 桥接
- providers.ts（+17）、useJobs.ts（+2）、shared/history.ts（+4）：数据适配

### 5. 数据库层
- db-supabase/src/index.ts（+7）：音频任务相关查询字段

### 6. 文档
- 阿里云百炼音视频生成接入方案.md 更新