### PR TITLE
feat: TokenHub 厂商接入（API 型 + 额度查询 + UI 适配）

### DIFF
--- a/apps/desktop/src/main/api-branch.ts
+++ b/apps/desktop/src/main/api-branch.ts
@@ -26,7 +26,10 @@ import {
   volcengineGenBlocker,
   volcengineModelFreeStatus,
   volcGenTokenEstimate,
-  VOLC_DECOMMISSIONED_MODELS
+  VOLC_DECOMMISSIONED_MODELS,
+  decodeTokenhubPayload,
+  tokenhubFreeVideoModels,
+  tokenhubGenerateWithKey
 } from '@quota-flow/providers'
 import type { VolcengineFreeVideoModel, ZhipuGenerateOptions, BailianGenerateOptions, BailianFreeTierSlim } from '@quota-flow/providers'
 import { ipcMain, safeStorage } from 'electron'
@@ -475,13 +478,6 @@ function makeBailianBranch(): ApiGenerationBranch {
   }
 }
 
-/** 已注册的 API 生成分支（key = providerId） */
-export const API_BRANCHES: Record<string, ApiGenerationBranch> = {
-  zhipu: makeZhipuBranch(),
-  volcengine: makeVolcengineBranch(),
-  bailian: makeBailianBranch()
-}
-
 /** 火山方舟免费视频模型默认时长（未收录固定时长走通用档） */
 const VOLC_ENGINE_MODEL_DURATIONS = [5, 10]
 /** 火山免费视频模型统一支持文生 + 图生（Seedance 均有免费推理额度） */
@@ -604,6 +600,102 @@ function makeVolcengineBranch(): ApiGenerationBranch {
 
 let apiIpcRegistered = false
 
+/**
+ * 腾讯云 TokenHub 视频生成目录（静态兜底表）。四个免费视频模型积分费率/计费方式已实测官方（产品计费 1823/130055）。
+ * 时长档官方 OpenAI 兼容示例未给出（见计划 §4.3），先按项目默认档 [5] 作为 TEMP 兜底，待真实提交实测后修正。
+ */
+const TOKENHUB_MODELS = tokenhubFreeVideoModels()
+/** 各模型生成模式（FX 需「特效模板」参数，现调度台无模板选择器，暂不开放生成入口） */
+const TOKENHUB_MODEL_MODES: Record<string, Array<{ value: string; label: string }>> = {
+  'hy-video-1.5': [
+    { value: 'text2video', label: '文生视频' },
+    { value: 'img2video', label: '图生视频' }
+  ],
+  'yt-video-2.0': [{ value: 'img2video', label: '图生视频' }],
+  'yt-video-humanactor': [{ value: 'img2video', label: '图生视频' }],
+  'yt-video-fx': []
+}
+
+function makeTokenhubBranch(): ApiGenerationBranch {
+  return {
+    id: 'tokenhub',
+    displayName: '腾讯云TokenHub',
+    unitName: '积分',
+    parseCredentials(decrypted) {
+      try {
+        const { apiKey } = decodeTokenhubPayload(decrypted)
+        return apiKey ? { apiKey } : null
+      } catch {
+        return null
+      }
+    },
+    cost() {
+      // 本轮接入的均为免费视频模型，cost=0；本地账本不对 tokenhub 做原子扣减（Uin 级共享积分）
+      return 0
+    },
+    supportedDurations() {
+      // TEMP: 时长档待真实提交实测（计划 §4.3），先按项目默认档兜底
+      return [5]
+    },
+    async remaining() {
+      // Uin 级积分接口尚未实测（计划 §4.2），返回 null 表示「未知」，不做公开 API 实时查询
+      return null
+    },
+    preflight() {
+      // Uin 级积分未知时不做客户端硬拦截：免费额度耗尽由服务端拒绝（含 403 未领取），生成错误分类提示即可，
+      // 避免「额度未知→全拦死」导致无法生成（对齐百炼 bailian 的做法）。
+      return { ok: true }
+    },
+    catalog(perModelFreeQuota) {
+      return TOKENHUB_MODELS.map((m) => {
+        const isFx = m.id === 'yt-video-fx'
+        return {
+          model: m.id,
+          priceLabel: m.price,
+          cost: 0,
+          durations: m.durations?.length ? m.durations : [5],
+          size: null,
+          modes: TOKENHUB_MODEL_MODES[m.id] ?? [],
+          freeQuota: perModelFreeQuota?.[m.id],
+          ...(isFx ? { unavailable: 'no_endpoint' as const, unavailableLabel: '已识别免费模型，待模板选择器' } : {})
+        }
+      })
+    },
+    async generate(input, creds, params) {
+      if (params.mode !== 'text2video' && params.mode !== 'img2video') {
+        return { ok: false, error: '腾讯云TokenHub 当前仅支持文生视频 / 图生视频' }
+      }
+      const images = (params.images ?? []).filter((u) => /^https?:\/\//i.test(u))
+      if (params.mode === 'img2video' && images.length < 1) {
+        return { ok: false, error: '图生视频需要至少上传 1 张公网 HTTPS 图片' }
+      }
+      const r = await tokenhubGenerateWithKey(creds.apiKey, {
+        mode: params.mode,
+        model: params.model,
+        prompt: params.prompt,
+        images,
+        onProgress: params.onProgress
+      })
+      return {
+        ok: r.ok,
+        videoUrl: r.videoUrl,
+        coverImageUrl: r.coverImageUrl,
+        traceId: r.traceId,
+        error: r.error,
+        unavailable: r.unavailable
+      }
+    }
+  }
+}
+
+/** 已注册的 API 生成分支（key = providerId） */
+export const API_BRANCHES: Record<string, ApiGenerationBranch> = {
+  zhipu: makeZhipuBranch(),
+  volcengine: makeVolcengineBranch(),
+  bailian: makeBailianBranch(),
+  tokenhub: makeTokenhubBranch()
+}
+
 /** 注册 API 型厂商相关 IPC：provider:api-models（「查看模型」弹窗目录） */
 export function registerApiIpc(): void {
   if (apiIpcRegistered) return
@@ -656,6 +748,27 @@ export function registerApiIpc(): void {
           for (const m of models) {
             if (m?.id && m.freeQuota) perModelFreeQuota[m.id] = m.freeQuota
           }
+        }
+      } catch {}
+    }
+    // 腾讯云 TokenHub：优先读负载里绑定时捕获的每模型 freeQuota（DescribeModelEndpointList），
+    // 旧负载无 models 时回退到 Uin 级共享 points，对每个免费模型叠加展示
+    if (providerId === 'tokenhub' && typeof encrypted === 'string' && encrypted) {
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
+        const payload = decodeTokenhubPayload(plain)
+        if (Array.isArray(payload.models)) {
+          const byId: Record<string, { remaining?: number; total?: number }> = {}
+          for (const m of payload.models) {
+            if (m?.id && m.freeQuota && typeof m.freeQuota.remaining === 'number') {
+              byId[m.id] = { remaining: m.freeQuota.remaining, total: m.freeQuota.total }
+            }
+          }
+          if (Object.keys(byId).length > 0) perModelFreeQuota = byId
+        } else if (payload.points && typeof payload.points.remaining === 'number') {
+          perModelFreeQuota = Object.fromEntries(
+            tokenhubFreeVideoModels().map((m) => [m.id, { remaining: payload.points!.remaining, total: payload.points!.total ?? 0 }])
+          )
         }
       } catch {}
     }

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -71,6 +71,8 @@ export interface QuotaUpdatedPayload {
   volcRefreshKeyId?: string
   /** 阿里云百炼生成成功后触发：渲染层据此静默重抓该账号控制台最新免费额度 */
   bailianRefreshKeyId?: string
+  /** 腾讯云 TokenHub 生成成功后触发：渲染层据此刷新该账号额度（本轮未实测积分接口，预留钩子） */
+  tokenhubRefreshKeyId?: string
 }
 
 const UA =
@@ -937,7 +939,9 @@ async function runApiBranch(
       ? { volcRefreshKeyId: cand.id }
       : providerId === 'bailian'
         ? { bailianRefreshKeyId: cand.id }
-        : { zhipuRefreshKeyId: cand.id })
+        : providerId === 'tokenhub'
+          ? { tokenhubRefreshKeyId: cand.id }
+          : { zhipuRefreshKeyId: cand.id })
   })
   return { ok: true, jobId: job.id }
 }

--- a/apps/desktop/src/main/providers.ts
+++ b/apps/desktop/src/main/providers.ts
@@ -23,7 +23,25 @@ import {
   aggregateBailianFreeQuota,
   isBailianVideoFreeModel
 } from '@quota-flow/providers'
-import type { VolcengineFreeVideoModel, BailianStoredCookie } from '@quota-flow/providers'
+import {
+  testTokenhubApiKey,
+  tokenhubAccountFingerprint,
+  decodeTokenhubPayload,
+  fetchTokenhubQuota,
+  parseTokenhubDescribeResponse,
+  attachTokenhubFreeQuota,
+  tokenhubFreeVideoModels,
+  TKH_CONSOLE_APIKEY_URL,
+  TKH_CONSOLE_OPEN_URL,
+  TKH_CONSOLE_PARTITION
+} from '@quota-flow/providers'
+import type {
+  VolcengineFreeVideoModel,
+  BailianStoredCookie,
+  TokenhubStoredCookie,
+  TokenhubFreeVideoModel,
+  TokenhubModelQuota
+} from '@quota-flow/providers'
 
 /** 对「解密后的明文」仅做透明的 models 不可用标记写入，返回新明文（不触发网络；consoleJwt/accountId 原样保留）。 */
 export function markVolcModelUnavailable(
@@ -86,6 +104,7 @@ export type ProviderId =
   | 'kling'
   | 'hailuo'
   | 'bailian'
+  | 'tokenhub'
 
 interface ProviderSite {
   loginUrl?: string
@@ -130,6 +149,11 @@ const PROVIDER_SITES: Record<ProviderId, ProviderSite> = {
   bailian: {
     loginUrl: 'https://bailian.console.aliyun.com/cn-beijing?tab=model#/api-key',
     healthUrl: 'https://bailian.console.aliyun.com/'
+  },
+  // 腾讯云 TokenHub：tokenhub 为 apikey 厂商，登录页指向「API Key 管理」页
+  tokenhub: {
+    loginUrl: 'https://console.cloud.tencent.com/tokenhub/apikey',
+    healthUrl: 'https://console.cloud.tencent.com/'
   }
 }
 
@@ -174,9 +198,49 @@ const ZHIPU_CONSOLE_PARTITION = 'persist:qf-zhipu-console'
 function zhipuConsolePartitionFor(keyId?: string): string {
   return keyId ? `${ZHIPU_CONSOLE_PARTITION}:${keyId}` : ZHIPU_CONSOLE_PARTITION
 }
+/** 腾讯云 TokenHub 控制台会话分区（账号级隔离，独立于通用 persist:qf-p:tokenhub） */
+function tokenhubConsolePartitionFor(keyId?: string): string {
+  return keyId ? `${TKH_CONSOLE_PARTITION}:${keyId}` : TKH_CONSOLE_PARTITION
+}
+function tokenhubConsoleSession(keyId?: string): Electron.Session {
+  return session.fromPartition(tokenhubConsolePartitionFor(keyId))
+}
+/** 腾讯云 TokenHub 控制台域名（cookie 建档 origin） */
+const TKH_CONSOLE_ORIGIN = 'https://console.cloud.tencent.com'
+/** 腾讯云 TokenHub 每模型额度静默同步时间戳（供「查看模型」自愈续抓节流） */
+const tokenhubSyncAt = new Map<string, number>()
+
+/**
+ * 绑定捕获时的 TokenHub 控制台 cookie 缓存（按 uin 暂存）。
+ * 用途：渲染层把捕获结果落库负载时可能因状态/旧 bundle 丢 cookies，加密兜底合并这里最近的捕获结果，
+ * 确保登录 cookie 一定随负载持久化，供「进入官网」跨重启重新注入。
+ */
+const tokenhubCapturedCookies = new Map<string, TokenhubStoredCookie[]>()
+
+/** 向 TokenHub 控制台分区回注入 cookie（定向到 tokenhubConsolePartitionFor，避免写入通用分区） */
+async function injectTokenhubConsoleCookies(keyId: string, cookies: TokenhubStoredCookie[]): Promise<void> {
+  const ses = session.fromPartition(tokenhubConsolePartitionFor(keyId))
+  ses.setUserAgent(CHROME_UA)
+  for (const c of cookies) {
+    try {
+      await ses.cookies.set({
+        url: `${c.secure ? 'https' : 'http'}://${(c.domain || '').replace(/^\./, '') || TKH_CONSOLE_ORIGIN.replace(/^https?:\/\//, '')}${c.path || '/'}`,
+        domain: c.domain || undefined,
+        name: c.name,
+        value: c.value,
+        httpOnly: c.httpOnly,
+        secure: c.secure,
+        expirationDate: typeof c.expires === 'number' && c.expires > 0 ? Math.floor(c.expires / 1000) : undefined
+      })
+    } catch {
+      // 单条失败不阻塞其余注入
+    }
+  }
+}
 function partitionFor(providerId: string, keyId?: string): string {
   if (providerId === 'zhipu') return zhipuConsolePartitionFor(keyId)
   if (providerId === 'volcengine') return volcConsolePartitionFor(keyId)
+  if (providerId === 'tokenhub') return tokenhubConsolePartitionFor(keyId)
   const base = 'persist:qf-p:' + providerId
   return keyId ? `${base}:${keyId}` : base
 }
@@ -773,6 +837,11 @@ async function openProviderSite(
     } catch {
       /* 诊断失败不影响打开官网 */
     }
+  } else if (providerId === 'tokenhub') {
+    // 复用绑定时捕获会话所在分区（persist:qf-tokenhub-console[:keyId]），打开即带已登录会话；每账号独立分区不串号
+    url = TKH_CONSOLE_APIKEY_URL
+    partition = tokenhubConsolePartitionFor(keyId)
+    injectableEncrypted = encryptedKey
   } else {
     const site = providerSite(providerId)
     url = site?.loginUrl || site?.healthUrl
@@ -810,6 +879,19 @@ async function openProviderSite(
           )
         } catch (e) {
           console.log(`[qf-bailian] OPEN-SITE-INJECT keyId=${keyId} payloadCookies=${payloadCookies} err=${e instanceof Error ? e.message : String(e)}`)
+        }
+      } else if (providerId === 'tokenhub') {
+        // TokenHub 同百炼：登录态落在持久控制台分区，重启后未必留存 authenticating cookie，
+        // 从加密负载读取绑定时持久化的控制台 cookie 重注入，重建登录态（不覆盖目标分区已有 cookie）
+        let payloadCookies = 0
+        try {
+          const plain = safeStorage.decryptString(Buffer.from(injectableEncrypted, 'base64'))
+          const d = decodeTokenhubPayload(plain)
+          payloadCookies = Array.isArray(d.cookies) ? d.cookies.length : 0
+          if (payloadCookies > 0) await injectTokenhubConsoleCookies(keyId, d.cookies!)
+          console.log(`[qf-tokenhub] OPEN-SITE-INJECT keyId=${keyId} payloadCookies=${payloadCookies}`)
+        } catch (e) {
+          console.log(`[qf-tokenhub] OPEN-SITE-INJECT keyId=${keyId} payloadCookies=${payloadCookies} err=${e instanceof Error ? e.message : String(e)}`)
         }
       } else {
         const parsed = parseStoredCredentials(injectableEncrypted, providerId)
@@ -2701,6 +2783,282 @@ export async function captureBailianConsoleSession(opts?: {
 
 let registered = false
 
+/**
+ * 腾讯云 TokenHub 控制台会话捕获。
+ * TokenHub 免费额度是「主账号(Uin)级共享积分」（话单在启用管理页，数据面公开 API 读不到）。
+ * 本轮先捕获主账号标识 uin，用于 tokenhubAccountFingerprint 生成账号级去重指纹（同 Uin 多 API Key 去重）；
+ * Uin 级积分采集接口尚未实测确认（见计划 §4.2/4.5），额度展示走本地账本周期授信，不做凭猜的积分抓取。
+ * 捕获依赖腾讯云控制台下发的 uin cookie（值形如 o<uin>）；登录后检测到即自动关闭窗口返回。
+ */
+export async function captureTokenhubConsoleSession(opts?: {
+  quiet?: boolean
+  keyId?: string
+}): Promise<{
+  ok: boolean
+  uin?: string
+  cookies?: TokenhubStoredCookie[]
+  /** 实抓到的每模型免费额度（挂到目录模型上；抓不到则缺省，由渲染层当「额度未知」展示） */
+  models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>
+  error?: string
+}> {
+  const quiet = !!opts?.quiet
+  const optKeyId = opts?.keyId
+  const winKey = `${quiet ? 'tokenhub-console-quiet' : 'tokenhub-console'}:${optKeyId ?? 'shared'}`
+  const existing = loginWindows.get(winKey)
+  if (existing && !existing.isDestroyed()) {
+    existing.focus()
+    return { ok: false, error: quiet ? '会话捕获进行中' : '腾讯云TokenHub 控制台窗口已打开' }
+  }
+  // 首次交互式绑定清空登录态避免残留；静默续期保留
+  if (!quiet) {
+    try {
+      await tokenhubConsoleSession(optKeyId).clearStorageData()
+    } catch {}
+  }
+  const ses = tokenhubConsoleSession(optKeyId)
+
+  const win = new BrowserWindow({
+    width: 1120,
+    height: 800,
+    minWidth: 900,
+    minHeight: 600,
+    show: !quiet,
+    paintWhenInitiallyHidden: true,
+    autoHideMenuBar: true,
+    title: quiet ? '腾讯云控制台 - Quota-Flow' : 'Quota-Flow · 腾讯云控制台（TokenHub）',
+    backgroundColor: '#ffffff',
+    webPreferences: {
+      partition: tokenhubConsolePartitionFor(optKeyId),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+  ses.setUserAgent(CHROME_UA)
+  win.webContents.setUserAgent(CHROME_UA)
+  // 拦截非 http(s) 深链跳转，避免触发系统级「打开此链接的应用」弹窗
+  const BLOCKED_PROTO_RE = /^(?!https?:)[a-z][a-z0-9+.-]*:/i
+  win.webContents.on('will-navigate', (ev, url) => {
+    if (BLOCKED_PROTO_RE.test(url)) ev.preventDefault()
+  })
+  win.webContents.setWindowOpenHandler(({ url }) => (BLOCKED_PROTO_RE.test(url) ? { action: 'deny' } : { action: 'allow' }))
+  loginWindows.set(winKey, win)
+  win.on('closed', () => loginWindows.delete(winKey))
+  void win.loadURL(TKH_CONSOLE_OPEN_URL).catch(() => {})
+
+  // 交互式绑定：注入可拖拽悬浮提示条，引导用户登录后复制 API Key（静默续期窗口隐藏无需提示）
+  if (!quiet) {
+    const HINT_INJECT = `(() => {
+      if (window.__QUOTA_FLOW_TOKENHUB_UI__) return;
+      window.__QUOTA_FLOW_TOKENHUB_UI__ = true;
+      const bar = document.createElement('div');
+      bar.id = 'qf-tokenhub-bar';
+      bar.style.cssText = 'position:fixed;top:12px;left:12px;z-index:2147483647;display:flex;flex-direction:column;gap:6px;padding:8px 12px;border-radius:8px;background:rgba(20,20,22,.92);color:#fff;font:12.5px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;box-shadow:0 4px 16px rgba(0,0,0,.35);user-select:none;max-width:460px;';
+      bar.innerHTML =
+        '<div id="qf-tokenhub-header" style="display:flex;align-items:center;gap:6px;font-weight:600;color:#fff;cursor:grab;font-size:12.5px;">' +
+        '<span id="qf-tokenhub-grip" style="color:#9aa0a6;letter-spacing:1px;font-size:13px;">⋮⋮</span>' +
+        '<span>Quota-Flow · 腾讯云 TokenHub 控制台</span>' +
+        '</div>' +
+        '<div style="color:#c4c8d0;font-size:12px;line-height:1.4;">请在页面登录后前往「TokenHub → API Key 管理」复制 API Key；</div>' +
+        '<div style="color:#c4c8d0;font-size:12px;line-height:1.4;">复制完成后，回到 Quota-Flow 窗口粘贴 API Key 并保存。</div>' +
+        '<div style="display:flex;justify-content:flex-end;">' +
+        '<button id="qf-tokenhub-close" style="padding:5px 12px;border:0;border-radius:6px;background:#2ea56f;color:#fff;font:600 12px/1 inherit;cursor:pointer;">已复制，关闭窗口</button>' +
+        '</div>';
+      document.body.appendChild(bar);
+      document.getElementById('qf-tokenhub-close').addEventListener('click', () => { window.close(); });
+      let dragging = false, offX = 0, offY = 0;
+      const grip = document.getElementById('qf-tokenhub-grip');
+      const header = document.getElementById('qf-tokenhub-header');
+      const barEl = document.getElementById('qf-tokenhub-bar');
+      const startDrag = (e) => { dragging = true; offX = e.clientX - barEl.offsetLeft; offY = e.clientY - barEl.offsetTop; barEl.style.cursor = 'grabbing'; e.preventDefault(); };
+      if (grip) grip.addEventListener('mousedown', startDrag);
+      if (header) header.addEventListener('mousedown', startDrag);
+      document.addEventListener('mousemove', (e) => { if (!dragging) return; const x = Math.max(4, Math.min(window.innerWidth - barEl.offsetWidth - 4, e.clientX - offX)); const y = Math.max(4, Math.min(window.innerHeight - barEl.offsetHeight - 4, e.clientY - offY)); barEl.style.left = x + 'px'; barEl.style.top = y + 'px'; });
+      document.addEventListener('mouseup', () => { dragging = false; barEl.style.cursor = 'grab'; });
+    })()`
+    win.webContents.on('did-finish-load', () => {
+      setTimeout(() => {
+        // 注入延后于加载完成执行，但定时器可能迟于窗口关闭触发：webContents 已销毁时直接跳过
+        if (win.isDestroyed() || win.webContents.isDestroyed()) return
+        void win.webContents.executeJavaScript(HINT_INJECT).catch(() => {})
+      }, 500)
+    })
+  }
+
+  // —— 免费额度捕获（每模型） ——
+  // 「启用管理」默认落在「语言模型」标签；注入 fetch/XHR 钩子拦截 DescribeModelEndpointList(VISION) 响应，
+  // 并自动点开「视觉模型」标签触发 VISION 请求。响应文本累积到 window.__TKH_RESPONSES__ 供主进程读回解析。
+  // 实测契约（2026-08-21）：响应 data.data.data.Response.ModelEndpointSet[]，元素 ModelId + ChargeType='FREE' +
+  // FreeTrialClaimed=true + ChargeDetail(字符串) -> FreeQuota{TotalQuota,UsedQuota,UsagePercent,ExpireTime}；每模型独立 50 积分。
+  const CAP_INJECT = `(() => {
+    if (window.__QUOTA_FLOW_TKH_CAP__) return;
+    window.__QUOTA_FLOW_TKH_CAP__ = true;
+    window.__TKH_RESPONSES__ = window.__TKH_RESPONSES__ || [];
+    window.__TKH_SUBMIT__ = false;
+    const ingest = (u, t) => {
+      try {
+        if (!u || String(u).indexOf('DescribeModelEndpointList') < 0) return;
+        if (typeof t !== 'string' || !t) return;
+        window.__TKH_RESPONSES__.push(t);
+        if (window.__TKH_RESPONSES__.length > 10) window.__TKH_RESPONSES__ = window.__TKH_RESPONSES__.slice(-10);
+        window.__TKH_SUBMIT__ = true;
+        window.__TKH_OK__ = true;
+      } catch (_) {}
+    };
+    const oOF = window.fetch;
+    window.fetch = function (...args) {
+      const url = typeof args[0] === 'string' ? args[0] : ((args[0] && args[0].url) || '');
+      return oOF.apply(this, args).then((res) => {
+        try { if (String(url).indexOf('DescribeModelEndpointList') >= 0) res.clone().text().then((t) => ingest(url, t)); } catch (_) {}
+        return res;
+      });
+    };
+    const oX = XMLHttpRequest.prototype.open;
+    const oS = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.open = function (m, u) { this.__qfu = u; return oX.apply(this, arguments); };
+    XMLHttpRequest.prototype.send = function (body) {
+      if (this.__qfu && String(this.__qfu).indexOf('DescribeModelEndpointList') >= 0) {
+        const self = this, u = this.__qfu;
+        this.addEventListener('loadend', function () { try { ingest(u, self.responseText || ''); } catch (_) {} });
+      }
+      return oS.apply(this, arguments);
+    };
+    const tryOpenVision = () => {
+      try {
+        const tabs = Array.from(document.querySelectorAll('li, a, button, div, span'));
+        const hit = tabs.filter((e) => e.childElementCount <= 1 && e.textContent && e.textContent.trim() === '视觉模型' && e.tagName !== 'A');
+        if (hit.length) hit[0].click();
+      } catch (_) {}
+    };
+    // 交互式绑定用户可能未登录，VISION 请求在登录后才生效；周期性重触发视觉模型标签直至拿到一条响应。
+    window.__TKH_OK__ = false;
+    tryOpenVision();
+    window.__TKH_RETRY__ = setInterval(function () {
+      try {
+        if (!window.__TKH_OK__) tryOpenVision();
+        else if (window.__TKH_RETRY__) { clearInterval(window.__TKH_RETRY__); window.__TKH_RETRY__ = null; }
+      } catch (_) {}
+    }, 4000);
+  })()`
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(() => {
+      if (win.isDestroyed() || win.webContents.isDestroyed()) return
+      void win.webContents.executeJavaScript(CAP_INJECT).catch(() => {})
+    }, 400)
+  })
+
+  // 腾讯云控制台把当前主账号 uin 写入 uin cookie，值为 o<uin>（leading 'o' 去掉即纯数字账号）。
+  const resolveUin = async (): Promise<string | null> => {
+    try {
+      const cks = await ses.cookies.get({ url: 'https://console.cloud.tencent.com' })
+      for (const c of cks) {
+        if (c.name === 'uin' && c.value) {
+          const v = c.value.replace(/^o/i, '').trim()
+          if (/^\d+$/.test(v)) return v
+        }
+      }
+    } catch {}
+    return null
+  }
+
+  const FREQ_MS = 1200
+  const MAX_WAIT_MS = 5 * 60 * 1000
+  /** uin 首次捕获后再给额度最长等待：静默续期/交互绑定都不至于久挂；额度通常登录后 2-4s 内就到 */
+  const QUOTA_GRACE_MS = 12000
+  // 已捕获到的 uin（账号级去重维度）；记录后窗口关闭时据其归档最终完整登录 cookie
+  let capturedUin: string | null = null
+  let uinAt = 0
+  /** 已解析出的每模型免费额度（DescribeModelEndpointList → parseTokenhubDescribeResponse 归一） */
+  let capturedQuota: Array<{ model: string; quota: TokenhubModelQuota }> | null = null
+  /** 从该账号控制台分区收集登录 cookie 并写入缓存（供「进入官网」跨重启重建登录态；encrypt 兜底合并） */
+  const collectCookies = async (uin: string): Promise<void> => {
+    try {
+      const cs = exportCookies(await ses.cookies.get({}))
+      if (cs.length > 0) tokenhubCapturedCookies.set(uin, cs)
+    } catch {}
+  }
+  /** 读回页面里已拦截到的 DescribeModelEndpointList 响应，解析为每模型额度 */
+  const readQuota = async (): Promise<void> => {
+    try {
+      if (win.isDestroyed() || win.webContents.isDestroyed()) return
+      const raw = await win.webContents.executeJavaScript(
+        'window.__TKH_SUBMIT__ ? JSON.stringify(window.__TKH_RESPONSES__) : null'
+      )
+      if (typeof raw !== 'string' || !raw) return
+      const list = JSON.parse(raw) as string[]
+      const seen = new Map<string, TokenhubModelQuota>()
+      for (const t of list || []) {
+        for (const e of parseTokenhubDescribeResponse(t)) {
+          if (!seen.has(e.model)) seen.set(e.model, e.quota)
+        }
+      }
+      if (seen.size > 0) capturedQuota = Array.from(seen.entries()).map(([model, quota]) => ({ model, quota }))
+    } catch {}
+  }
+  const buildModels = (): Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }> | undefined =>
+    capturedQuota && capturedQuota.length
+      ? attachTokenhubFreeQuota(tokenhubFreeVideoModels(), Object.fromEntries(capturedQuota.map((i) => [i.model, i.quota])))
+      : undefined
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (
+      res: { ok: boolean; uin?: string; models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>; error?: string },
+      closeWin = true
+    ) => {
+      if (settled) return
+      settled = true
+      clearInterval(timer)
+      clearTimeout(timeout)
+      // 清理页面注入的周期点击 Timer，避免窗口关闭后残留
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        try {
+          void win.webContents.executeJavaScript('if(window.__TKH_RETRY__){clearInterval(window.__TKH_RETRY__);window.__TKH_RETRY__=null}')
+        } catch {}
+      }
+      if (closeWin) {
+        try {
+          if (!win.isDestroyed()) win.close()
+        } catch {}
+      }
+      resolve(res)
+    }
+    win.on('closed', () => {
+      // 无论是否已 settle：交互式窗口中用户登录并复制完 API Key 后关闭窗口，登录态已定型，
+      // 此时再收集一次「最终完整登录 cookie」覆盖缓存，供加密兜底合并（避免 uin 刚出现时收集到不完整登录态）
+      if (capturedUin) void collectCookies(capturedUin)
+      if (!settled) finish({ ok: false, error: '窗口已关闭' })
+    })
+    const tick = async () => {
+      if (win.isDestroyed() || settled) {
+        clearInterval(timer)
+        return
+      }
+      const uin = await resolveUin()
+      if (uin && !settled && !capturedUin) {
+        console.log(`[qf-tokenhub] CAPTURE uin=${uin}`)
+        capturedUin = uin
+        uinAt = Date.now()
+        // 立即收集一次作为兜底底稿；最终完整登录态以窗口关闭时归档为准
+        await collectCookies(uin)
+      }
+      if (!settled) {
+        await readQuota()
+        if (capturedQuota && capturedQuota.length) {
+          console.log(`[qf-tokenhub] CAPTURE quota models=${capturedQuota.length}`)
+        }
+      }
+      // 已拿 uin，且「拿到每模型额度 或 额度宽限已过」→ 结算。
+      // 交互式(closeWin=false)结算后保持窗口打开供用户复制 API Key；静默续期(closeWin=true)关窗释放。
+      if (capturedUin && !settled && ((capturedQuota && capturedQuota.length > 0) || Date.now() - uinAt > QUOTA_GRACE_MS)) {
+        finish({ ok: true, uin: capturedUin, models: buildModels() }, quiet)
+      }
+    }
+    const timer = setInterval(() => void tick(), FREQ_MS)
+    const timeout = setTimeout(() => finish({ ok: false, error: '捕获超时，请确认已登录腾讯云控制台' }), MAX_WAIT_MS)
+    void tick()
+  })
+}
+
 export function initProviders(): void {
   if (registered) return
   registered = true
@@ -2731,6 +3089,23 @@ export function initProviders(): void {
             }
           }
         }
+      } else if (providerId === 'tokenhub') {
+        // TokenHub 同百炼兜底：捕获的 uin 存在但负载未带入 cookies 时，用缓存最近一次同 uin 的 cokies 合并
+        const trimmedT = (plain || '').trim()
+        if (trimmedT.startsWith('{')) {
+          const d = decodeTokenhubPayload(trimmedT)
+          if (d.uin && (!Array.isArray(d.cookies) || d.cookies.length === 0)) {
+            const live = tokenhubCapturedCookies.get(d.uin)
+            if (live && live.length > 0) {
+              try {
+                const obj = JSON.parse(trimmedT)
+                obj.cookies = live
+                payloadPlain = JSON.stringify(obj)
+                console.log(`[qf-tokenhub] ENC mergeCapturedCookies uin=${d.uin} n=${live.length}`)
+              } catch {}
+            }
+          }
+        }
       }
       const encrypted = safeStorage.encryptString(payloadPlain).toString('base64')
       // apikey 型厂商：指纹用于去重。
@@ -2745,7 +3120,9 @@ export function initProviders(): void {
               ? await volcengineAccountFingerprint(plain)
               : providerId === 'bailian'
                 ? await bailianAccountFingerprint(plain)
-                : fingerprintFor(providerId, plain.trim())
+                : providerId === 'tokenhub'
+                  ? await tokenhubAccountFingerprint(plain)
+                  : fingerprintFor(providerId, plain.trim())
         // 火山方舟去重诊断：确认 accountId 是否进链路、指纹是「账号级」还是退化成「Key 哈希」
         if (providerId === 'volcengine') {
           const { accountId } = decodeVolcenginePayload(plain)
@@ -2780,7 +3157,9 @@ export function initProviders(): void {
         ? await testVolcengineApiKey(apiKey)
         : providerId === 'bailian'
           ? await testBailianApiKey(apiKey)
-          : await testZhipuApiKey(apiKey)
+          : providerId === 'tokenhub'
+            ? await testTokenhubApiKey(apiKey)
+            : await testZhipuApiKey(apiKey)
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : 'API Key 校验失败' }
     }
@@ -2799,6 +3178,12 @@ export function initProviders(): void {
           (t) => isBailianVideoFreeModel(t.model) && !t.expired
         )
         return { ok: true, quota: aggregateBailianFreeQuota(tiers) }
+      }
+      if (providerId === 'tokenhub') {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { apiKey, uin } = decodeTokenhubPayload(plain)
+        if (!apiKey) return { ok: false, error: '未解析到 API Key' }
+        return fetchTokenhubQuota(apiKey, uin ?? undefined)
       }
       const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
       const { apiKey, consoleJwt } = decodeZhipuPayload(plain)
@@ -2826,6 +3211,14 @@ export function initProviders(): void {
     return captureVolcEngineConsoleSession({
       keyId: typeof keyId === 'string' && keyId ? keyId : undefined,
       targetUrl: VOLC_OPEN_MANAGEMENT_URL
+    })
+  })
+
+  // 腾讯云 TokenHub 控制台会话捕获：按账号 keyId 弹出「启用管理」页并捕获主账号标识 uin（去重维度）。
+  // uin 用于 tokenhubAccountFingerprint 生成账号级指纹；未捕获则加密时退化为按 API Key 哈希去重。
+  ipcMain.handle('provider:capture-tokenhub-session', async (_e, keyId?: string) => {
+    return captureTokenhubConsoleSession({
+      keyId: typeof keyId === 'string' && keyId ? keyId : undefined
     })
   })
 
@@ -2996,6 +3389,60 @@ export function initProviders(): void {
         }
         // 同步超时/未抓到（登录态失效或页面未就绪）：保留旧额度，不报错，交由调用方提示可稍后手动刷新
         logVolcSync(`SYNC_PRESERVED key=${keyId} ok=${res.ok} source=${(res as { source?: string }).source ?? '?'}`)
+        return { ok: true, preserved: true }
+      } catch (e) {
+        return { ok: false, reason: 'error', error: e instanceof Error ? e.message : '额度同步失败' }
+      }
+    }
+  )
+  // 腾讯云 TokenHub 每模型额度同步：后台复用该账号分区登录态（必要时回注入已存 cookie）静默抓取最新每模型免费额度，
+  // 命中则重建加密负载（models + uin + cookies）返回 newEncrypted，供渲染层落库并刷新「查看模型」展示。
+  // 用于「查看模型」自愈：存量账号负载无 models（旧版本绑定）时，点一次即可续抓补全，无需重新绑定。
+  ipcMain.handle(
+    'provider:tokenhub-sync-models',
+    async (_e, _providerId: string, keyId: string, encrypted: string, maxStaleMs?: number) => {
+      if (!encrypted) return { ok: false, reason: 'no-secret', error: '缺少密钥' }
+      // 缓存命中：maxStaleMs>0 且负载里已有每模型额度、上次同步未超期 → 直接返回，跳过一次 webview 同步让弹窗秒开
+      if (typeof maxStaleMs === 'number' && maxStaleMs > 0) {
+        try {
+          const plain = safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
+          const { models } = decodeTokenhubPayload(plain)
+          const syncedAt = tokenhubSyncAt.get(keyId)
+          const hasQuota = Array.isArray(models) && models.some((m) => m?.freeQuota && typeof m.freeQuota.remaining === 'number')
+          if (hasQuota && typeof syncedAt === 'number' && Date.now() - syncedAt < maxStaleMs) {
+            return { ok: true, cached: true }
+          }
+        } catch {
+          /* 负载解析失败则按未命中继续走完整同步 */
+        }
+      }
+      try {
+        const plain = safeStorage.decryptString(Buffer.from(encrypted ?? '', 'base64'))
+        const { apiKey, uin, cookies } = decodeTokenhubPayload(plain)
+        if (!apiKey) return { ok: false, reason: 'no-key', error: '未解析到 API Key' }
+        // 回注入已存控制台登录 cookie，保证静默窗口能保持登录态（存量账号未走本应用绑定、分区无登录时也能恢复）
+        if (Array.isArray(cookies) && cookies.length > 0) {
+          try {
+            await injectTokenhubConsoleCookies(typeof keyId === 'string' && keyId ? keyId : '', cookies)
+          } catch {}
+        }
+        const res = await captureTokenhubConsoleSession({ quiet: true, keyId })
+        // 抓到每模型额度 → 用最新 models 重建负载回库（保留 apiKey/uin/原 cookies）
+        if (res.ok && Array.isArray(res.models) && res.models.length > 0) {
+          const newPlain = JSON.stringify({
+            v: 1,
+            apiKey,
+            uin: res.uin ?? uin ?? null,
+            models: res.models,
+            cookies: Array.isArray(cookies) ? cookies : undefined
+          })
+          const newEncrypted = safeStorage.encryptString(newPlain).toString('base64')
+          tokenhubSyncAt.set(keyId, Date.now())
+          console.log(`[tkh-sync] 回写 models=${res.models.map((m) => m.id).join(',')} uin=${res.uin ?? uin ?? 'NO'}`)
+          const hasQuota = res.models.some((m) => m?.freeQuota && typeof m.freeQuota.remaining === 'number')
+          return { ok: true, encrypted: newEncrypted, models: res.models, hasQuota }
+        }
+        // 同步未抓到（登录态失效/页面未就绪/无每模型额度）：保留旧值交由调用方提示稍后手动刷新
         return { ok: true, preserved: true }
       } catch (e) {
         return { ok: false, reason: 'error', error: e instanceof Error ? e.message : '额度同步失败' }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
+import type { TokenhubFreeVideoModel, TokenhubModelQuota } from '@quota-flow/providers'
 
 export type ProviderId = 'yuanbao' | 'qwenwan'
 
@@ -109,6 +110,8 @@ export interface QuotaUpdatedPayload {
   volcRefreshKeyId?: string
   /** 阿里云百炼生成成功后触发：据此静默重抓该账号控制台最新免费额度 */
   bailianRefreshKeyId?: string
+  /** 腾讯云 TokenHub 生成成功后触发：据此刷新该账号额度（本轮未实测积分接口，预留钩子） */
+  tokenhubRefreshKeyId?: string
 }
 
 /** 智谱平台资源包余额（fetch-quota 返回） */
@@ -299,7 +302,12 @@ export interface DesktopApi {
      * 捕获阿里云百炼控制台登录会话：账号 PK + 免费额度整表快照（解析为归一化条目）
      * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
      */
-    captureBailianSession: (keyId?: string) => Promise<{ ok: boolean; accountId?: string | null; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; error?: string }>
+    captureBailianSession: (keyId?: string) => Promise<{ ok: boolean; accountId?: string | null; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; error?: string }>,
+    /**
+     * 捕获腾讯云 TokenHub 控制台会话：主账号标识 uin（账号级去重维度）+ 每模型免费额度（DescribeModelEndpointList）。
+     * @param keyId 可选：账号 keyId，用于把控制台登录态隔离到该账号自己的分区，避免多账号串会话
+     */
+    captureTokenhubSession: (keyId?: string) => Promise<{ ok: boolean; uin?: string; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>; error?: string }>
     /**
      * 读取指定火山方舟账号的控制台会话状态（依据 consoleJwt 的 JWT exp 判定 alive / expiring / expired）
      */
@@ -342,6 +350,16 @@ export interface DesktopApi {
       freeTiers?: BailianFreeTier[]
       quota?: { available: boolean; total: number; remaining: number; expired?: boolean }
       preserved?: boolean
+      reason?: string
+      error?: string
+    }>,
+    tokenhubSyncModels: (keyId: string, encrypted: string, maxStaleMs?: number) => Promise<{
+      ok: boolean
+      encrypted?: string
+      models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>
+      hasQuota?: boolean
+      preserved?: boolean
+      cached?: boolean
       reason?: string
       error?: string
     }>
@@ -499,6 +517,14 @@ const api: DesktopApi = {
         freeTiers?: BailianFreeTier[]
         error?: string
       }>,
+    captureTokenhubSession: (keyId) =>
+      ipcRenderer.invoke('provider:capture-tokenhub-session', keyId) as Promise<{
+        ok: boolean
+        uin?: string
+        cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>
+        models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>
+        error?: string
+      }>,
     volcSessionStatus: (keyId, encrypted) =>
       ipcRenderer.invoke('provider:volc-session-status', 'volcengine', keyId, encrypted) as Promise<ZhipuSessionStatusResult>,
     volcRenewSession: (keyId, encrypted) =>
@@ -527,6 +553,17 @@ const api: DesktopApi = {
         freeTiers?: BailianFreeTier[]
         quota?: { available: boolean; total: number; remaining: number; expired?: boolean }
         preserved?: boolean
+        reason?: string
+        error?: string
+      }>,
+    tokenhubSyncModels: (keyId, encrypted, maxStaleMs) =>
+      ipcRenderer.invoke('provider:tokenhub-sync-models', 'tokenhub', keyId, encrypted, maxStaleMs) as Promise<{
+        ok: boolean
+        encrypted?: string
+        models?: Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>
+        hasQuota?: boolean
+        preserved?: boolean
+        cached?: boolean
         reason?: string
         error?: string
       }>

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -9,6 +9,7 @@ import { errMsg } from '../utils/error'
 import type { AuthUser } from '../hooks/useAuth'
 import type { TeamContext } from '@quota-flow/db-supabase'
 import type { VolcengineCapturedModel, BailianFreeTier } from '../../../preload'
+import type { TokenhubFreeVideoModel, TokenhubModelQuota } from '@quota-flow/providers'
 import desktopPackage from '../../../../package.json'
 
 export interface UpdaterStatusView {
@@ -675,6 +676,16 @@ export function AddProviderModal({
   const [bailianCookies, setBailianCookies] = useState<
     Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }> | null
   >(null)
+  // 腾讯云 TokenHub 主账号标识 uin：从控制台会话捕获，保存时并入 payload 作为账号级去重依据（免费积分按 Uin 共享）
+  const [tkhAccountId, setTkhAccountId] = useState<string | null>(null)
+  // 腾讯云 TokenHub 控制台登录 cookie：捕获时随负载持久化，供「进入官网」跨重启重建登录态
+  const [tkhCookies, setTkhCookies] = useState<
+    Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }> | null
+  >(null)
+  // 腾讯云 TokenHub 每模型免费额度：从控制台 DescribeModelEndpointList(VISION) 捕获，随负载持久化供「查看模型」展示
+  const [tkhModels, setTkhModels] = useState<
+    Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }> | null
+  >(null)
   const [apiKey, setApiKey] = useState('')
   const [accountName, setAccountName] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -744,6 +755,7 @@ export function AddProviderModal({
     setVolcAccountId(null)
     setConsoleJwt(null)
     setVolcModels(null)
+    setTkhAccountId(null)
   }
 
   const saveEncrypted = async (
@@ -923,18 +935,28 @@ export function AddProviderModal({
       const trimmed = apiKey.trim()
       // 智谱 / 火山方舟 / 阿里云百炼：如有捕获的控制台会话令牌(consoleJwt)、账号标识(volcAccountId/bailianAccountId)
       // 或免费额度快照，并入结构化 payload，供主进程生成「账号级」去重指纹 + 账号级聚合额度展示
-      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian'
+      const isApiProvider =
+        providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian' || providerId === 'tokenhub'
       const isBailian = providerId === 'bailian'
+      const isTokenhub = providerId === 'tokenhub'
       const raw =
-        isApiProvider && (consoleJwt || volcAccountId || bailianAccountId || (providerId === 'volcengine' && volcModels?.length) || (isBailian && (bailianFreeTiers?.length || bailianCookies?.length)))
+        isApiProvider &&
+          (consoleJwt ||
+            volcAccountId ||
+            bailianAccountId ||
+            tkhAccountId ||
+            (providerId === 'volcengine' && volcModels?.length) ||
+            (isTokenhub && tkhModels?.length) ||
+            (isBailian && (bailianFreeTiers?.length || bailianCookies?.length)))
           ? JSON.stringify({
               v: 1,
               apiKey: trimmed,
               consoleJwt,
               accountId: isBailian ? bailianAccountId : volcAccountId,
-              models: providerId === 'volcengine' ? (volcModels ?? []) : undefined,
+              uin: isTokenhub ? (tkhAccountId ?? undefined) : undefined,
+              models: isTokenhub ? (tkhModels ?? undefined) : providerId === 'volcengine' ? (volcModels ?? []) : undefined,
               freeTiers: isBailian ? (bailianFreeTiers ?? undefined) : undefined,
-              cookies: isBailian ? (bailianCookies ?? undefined) : undefined
+              cookies: isBailian ? (bailianCookies ?? undefined) : isTokenhub ? (tkhCookies ?? undefined) : undefined
             })
           : trimmed
       const enc = await window.api.providers.encrypt(selected.providerId, raw)
@@ -995,21 +1017,27 @@ export function AddProviderModal({
       setBailianAccountId(null)
       setBailianFreeTiers(null)
       setBailianCookies(null)
+      setTkhAccountId(null)
+      setTkhCookies(null)
+      setTkhModels(null)
       let bindId: string | null = null
-      if (providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian') {
+      if (providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian' || providerId === 'tokenhub') {
         bindId = crypto.randomUUID()
         setLoginTempId(bindId)
       }
-      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian'
+      const isApiProvider = providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian' || providerId === 'tokenhub'
       const isBailian = providerId === 'bailian'
-      // 火山方舟 / 百炼走独立会话捕获入口（partition/注入与智谱隔离）
+      const isTokenhub = providerId === 'tokenhub'
+      // 火山方舟 / 百炼 / 腾讯云TokenHub 走独立会话捕获入口（partition/注入与智谱隔离）
       const apiRes =
         providerId === 'volcengine'
           ? await window.api.providers.captureVolcengineSession(bindId ?? undefined)
           : isBailian
             ? await window.api.providers.captureBailianSession(bindId ?? undefined)
-            : null
-      const finalRes: { ok: boolean; consoleJwt?: string; accountId?: string | null; models?: VolcengineCapturedModel[]; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; source?: 'console' | 'fallback'; error?: string } = apiRes
+            : isTokenhub
+              ? await window.api.providers.captureTokenhubSession(bindId ?? undefined)
+              : null
+      const finalRes: { ok: boolean; consoleJwt?: string; accountId?: string | null; uin?: string | null; models?: (VolcengineCapturedModel | (TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }))[]; freeTiers?: BailianFreeTier[]; cookies?: Array<{ name: string; value: string; domain?: string; path?: string; httpOnly?: boolean; secure?: boolean; expires?: number }>; source?: 'console' | 'fallback'; error?: string } = apiRes
         ?? (isApiProvider
           ? await window.api.providers.captureZhipuSession(bindId ?? undefined)
           : { ok: false, error: '该厂商不支持控制台会话捕获' })
@@ -1018,6 +1046,21 @@ export function AddProviderModal({
         if (finalRes.accountId) {
           if (isBailian) setBailianAccountId(finalRes.accountId)
           else setVolcAccountId(finalRes.accountId)
+        }
+        if (isTokenhub && finalRes.uin) {
+          setTkhAccountId(finalRes.uin)
+          setNotice(`已识别主账号（Uin ${finalRes.uin}），将以账号级去重绑定`)
+        }
+        // 「绑定即抓额度」：腾讯云 TokenHub 抓取每模型免费视频额度并随负载持久化，供「查看模型」按模型展示
+        if (isTokenhub && Array.isArray(finalRes.models) && finalRes.models.length > 0) {
+          const tkhModelsArr = finalRes.models as Array<TokenhubFreeVideoModel & { freeQuota?: TokenhubModelQuota }>
+          const withQuota = tkhModelsArr.filter((m) => m?.freeQuota && typeof m.freeQuota.remaining === 'number')
+          setTkhModels(tkhModelsArr)
+          setNotice(
+            withQuota.length
+              ? `已捕获每模型免费额度：${withQuota.length} 个模型有额度，可在「查看模型」查看`
+              : `已识别 ${finalRes.models.length} 个免费视频模型，暂未捕获到每模型额度`
+          )
         }
         // 「绑定即抓模型」：火山方舟在控制台页面抓到免费视频模型清单，提示用户并暂存随负载持久化
         if (providerId === 'volcengine' && Array.isArray(finalRes.models) && finalRes.models.length > 0) {
@@ -1035,6 +1078,14 @@ export function AddProviderModal({
         // 暂存百炼控制台登录 cookie：捕获成功即随负载持久化，供「进入官网」跨重启重建登录态
         if (isBailian && Array.isArray(finalRes.cookies) && finalRes.cookies.length > 0) {
           setBailianCookies(finalRes.cookies)
+        }
+        // 暂存腾讯云 TokenHub 控制台登录 cookie：捕获成功即随负载持久化，供「进入官网」跨重启重建登录态
+        if (isTokenhub && Array.isArray(finalRes.cookies) && finalRes.cookies.length > 0) {
+          setTkhCookies(finalRes.cookies)
+          setNotice(
+            finalRes.uin ? `已识别主账号（Uin ${finalRes.uin}），控制台登录态已保存，进入官网需重新登录时自动恢复`
+              : '腾讯云TokenHub 控制台登录态已保存'
+          )
         }
       } else if (finalRes.error) {
         setError(finalRes.error)
@@ -1355,7 +1406,7 @@ export function AddProviderModal({
               <button className="btn-sm" onClick={() => void testApiKeyInput()} disabled={saving}>
                 测试 API Key
               </button>
-              {(providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian') && (
+              {(providerId === 'zhipu' || providerId === 'volcengine' || providerId === 'bailian' || providerId === 'tokenhub') && (
                 <button className="btn-sm primary" onClick={() => void openGetApiKey()} disabled={saving}>
                   获取 API Key
                 </button>

--- a/apps/desktop/src/renderer/src/components/Providers.tsx
+++ b/apps/desktop/src/renderer/src/components/Providers.tsx
@@ -14,6 +14,8 @@ const PAGE_SIZE = 10
 
 // 火山「查看模型」额度缓存有效期：有效期内点开不再触发 webview 同步，直接秒开展示缓存值；过期后台静默刷新
 const VOLC_VIEW_MODELS_CACHE_MS = 5 * 60 * 1000
+/** 腾讯云 TokenHub 「查看模型」每模型额度静默同步的缓存窗口：命中（已有每模型额度且未超期）不再重复开控制台 */
+const TKH_VIEW_MODELS_CACHE_MS = 5 * 60 * 1000
 
 /** 顶部额度汇总条
  * - volcengine：聚合免费模型的额度（保持火山方舟原有展示，单位 tokens）
@@ -179,7 +181,7 @@ interface ProvidersProps {
 
 export default function Providers({ fresh, viewScope, usageScope, onBound, providers, canBind = true }: ProvidersProps) {
   const { user, team } = useAuth()
-  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, volcTokenOverrides, bailianQuotaOverrides, setKeyHealth, refreshVolcengineModelsOnce, refreshBailianQuotaOnce } = providers
+  const { loading, refreshing, error, aggs, reload, testHealth, rename, setDefault, setEnabled, setProviderKeyScope, unbind, zhipuQuotaOverrides, volcTokenOverrides, bailianQuotaOverrides, setKeyHealth, refreshVolcengineModelsOnce, refreshBailianQuotaOnce, refreshTokenhubModelsOnce } = providers
   const [text, setText] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -245,8 +247,8 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
     setModelsLoading(true)
     try {
       let encrypted: string | undefined
-      // 火山方舟 / 阿里云百炼：取该账号密钥负载，供主进程读取每模型免费额度（火山 token / 百炼 freeTiers）
-      if (providerId === 'volcengine' || providerId === 'bailian') {
+      // 火/百炼/腾讯云：取该账号密钥负载，供主进程读取每模型免费额度（火山 token / 百炼 freeTiers / 腾讯云 token 点数）
+      if (providerId === 'volcengine' || providerId === 'bailian' || providerId === 'tokenhub') {
         const svc = getProviderService()
         if (svc && user) {
           const secret = await svc.getProviderKeySecret(user.id, keyId)
@@ -273,6 +275,16 @@ export default function Providers({ fresh, viewScope, usageScope, onBound, provi
         // 阿里云百炼：复用账号 cookie 静默重抓控制台最新免费额度 → 用新密文重拉目录刷新最新剩余，对齐火山
       } else if (providerId === 'bailian') {
         const fresh = await refreshBailianQuotaOnce(keyId)
+        if (fresh && token === modelsTokenRef.current) {
+          const newRes = await window.api.providers.apiModels(providerId, fresh)
+          if (token === modelsTokenRef.current && newRes.ok && newRes.models) {
+            setModels(newRes.models)
+          }
+        }
+        // 腾讯云 TokenHub：后台复用该账号登录态静默续抓最新每模型免费额度 → 用新密文重拉目录刷新剩余，对齐火山/百炼
+        // （存量账号负载无 models 时，点一次「查看模型」即自愈补全每模型额度，无需重新绑定）
+      } else if (providerId === 'tokenhub') {
+        const fresh = await refreshTokenhubModelsOnce(keyId, TKH_VIEW_MODELS_CACHE_MS)
         if (fresh && token === modelsTokenRef.current) {
           const newRes = await window.api.providers.apiModels(providerId, fresh)
           if (token === modelsTokenRef.current && newRes.ok && newRes.models) {
@@ -849,7 +861,7 @@ function ProviderRow({
                         )}
                       </td>
                       <td>
-                        {!isApiKeyProvider || agg.providerId === 'zhipu' || agg.providerId === 'volcengine' || agg.providerId === 'bailian' ? (
+                        {!isApiKeyProvider || agg.providerId === 'zhipu' || agg.providerId === 'volcengine' || agg.providerId === 'bailian' || agg.providerId === 'tokenhub' ? (
                           <>
                             <button
                               className="btn-sm"

--- a/apps/desktop/src/renderer/src/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/src/hooks/useProviders.ts
@@ -194,6 +194,8 @@ export interface ProvidersResult {
   refreshVolcengineModelsOnce: (keyId: string, opts?: { maxStaleMs?: number }) => Promise<string | false>
   /** 阿里云百炼额度刷新：复用该账号 cookie 静默重抓控制台最新免费额度并落库；命中返回新密文，未命中返回 false */
   refreshBailianQuotaOnce: (keyId: string) => Promise<string | false>
+  /** 腾讯云 TokenHub 每模型额度同步：后台静默续抓该账号最新每模型免费额度并落库；命中返回新密文，未抓到返回 false */
+  refreshTokenhubModelsOnce: (keyId: string, maxStaleMs?: number) => Promise<string | false>
 }
 
 export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult {
@@ -512,6 +514,29 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
           // 同步回填账号级指纹：抓到的 accountId 稳定后重算指纹入库，同账号多 Key 共享，去重提示才命中
           accountFingerprint: res.accountFingerprint ?? null
         })
+        void window.api.keysCache.invalidate({ keyId })
+        return res.encrypted
+      } catch {
+        return false
+      }
+    },
+    [user]
+  )
+
+  // 腾讯云 TokenHub 每模型额度同步：后台复用该账号分区登录态（必要时回注入 cookie）静默抓取最新每模型免费额度并落库。
+  // 命中（抓到每模型额度）用重建的加密负载更新 DB 并返回新 encrypted，供「查看模型」即时展示；
+  // 未抓到（登录态失效/页面未就绪）保留旧值返回 false，不打断调用方。主要用于「查看模型」自愈续抓存量账号。
+  const refreshTokenhubModelsOnce = useCallback(
+    async (keyId: string, maxStaleMs?: number): Promise<string | false> => {
+      const svc = getProviderService()
+      if (!svc || !user) return false
+      try {
+        const secret = await svc.getProviderKeySecret(user.id, keyId)
+        if (!secret) return false
+        const res = await window.api.providers.tokenhubSyncModels(keyId, secret.encrypted_key, maxStaleMs)
+        if (res.cached) return false // 命中缓存：数据仍新鲜，无需回写与返回
+        if (!res.ok || res.preserved || !res.encrypted) return false
+        await svc.refreshProviderKey(user.id, keyId, { encryptedKey: res.encrypted, healthStatus: res.hasQuota ? 'healthy' : undefined })
         void window.api.keysCache.invalidate({ keyId })
         return res.encrypted
       } catch {
@@ -982,6 +1007,7 @@ export function useProviders(viewScope: ViewScope = 'personal'): ProvidersResult
     volcTokenOverrides,
     bailianQuotaOverrides,
     refreshVolcengineModelsOnce,
-    refreshBailianQuotaOnce
+    refreshBailianQuotaOnce,
+    refreshTokenhubModelsOnce
   }
 }

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -11,7 +11,8 @@ export const PROVIDER_LABEL: Record<string, string> = {
   hailuo: '海螺',
   zhipu: '智谱（bigmodel）',
   volcengine: '火山方舟',
-  bailian: '阿里云百炼'
+  bailian: '阿里云百炼',
+  tokenhub: '腾讯云TokenHub'
 }
 
 export const MODELS: Record<string, string[]> = {
@@ -193,6 +194,41 @@ export function bailianModelInputs(model: string): string[] {
   }
 }
 
+/**
+ * 腾讯云 TokenHub 免费视频模型展示价格（与主进程 api-branch.tokenhubFreeVideoModels 保持一致）。
+ * 来源：官方产品计费页实测（四模型积分费率/计费方式）。
+ */
+export const TKH_MODEL_PRICE: Record<string, string> = {
+  'hy-video-1.5': '1.5 积分/次',
+  'yt-video-2.0': '2 积分/次起（480p）',
+  'yt-video-humanactor': '1 积分/秒（720p）',
+  'yt-video-fx': '按模板积分'
+}
+
+/** 腾讯云 TokenHub 各模型固定生成时长（秒）；官方 OpenAI 兼容示例未给出，先按项目默认档 [5] TEMP 兜底，待真实提交实测修正 */
+export const TKH_MODEL_DURATIONS: Record<string, number[]> = {
+  'hy-video-1.5': [5],
+  'yt-video-2.0': [5],
+  'yt-video-humanactor': [5],
+  'yt-video-fx': [5]
+}
+
+/** 腾讯云 TokenHub 按模型取有效时长；未收录模型回退默认档 */
+export function tkhModelDurations(model: string): number[] {
+  return TKH_MODEL_DURATIONS[model ?? ''] ?? DEFAULT_SUPPORTED_DURATIONS
+}
+
+/** 腾讯云 TokenHub 各模型可用的生成模式（与主进程 api-branch.TOKENHUB_MODEL_MODES 口径一致） */
+const TKH_MODEL_MODES: Record<string, Array<{ value: string; label: string }>> = {
+  'hy-video-1.5': [
+    { value: 'text2video', label: '文生视频' },
+    { value: 'img2video', label: '图生视频' }
+  ],
+  'yt-video-2.0': [{ value: 'img2video', label: '图生视频' }],
+  'yt-video-humanactor': [{ value: 'img2video', label: '图生视频' }],
+  'yt-video-fx': []
+}
+
 export interface DurationOption {
   value: number
   label: string
@@ -279,6 +315,10 @@ export function providerModeOptions(provider: string, model = ''): Array<{ value
   }
   if (provider === 'dola') {
     return [{ value: 'multi_ref', label: '多参考生成' }]
+  }
+  if (provider === 'tokenhub') {
+    // 腾讯云 TokenHub 各模型模式与主进程 TOKENHUB_MODEL_MODES 一致；FX 待模板选择器，暂无入口
+    return TKH_MODEL_MODES[model ?? ''] ?? []
   }
   return [
     { value: 't2v', label: '文生视频' },
@@ -399,6 +439,13 @@ export function uploadHint(provider: string, mode: string): string {
   }
   if (provider === 'yuanbao') return '上传图片作为参考（最多 10 张，Ctrl+V 可粘贴）'
   if (provider === 'dola') return '上传图片作为参考（最多 10 张，Ctrl+V 可粘贴）'
+  if (provider === 'tokenhub') {
+    const map: Record<string, string> = {
+      img2video: '图生视频需上传 1 张公网 HTTPS 图片',
+      text2video: '文生视频无需上传素材'
+    }
+    return map[mode] ?? '文生视频无需上传素材'
+  }
   if (provider === 'doubao' && mode === 'multi_ref') return '上传图片作为参考（最多 10 张）'
   if (mode === 'multi_ref') return '拖拽图片 / 视频到此处（多参考生成，最多 5 个）'
   // 图生视频/首尾帧/首帧：提示需要图片素材
@@ -441,6 +488,10 @@ export function computeCost(
   }
   if (provider === 'dola') {
     return { text: 1 + d + ' 点', who: model + ' · ' + duration + 's' }
+  }
+  if (provider === 'tokenhub') {
+    const price = TKH_MODEL_PRICE[model] ?? '免费'
+    return { text: price, who: model + ' · ' + duration + 's' }
   }
   return { text: '1 次', who: (PROVIDER_LABEL[provider] ?? provider) + ' 执行' }
 }

--- a/migrations/0036_add_tokenhub_provider.sql
+++ b/migrations/0036_add_tokenhub_provider.sql
@@ -1,0 +1,36 @@
+-- 0036_add_tokenhub_provider.sql
+-- 腾讯云 TokenHub（大模型服务平台）账号绑定 seed：API Key 登录，非网页 cookie 登录。
+-- apikey 型厂商「额度单位 / 默认日额度 / 等效除数」不在 Admin 端手工填写，额度由接入层自动核算。
+-- 免费额度为主账号(Uin)级共享积分（1 积分=1.0 元），需在「启用管理」页领取后可用（生视频免费包 50 积分/1 年）。
+-- 本轮 Uin 级积分采集接口尚未探测确认（见方案 §4.2/4.5），先走每日账本 daily_total。
+-- 免费视频模型目录（2026-08-21 实测官方，模型列表 1823/130051 + 产品计费 1823/130055，Model ID 为平台固定值）：
+--   hy-video-1.5 文生+图生 1.5积分/次 / yt-video-2.0 图生 2积分/次起(480p) /
+--   yt-video-humanactor 图生·按秒 1积分/秒(720p) / yt-video-fx 图生·按模板。
+-- 与桌面 spec.ts 的 MODELS.tokenhub 镜像；TokenHub 数据不进 provider_caps 表（见方案 §5 Egress 削减）。
+-- Idempotent：重复执行只更新 seed 字段，不重复插入。
+
+INSERT INTO providers (id, name, logo, capabilities, auth_type, unit_name, default_daily_quota, equivalent_count_divisor)
+VALUES
+  (
+    'tokenhub',
+    '腾讯云TokenHub',
+    '腾',
+    '{"models":[
+      {"id":"hy-video-1.5","modes":["text2video","img2video"],"free":true,"price":"1.5 积分/次"},
+      {"id":"yt-video-2.0","modes":["img2video"],"free":true,"price":"2 积分/次起（480p）"},
+      {"id":"yt-video-humanactor","modes":["img2video"],"free":true,"price":"1 积分/秒（720p）"},
+      {"id":"yt-video-fx","modes":["img2video"],"free":true,"price":"按模板积分"}
+    ]}'::jsonb,
+    'apikey',
+    '积分',
+    50,
+    1
+  )
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  logo = EXCLUDED.logo,
+  capabilities = EXCLUDED.capabilities,
+  auth_type = EXCLUDED.auth_type,
+  unit_name = EXCLUDED.unit_name,
+  default_daily_quota = EXCLUDED.default_daily_quota,
+  equivalent_count_divisor = EXCLUDED.equivalent_count_divisor;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -9,6 +9,7 @@ import { QwenWanProvider } from "./qwen";
 export * from "./zhipu";
 export * from "./volcengine";
 export * from "./bailian";
+export * from "./tokenhub";
 
 export interface ProviderFactoryOptions {
 }

--- a/packages/providers/src/tokenhub.ts
+++ b/packages/providers/src/tokenhub.ts
@@ -1,0 +1,495 @@
+// 腾讯云 TokenHub 大模型服务平台 API Key 型厂商适配器
+//
+// 本轮实现「绑定 + 去重 + 模型额度查看 + 调度台视频生成」所需能力。
+// 数据面（已实测，官方调用指南 1823/135716，2026-08-21）：
+//   - 四个视频模型共用同一对 OpenAI 兼容端点：
+//       提交  POST https://tokenhub.tencentmaas.com/v1/api/video/submit
+//       查询  POST https://tokenhub.tencentmaas.com/v1/api/video/query
+//     `Authorization: Bearer <TokenHub API Key>` 鉴权，参数一律小写下划线。
+//   - 四模型 body 差异仅在字段（HY 传 prompt；YT-2.0/HumanActor/FX 传 image:{url}/模板）。
+// 免费额度实测（2026-08-21，控制台「启用管理 → 视觉模型」DescribeModelEndpointList）：
+//   免费额度是「每模型独立」的（非 Uin 级共享），四视频模型各有 50 加入口免费积分，
+//   字段来自响应 ModelEndpointSet[].ChargeDetail(JSON 字符串).FreeQuota{TotalQuota,UsedQuota,UsagePercent,ExpireTime}。
+
+import { createHash } from "node:crypto";
+
+export const TKH_BASE_URL = "https://tokenhub.tencentmaas.com";
+/** 启用管理页（含免费生视频包/剩余积分的概览） */
+export const TKH_CONSOLE_OPEN_URL = "https://console.cloud.tencent.com/tokenhub/open-management";
+/** API Key 管理页（绑定「获取 API Key」） */
+export const TKH_CONSOLE_APIKEY_URL = "https://console.cloud.tencent.com/tokenhub/apikey";
+/** TokenHub 控制台持久化分区 */
+export const TKH_CONSOLE_PARTITION = "persist:qf-tokenhub-console";
+
+/** 数据面统一端点 */
+export const TKH_VIDEO_SUBMIT_URL = `${TKH_BASE_URL}/v1/api/video/submit`;
+export const TKH_VIDEO_QUERY_URL = `${TKH_BASE_URL}/v1/api/video/query`;
+
+/** 单个模型免费额度（来自控制台 DescribeModelEndpointList 响应的 ChargeDetail.FreeQuota） */
+export interface TokenhubModelQuota {
+  /** 免费额度总数（积分/次） */
+  total: number
+  /** 已用额度 */
+  used: number
+  /** 剩余额度 = total - used */
+  remaining: number
+  /** 用量百分比 0-100 */
+  percent: number
+  /** 到期时间（ISO，控制台返回 UTC） */
+  expiresAt?: string | null
+  /** 已过期 */
+  expired?: boolean
+}
+
+/**
+ * 解析 DescribeModelEndpointList 的响应文本，抽出「免费视频模型 → 每模型免费额度」。
+ * 实测结构（2026-08-21，服务端固定）：{
+ *   code:0, data:{ code:0, cgwerrorCode:0, data:{ Response:{ ModelEndpointSet:[{ ModelId, ChargeType:'FREE',
+ *     ChargeDetail:'{"FreeQuota":{"TotalQuota":50,"UsedQuota":0,"UsagePercent":0,"ExpireTime":"..."}}' }] } } }
+ * }
+ * 仅保留 ChargeType=FREE 且已领取(FreeTrialClaimed)且有 FreeQuota 的模型；ChargeDetail 是字符串，需二次 parse。
+ */
+export function parseTokenhubDescribeResponse(respText: string): Array<{ model: string; quota: TokenhubModelQuota }> {
+  const out: Array<{ model: string; quota: TokenhubModelQuota }> = []
+  if (!respText) return out
+  try {
+    const root = JSON.parse(respText)
+    const set =
+      root?.data?.data?.data?.Response?.ModelEndpointSet ??
+      root?.data?.data?.Response?.ModelEndpointSet ??
+      []
+    if (!Array.isArray(set)) return out
+    const now = Date.now()
+    for (const ep of set) {
+      const modelId = typeof ep?.ModelId === 'string' ? ep.ModelId : null
+      if (!modelId) continue
+      if (ep?.ChargeType !== 'FREE') continue
+      if (ep?.FreeTrialClaimed !== true) continue
+      let fq: { TotalQuota?: number; UsedQuota?: number; UsagePercent?: number; ExpireTime?: string } | null = null
+      const cd = ep?.ChargeDetail
+      if (typeof cd === 'string') {
+        try {
+          fq = JSON.parse(cd)?.FreeQuota ?? null
+        } catch {}
+      } else if (cd && typeof cd === 'object') {
+        fq = cd?.FreeQuota ?? null
+      }
+      if (!fq) continue
+      const total = typeof fq.TotalQuota === 'number' ? fq.TotalQuota : NaN
+      const used = typeof fq.UsedQuota === 'number' ? fq.UsedQuota : NaN
+      const percent = typeof fq.UsagePercent === 'number' ? fq.UsagePercent : NaN
+      if (!Number.isFinite(total) || !Number.isFinite(used)) continue
+      const expIso = typeof fq.ExpireTime === 'string' && fq.ExpireTime ? fq.ExpireTime : null
+      const expired = expIso ? now > new Date(expIso).getTime() : undefined
+      out.push({
+        model: modelId,
+        quota: {
+          total,
+          used,
+          remaining: Math.max(0, total - used),
+          percent: Number.isFinite(percent) ? percent : used === 0 ? 0 : Math.round((used / total) * 100),
+          expiresAt: expIso,
+          expired
+        }
+      })
+    }
+  } catch {
+    return out
+  }
+  return out
+}
+
+/**
+ * 把实抓的每模型额度挂到目录模型上（与火山 volcengine 的 models[].freeQuota 同构），
+ * 配额源缺失的模型保持 freeQuota 为空 → 上层按「额度未知」展示 ——/未知。
+ */
+export function attachTokenhubFreeQuota<T extends { id: string }>(
+  models: T[],
+  quotaByModel: Record<string, TokenhubModelQuota> | null | undefined,
+): Array<T & { freeQuota?: TokenhubModelQuota }> {
+  return (models ?? []).map((m) => {
+    const q = quotaByModel?.[m.id]
+    return q ? { ...m, freeQuota: q } : { ...m }
+  })
+}
+
+/** 与智谱/火山一致的旧额度结构说明（历史保留；实际已改为每模型独立额度，见 TokenhubModelQuota） */
+export interface TokenhubQuota {
+  available: boolean
+  /** 积分总数 */
+  total: number
+  /** 剩余积分 */
+  remaining: number
+  expiresAt?: string | null
+  packageName?: string | null
+  expired?: boolean
+  uin?: unknown
+}
+
+/** TokenHub 控制台登录 cookie（进入官网时需跨重启重注入的会话标识，如 uin/skey/token 等） */
+export interface TokenhubStoredCookie {
+  name: string
+  value: string
+  domain?: string
+  path?: string
+  httpOnly?: boolean
+  secure?: boolean
+  expires?: number
+}
+
+/**
+ * 解腾讯云 TokenHub 加密负载：
+ * 新版：{ v:1; apiKey: string; uin?: string|null; models?: TokenhubFreeVideoModel[]; points?: {remaining?:number; total?:number}; cookies? }
+ * 旧版：纯 API Key 字符串（非 `{` 开头）
+ */
+export function decodeTokenhubPayload(decrypted: string): {
+  apiKey: string
+  uin?: string | null
+  models?: TokenhubFreeVideoModel[]
+  points?: { remaining?: number; total?: number }
+  cookies?: TokenhubStoredCookie[]
+} {
+  const trimmed = (decrypted ?? "").trim()
+  if (!trimmed.startsWith("{")) return { apiKey: trimmed }
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      v?: number
+      apiKey?: string
+      uin?: string | null
+      models?: TokenhubFreeVideoModel[]
+      points?: { remaining?: number; total?: number }
+      cookies?: TokenhubStoredCookie[]
+    }
+    const apiKey = parsed.apiKey?.trim() ?? ""
+    let uin = parsed.uin ?? null
+    if (typeof uin === "string") {
+      uin = uin.trim() || null
+    } else {
+      uin = null
+    }
+    const models = Array.isArray(parsed.models) ? parsed.models.filter((m) => m && typeof m.id === "string") : undefined
+    const points =
+      parsed.points && (typeof parsed.points.remaining === "number" || typeof parsed.points.total === "number")
+        ? parsed.points
+        : undefined
+    const cookies = Array.isArray(parsed.cookies)
+      ? parsed.cookies.filter((c) => c && typeof c.name === "string" && typeof c.value === "string")
+      : undefined
+    return { apiKey, uin, models, points, cookies }
+  } catch {
+    return { apiKey: trimmed }
+  }
+}
+
+function fingerprintFor(providerId: string, raw: string): string {
+  const norm = raw.trim()
+  return createHash("sha256")
+    .update(`${providerId}|${norm}`)
+    .digest("hex")
+}
+
+/**
+ * TokenHub 账号级指纹：优先用控制台会话解析出的主账号标识 uin（同一 Uin 下多 API Key 共享免费积分，正确去重维度）。
+ * uin 为空（未捕获会话 / 未抓到账号接口）时回退按 API Key 明文哈希。
+ * payload 为「加密前明文」，可能是 {v:1,apiKey,uin,models,points} 或纯 API Key。
+ */
+export async function tokenhubAccountFingerprint(payload: string): Promise<string | null> {
+  const { apiKey, uin } = decodeTokenhubPayload(payload)
+  if (!apiKey) return null
+  if (uin) return fingerprintFor("tokenhub", "tkh-account:" + uin)
+  return fingerprintFor("tokenhub", apiKey)
+}
+
+/**
+ * 校验 TokenHub API Key 是否有效（不产生任何生成费用）：
+ * 用一个不可能存在的任务 id 触发查询，用状态码区分鉴权——无效 key 返回 401，有效 key 返回业务错误(非 401)。
+ * 仅把 401 视为「无效」，其余 HTTP 响应视为鉴权已通过。
+ */
+export async function testTokenhubApiKey(apiKey: string): Promise<{ ok: boolean; error?: string }> {
+  const key = (apiKey ?? "").trim()
+  if (!key) return { ok: false, error: "请先输入 API Key" }
+  try {
+    const res = await fetch(TKH_VIDEO_QUERY_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "hy-video-1.5", id: "qf-invalid-key-check-nonexistent" }),
+      signal: AbortSignal.timeout(15000),
+    })
+    if (res.status === 401) return { ok: false, error: "API Key 无效或已失效（身份验证失败）" }
+    if (res.status >= 200 && res.status < 600) return { ok: true }
+    return { ok: false, error: `校验失败（HTTP ${res.status}）` }
+  } catch {
+    return { ok: false, error: "校验失败（网络错误或超时）" }
+  }
+}
+
+/**
+ * 查询 TokenHub 真实额度（Uin 级共享积分）。
+ * TokenHub 免费额度是控制台侧的「启用管理」积分，数据面公开 API 无法读取；
+ * Uin 级积分接口尚未探测确认（见计划 §4.2/§4.5），本轮先返回「待探测」结果，由上层回退本地账本展示。
+ */
+export async function fetchTokenhubQuota(
+  apiKey: string,
+  uin?: string | null,
+): Promise<{ ok: true; quota: TokenhubQuota } | { ok: false; error: string }> {
+  if (!apiKey) return { ok: false, error: "缺少 API Key" }
+  // 控制台会话已捕获，但 Uin 级积分接口尚未确认，本轮不盲目请求未知端点。
+  return { ok: false, error: "腾讯云TokenHub 额度接口待探测：暂以本地账本为准" }
+}
+
+/**
+ * TokenHub 「免费视频生成」模型元数据（账号无关的稳定目录；不写死任何积分余额）。
+ * 积分费率/任务类型来源（2026-08-21 实测官方）：产品计费 1823/130055 + 模型列表 1823/130051 + 调用指南 1823/135716。
+ * 1 积分 = 1.0 元（官方模型价格 doc；个别社区文曾写视频 1 积分=1.2 元，以官方为准）。
+ */
+export interface TokenhubFreeVideoModel {
+  id: string
+  /** 控制台展示名（用于爬取归一化） */
+  name: string
+  modes: string[]
+  free: true
+  price: string
+  /** 计费方式：per_call 按次扣积分；per_second 按生成秒数扣积分 */
+  costType: 'per_call' | 'per_second'
+  /** per_call 单次消耗积分（仅 costType=per_call） */
+  pointsPerCall?: number
+  /** per_second 每秒消耗积分（仅 costType=per_second） */
+  pointsPerSecond?: number
+  /** 支持时长档（秒，官方 OpenAI 兼容示例未给出准确档位，未实测前保守置空，见计划 §4.3） */
+  durations?: number[]
+  /** 支持分辨率档（官方示例未给出，未实测前置空，见计划 §4.3） */
+  resolutions?: string[]
+  quotaHint: string
+  /** 每模型免费额度（绑定/静默刷新时随控制台 DescribeModelEndpointList 实抓写入；抓不到则缺省 → 展示未知） */
+  freeQuota?: TokenhubModelQuota
+}
+
+/**
+ * TokenHub 「免费视频生成模型」目录（厂商级、账号无关）。
+ * 仅声明元数据（id/名称/能力/费率），不写死任何积分余额——免费额度是每模型动态数据，由控制台
+ * DescribeModelEndpointList 实抓后随 `freeQuota` 写入（见 attachTokenhubFreeQuota）；抓不到即「额度未知」：前端显示 —、生成前保守拦截。
+ */
+export function tokenhubFreeVideoModels(): TokenhubFreeVideoModel[] {
+  return [
+    {
+      id: "hy-video-1.5",
+      name: "HY-Video-1.5",
+      modes: ["text2video", "img2video"],
+      free: true,
+      price: "1.5 积分/次",
+      costType: "per_call",
+      pointsPerCall: 1.5,
+      quotaHint: "免费生视频包（启用管理页领取）",
+    },
+    {
+      id: "yt-video-2.0",
+      name: "YT-Video-2.0",
+      modes: ["img2video"],
+      free: true,
+      price: "2 积分/次起（480p）",
+      costType: "per_call",
+      pointsPerCall: 2,
+      quotaHint: "免费生视频包（启用管理页领取）",
+    },
+    {
+      id: "yt-video-humanactor",
+      name: "YT-Video-HumanActor",
+      modes: ["img2video"],
+      free: true,
+      price: "1 积分/秒（720p）",
+      costType: "per_second",
+      pointsPerSecond: 1,
+      quotaHint: "免费生视频包（启用管理页领取）",
+    },
+    {
+      id: "yt-video-fx",
+      name: "YT-Video-FX",
+      modes: ["img2video"],
+      free: true,
+      price: "按模板积分",
+      costType: "per_call",
+      quotaHint: "免费生视频包（启用管理页领取）",
+    },
+  ]
+}
+
+/** 控制台「启用管理 → 视频生成」页抓到的条目（名 / 剩余与总积分）——结构待 §4.2/4.5 实测固化 */
+export interface TokenhubScrapedFreeModel {
+  name: string
+  id?: string
+  remaining?: number
+  total?: number
+}
+
+/** 展示名 → Model ID 固定映射（权威值） */
+export const TOKENHUB_FREE_NAME_TO_ID: Record<string, string> = Object.fromEntries(
+  tokenhubFreeVideoModels().map((m) => [m.name, m.id]),
+)
+
+/**
+ * 把实抓的模型名归一到「权威目录」的 Model ID：
+ * 精确命中固定映射 / 规范化后等于目录 id；含中文/超长/非法字符拒绝。
+ */
+function resolveTokenhubScrapedId(rawName: string): string | null {
+  const raw = (rawName || "").trim()
+  if (!raw) return null
+  const exact = TOKENHUB_FREE_NAME_TO_ID[raw]
+  if (exact) return exact
+  const norm = raw.toLowerCase().replace(/\s+/g, "-")
+  for (const m of FREE_CATALOG) if (m.id === norm) return m.id
+  if (/[\u4e00-\u9fa5]/.test(norm)) return null
+  if (norm.length > 64) return null
+  if (!/^[a-z0-9][a-z0-9._-]*[a-z0-9]$/.test(norm)) return null
+  return norm
+}
+
+/** 内置免费目录（作为爬取失败的权威兜底） */
+const FREE_CATALOG: TokenhubFreeVideoModel[] = tokenhubFreeVideoModels()
+
+/**
+ * 「绑定即抓模型」：把控制台实时抓到的免费生视频模型归一到目录。
+ * 当前确认的四个免费视频模型都在内置目录；「启用管理」页的视频模型/积分结构（§4.2/4.5）尚未实测确认，
+ * 故以目录为骨架，实抓失败/未知结构回退内置目录（source=fallback）。
+ */
+export function captureTokenhubFreeModels(
+  scraped: TokenhubScrapedFreeModel[] | null | undefined,
+): { models: TokenhubFreeVideoModel[]; source: "console" | "fallback" } {
+  const src = Array.isArray(scraped) ? scraped : []
+  if (src.length === 0) return { models: FREE_CATALOG.map((m) => ({ ...m })), source: "fallback" }
+  const byId = new Map<string, TokenhubFreeVideoModel>()
+  for (const m of FREE_CATALOG) byId.set(m.id, { ...m })
+  for (const s of src) {
+    const name = s.name?.trim() || ""
+    if (!name) continue
+    const id = resolveTokenhubScrapedId(name)
+    if (!id) continue
+    if (!byId.has(id)) continue
+  }
+  return { models: Array.from(byId.values()), source: "console" }
+}
+
+/** TokenHub 提交/查询失败的响应归类为「不可用」标记（镜像火山）；本轮端点简单，保留扩展 */
+export function tokenhubGenUnavailableKind(_code?: string, _msg?: string): 'decommissioned' | 'no_endpoint' | undefined {
+  const msgText = String(_msg ?? "")
+  if (/下架|下线|decommission|discontinued|end of service|not for sale/i.test(msgText)) return 'decommissioned'
+  if (/not found|does not exist|not activated|not enabled|未开通|无访问权限/i.test(msgText)) return 'no_endpoint'
+  return undefined
+}
+
+/** TokenHub 视频生成入参（mode 仅文生/图生；图生用公网 HTTPS 图片 URL） */
+export interface TokenhubGenerateOptions {
+  mode: "text2video" | "img2video"
+  model: string
+  prompt: string
+  /** 公网 HTTPS 图片 URL 数组（图生取首张） */
+  images?: string[]
+  onProgress?: (message: string) => void
+}
+
+export interface TokenhubGenerateOutcome {
+  ok: boolean
+  videoUrl?: string
+  coverImageUrl?: string
+  traceId?: string
+  error?: string
+  unavailable?: "decommissioned" | "no_endpoint"
+}
+
+/**
+ * TokenHub 视频生成（统一 OpenAI 兼容端点，submit→poll query→解析 URL）。
+ * 数据面已实测（官方调用指南 1823/135716，2026-08-21）：
+ *   submit 返回 {id,status:'queued',...}；query 入参 {model,id}，返回 {status:'queued|in_progress|completed|failed', data:{url}}。
+ * 四模型 body 差异见下方 SUBMIT_BODY。防御式解析：字段缺失按失败处理，绝不虚构 URL。
+ */
+export async function tokenhubGenerateWithKey(
+  apiKey: string,
+  opts: TokenhubGenerateOptions,
+): Promise<TokenhubGenerateOutcome> {
+  const key = (apiKey ?? "").trim()
+  if (!key) return { ok: false, error: "缺少 TokenHub API Key" }
+
+  const model = (opts.model ?? "").trim()
+  const imageUrl = ((opts.images ?? []).filter((u) => /^https?:\/\//i.test(u))[0] ?? "").trim()
+
+  const submitBody: Record<string, unknown> = { model }
+  if (model === "hy-video-1.5") {
+    // HY：文生传 prompt；图生随附 image:{url}
+    submitBody["prompt"] = opts.prompt
+    if (opts.mode === "img2video" && imageUrl) submitBody["image"] = { url: imageUrl }
+  } else if (model === "yt-video-2.0" || model === "yt-video-humanactor") {
+    if (!imageUrl) return { ok: false, error: "该模型为图生视频，需要至少 1 张公网 HTTPS 图片" }
+    submitBody["image"] = { url: imageUrl }
+  } else if (model === "yt-video-fx") {
+    // FX 需要「特效模板」参数，现调度台无模板选择器，先不虚构模板代入生成。
+    return { ok: false, error: "YT-Video-FX 需特效模板参数，暂不支持在调度台生成" }
+  } else {
+    return { ok: false, error: `TokenHub 未知模型 ${model}` }
+  }
+
+  opts.onProgress?.("提交生成任务…")
+  let traceId: string | undefined
+  try {
+    const submitRes = await fetch(TKH_VIDEO_SUBMIT_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify(submitBody),
+      signal: AbortSignal.timeout(20000),
+    })
+    if (submitRes.status === 401) return { ok: false, error: "API Key 无效或已失效（身份验证失败）" }
+    if (submitRes.status === 403) return { ok: false, error: "无权限或未开通（免费额度需先在启用管理页领取）", unavailable: "no_endpoint" }
+    if (!submitRes.ok) {
+      const kind = tokenhubGenUnavailableKind(String(submitRes.status), await safeText(submitRes))
+      return { ok: false, error: `提交失败（HTTP ${submitRes.status}）`, unavailable: kind }
+    }
+    const submitData = (await submitRes.json().catch(() => null)) as { id?: string; status?: string } | null
+    traceId = typeof submitData?.id === "string" && submitData.id ? submitData.id : undefined
+    if (!traceId) return { ok: false, error: "提交响应缺少任务 id" }
+  } catch {
+    return { ok: false, error: "提交失败（网络错误或超时）" }
+  }
+
+  // 轮询查询直到 completed/failed，超时兜底
+  const QUERY_MS = 3000
+  const MAX_WAIT_MS = 10 * 60 * 1000
+  const deadline = Date.now() + MAX_WAIT_MS
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, QUERY_MS))
+    let state: { status?: string; progress?: number; data?: { url?: string } } | null = null
+    try {
+      const qRes = await fetch(TKH_VIDEO_QUERY_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ model, id: traceId }),
+        signal: AbortSignal.timeout(20000),
+      })
+      if (qRes.status === 401) return { ok: false, error: "API Key 失效（查询被拒绝）" }
+      if (!qRes.ok) {
+        const kind = tokenhubGenUnavailableKind(String(qRes.status), await safeText(qRes))
+        return { ok: false, error: `查询失败（HTTP ${qRes.status}）`, unavailable: kind }
+      }
+      state = (await qRes.json().catch(() => null)) as { status?: string; progress?: number; data?: { url?: string } } | null
+    } catch {
+      continue
+    }
+    const status = state?.status ?? ""
+    if (status === "completed") {
+      const url = typeof state?.data?.url === "string" && state.data.url ? state.data.url : undefined
+      if (!url) return { ok: false, error: "生成完成但响应缺少视频 URL", traceId }
+      return { ok: true, videoUrl: url, coverImageUrl: undefined, traceId }
+    }
+    if (status === "failed") {
+      return { ok: false, error: "生成失败", traceId }
+    }
+    const progress = typeof state?.progress === "number" ? Math.round(state.progress) : undefined
+    opts.onProgress?.(progress !== undefined ? `生成中 ${progress}%` : "生成中…")
+  }
+  return { ok: false, error: "生成超时（请稍后到历史记录查询）", traceId }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 300)
+  } catch {
+    return ""
+  }
+}


### PR DESCRIPTION
## 修改内容

### 1. TokenHub 厂商接入（新增）
- 新增 tokenhub.ts：TokenHub API 适配器（生成提交、轮询、额度查询）
- 新增 migrations/0036_add_tokenhub_provider.sql：厂商配置
- packages/providers/src/index.ts：导出 tokenhub provider

### 2. API Branch 架构扩展
- api-branch.ts（+129）：新增 tokenhub 分支，支持 API 型生成流程
- providers.ts（+453）：新增 tokenhub 相关 IPC 处理（encrypt/healthCheck/captureSession 等）
- dispatch.ts（+6）：调度适配 tokenhub 任务

### 3. 桌面端 UI 适配
- Providers.tsx（+20）：新增 TokenHub 账号绑定入口
- Modals.tsx（+71）：新增 TokenHub API Key 输入弹窗
- useProviders.ts（+28）：TokenHub 数据加载
- preload/index.ts（+39）：对应 IPC 桥接
- spec.ts（+53）：新增 TokenHub 厂商标识与模型列表