### PR TITLE
feat(web): 新增 Quota-Flow 官网落地页

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,23 @@
 {
   "name": "@quota-flow/web",
   "version": "0.1.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "typecheck": "tsc --noEmit",
+    "clean": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "lucide-react": "^0.474.0",
+    "next": "15.5.23",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "typescript": "^5.5.0"
+  }
 }

--- a/apps/web/src/app/docs/DocsClient.tsx
+++ b/apps/web/src/app/docs/DocsClient.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Info,
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown
+} from "lucide-react";
+
+const sidebarGuideLinks = [
+  { id: "quickstart", label: "快速开始" },
+  { id: "self-host", label: "自部署教程" },
+  { id: "providers", label: "厂商清单" },
+  { id: "faq", label: "常见问题" }
+];
+
+const sidebarRefLinks = [
+  { href: "https://github.com/Shaun520/quota-flow", label: "GitHub 仓库" },
+  { href: "https://github.com/Shaun520/quota-flow/releases", label: "版本发布" },
+  { href: "https://github.com/Shaun520/quota-flow/issues", label: "问题反馈" }
+];
+
+const installCommands = `# Windows
+Quota-Flow Setup x.y.z.exe
+
+# macOS
+open Quota-Flow-x.y.z.dmg
+
+# Linux (AppImage)
+chmod +x Quota-Flow-x.y.z.AppImage
+./Quota-Flow-x.y.z.AppImage`;
+
+const cloneCommands = `git clone https://github.com/Shaun520/quota-flow.git
+cd quota-flow
+pnpm install
+pnpm build`;
+
+const envCommands = `cp .env.example .env
+# 编辑 .env，填入：
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_ANON_KEY=your-anon-key
+# SELF_HOSTED=true`;
+
+const startCommands = `cd apps/desktop
+pnpm dev`;
+
+const cliCommands = `# 查看额度总览
+pnpm --filter @quota-flow/cli dev check-quota
+
+# 指定厂商生成
+pnpm --filter @quota-flow/cli dev generate --mode text2video \\
+  --prompt "生成5秒猫咪视频" --provider yuanbao --json
+
+# 不指定厂商，走智能调度
+pnpm --filter @quota-flow/cli dev generate --mode text2video \\
+  --prompt "生成5秒猫咪视频" --json
+
+# 刷新账本
+pnpm --filter @quota-flow/cli dev refresh`;
+
+const providerRows = [
+  ["豆包", "doubao.com", "次数", "时长（5s/10s）", "WebView cookie 注入"],
+  ["即梦", "jimeng.jianying.com", "灵感值", "时长 + 分辨率 + 模型", "WebView cookie 注入"],
+  ["通义万相", "tongyi.aliyun.com", "次数", "时长", "WebView cookie 注入"],
+  ["元宝混元", "yuanbao.tencent.com", "次数", "固定次数", "WebView cookie 注入"],
+  ["可灵", "klingai.kuaishou.com", "积分", "时长 + 分辨率", "WebView cookie 注入"],
+  ["海螺", "hailuo.com", "次数", "固定次数", "WebView cookie 注入"],
+  ["MathMind", "mcp_mathmind-video", "次数", "固定次数", "真 API"]
+];
+
+const docsFaqs = [
+  {
+    q: "Quota-Flow 是 SaaS 吗？",
+    a: "不是传统 SaaS。Quota-Flow 是开源桌面端工具，官方提供托管的数据库与团队协作功能。你也可以完全自部署，脱离官方托管。"
+  },
+  {
+    q: "我的 cookie 会被上传到云端吗？",
+    a: "个人自绑的 cookie 只在本地内存解密，不会上传。团队公共 cookie 会加密后存到 Supabase，成员通过 Edge Function 代调用，明文不出云端。"
+  },
+  {
+    q: "为什么用 WebView 而不是直接调 API？",
+    a: "国内主流厂商的免费额度绑登录态，公开 API 是付费按量的。WebView 方案直接复用厂商官方页面，自带风控签名，无需逆向，接入新厂商只需填选择器。"
+  },
+  {
+    q: "团队额度池是怎么计算的？",
+    a: "团队总池 = admin 绑定的公共额度 + 成员自愿贡献的自带额度。不同厂商的原生单位按消耗表折算成「等效次数」用于总览 UI，实际扣减仍按各厂商原生单位执行。"
+  },
+  {
+    q: "cookie 多久会过期？",
+    a: "不同厂商寿命不同，一般为 7-30 天。系统每天凌晨 3 点后台静默访问厂商首页自动续命，目标是将重新登录频率降到平均 1-2 个月一次。"
+  },
+  {
+    q: "个人免费版有什么限制？",
+    a: "个人免费版包含全部核心功能与 7 家厂商接入，唯一区别是不能创建团队共享池，仅限 1 人使用。"
+  }
+];
+
+export default function DocsClient() {
+  const [openFaq, setOpenFaq] = useState<number>(0);
+  const [activeId, setActiveId] = useState<string>("quickstart");
+
+  useEffect(() => {
+    const sections = document.querySelectorAll<HTMLElement>(".docs-section");
+    const handleScroll = () => {
+      let current = "";
+      sections.forEach((section) => {
+        const top = section.getBoundingClientRect().top;
+        if (top <= 120) {
+          current = section.id;
+        }
+      });
+      if (current) setActiveId(current);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <>
+      <section className="page-hero">
+        <div className="container">
+          <h1>文档</h1>
+          <p>从下载安装到自部署，从厂商接入到团队共享，这里有你需要的全部指南。</p>
+        </div>
+      </section>
+
+      <div className="container">
+        <div className="docs-layout">
+          <aside className="docs-sidebar">
+            <div className="sidebar-section">
+              <div className="sidebar-title">指南</div>
+              <ul className="sidebar-links">
+                {sidebarGuideLinks.map((link) => (
+                  <li key={link.id}>
+                    <a href={`#${link.id}`} className={activeId === link.id ? "active" : ""}>
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="sidebar-section">
+              <div className="sidebar-title">参考</div>
+              <ul className="sidebar-links">
+                {sidebarRefLinks.map((link) => (
+                  <li key={link.href}>
+                    <a href={link.href} target="_blank" rel="noreferrer">{link.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+
+          <main className="docs-main">
+            <section className="docs-section" id="quickstart">
+              <h2>快速开始</h2>
+              <p>Quota-Flow 是一款桌面端工具，所有功能都在桌面端完成。落地页只做介绍，不承载产品功能。</p>
+
+              <h3>1. 下载安装</h3>
+              <p>访问 <Link href="/download">下载页</Link>，根据系统自动获取对应安装包。目前支持 Windows、macOS 与 Linux。</p>
+              <pre><code>{installCommands}</code></pre>
+
+              <h3>2. 选择使用模式</h3>
+              <p>首次启动会提示选择模式：</p>
+              <ul>
+                <li><strong>官方托管（推荐）</strong>：注册账号即可使用，团队无席位上限，适合绝大多数用户。</li>
+                <li><strong>自部署</strong>：数据完全由自己掌控，无席位限制，适合技术用户或隐私敏感场景。</li>
+              </ul>
+
+              <div className="callout info">
+                <div className="callout-icon"><Info size={18} /></div>
+                <p>自部署用户需要自备 Supabase 项目，并手动执行 migrations。详见下方「自部署教程」。</p>
+              </div>
+
+              <h3>3. 绑定厂商账号</h3>
+              <p>进入桌面端「设置」Tab，点击「绑定厂商」，按引导登录各家平台。登录完成后，cookie 会自动加密存储，额度会同步到账本。</p>
+              <ul>
+                <li>个人账号：本地内存解密，不上传云端。</li>
+                <li>团队公共账号：加密上传 Supabase，成员通过 Edge Function 代调用，明文不出云端。</li>
+              </ul>
+
+              <h3>4. 生成第一个视频</h3>
+              <p>切换到「调度台」Tab，输入 prompt 并选择时长/分辨率，点击「生成」。系统会自动：</p>
+              <ol>
+                <li>估算本次消耗</li>
+                <li>选择可用额度最多的厂商账号</li>
+                <li>后台提交生成请求</li>
+                <li>返回视频 URL 并写入历史</li>
+              </ol>
+
+              <div className="callout success">
+                <div className="callout-icon"><CheckCircle size={18} /></div>
+                <p>首次生成建议在 prompt 中指定「5 秒、720p」，这是大多数厂商免费额度支持的基础配置。</p>
+              </div>
+            </section>
+
+            <section className="docs-section" id="self-host">
+              <h2>自部署教程</h2>
+              <p>自部署适合希望完全掌控数据的技术用户。你需要自己注册 Supabase 并维护 migrations。</p>
+
+              <h3>前置要求</h3>
+              <ul>
+                <li>Node.js ≥ 20</li>
+                <li>pnpm 9.7.0+</li>
+                <li>一个空的 Supabase 项目（已启用 Auth + Postgres）</li>
+                <li>Git</li>
+              </ul>
+
+              <h3>安装步骤</h3>
+              <ol className="steps-list">
+                <li>
+                  <strong>克隆仓库并安装依赖</strong>
+                  <pre><code>{cloneCommands}</code></pre>
+                </li>
+                <li>
+                  <strong>配置环境变量</strong>
+                  <pre><code>{envCommands}</code></pre>
+                </li>
+                <li>
+                  <strong>执行数据库迁移</strong>
+                  <p>按序执行 <code>migrations/*.sql</code> 中的脚本。方式 A：在 Supabase Dashboard 的 SQL Editor 中逐个执行；方式 B：等待桌面端首次启动时提示自动执行。</p>
+                </li>
+                <li>
+                  <strong>启动桌面端</strong>
+                  <pre><code>{startCommands}</code></pre>
+                  <p>首次启动时，在设置中填入 Supabase URL 与 anon key，然后注册或登录即可。</p>
+                </li>
+              </ol>
+
+              <h3>CLI 真跑示例</h3>
+              <p>自部署用户也可通过 CLI 验证调度与额度：</p>
+              <pre><code>{cliCommands}</code></pre>
+
+              <div className="callout warning">
+                <div className="callout-icon"><AlertTriangle size={18} /></div>
+                <p>自部署用户不享受官方客服支持。遇到问题可在 GitHub Issues 提出，但不承诺 SLA。</p>
+              </div>
+            </section>
+
+            <section className="docs-section" id="providers">
+              <h2>厂商清单</h2>
+              <p>Quota-Flow 目前接入 7 家 AI 视频生成厂商。除 mathmind 走真 API 外，其余 6 家均通过 WebView 统一执行引擎调用。</p>
+
+              <div className="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>厂商</th>
+                      <th>产品</th>
+                      <th>额度单位</th>
+                      <th>影响因素</th>
+                      <th>调用方式</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {providerRows.map((row) => (
+                      <tr key={row[0]}>
+                        <td><strong>{row[0]}</strong></td>
+                        <td>{row[1]}</td>
+                        <td>{row[2]}</td>
+                        <td>{row[3]}</td>
+                        <td>{row[4]}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <h3>关于扣减单位</h3>
+              <p>不同厂商的免费额度单位不同：豆包/元宝/海螺按「次数」，即梦按「灵感值」，可灵按「积分」。系统通过 <code>provider_cost_tables</code> 维护各家消耗规则，最终折算成统一的「等效次数」用于总览展示。</p>
+              <p>例如：即梦 5 秒 720p 文生视频可能消耗 80 灵感值，若该厂商的等效分母为 80，则在团队总池中计为 1 次等效次数。</p>
+
+              <h3>接入新厂商</h3>
+              <p>得益于 WebView 统一执行引擎，新增一家 cookie 厂商通常只需填写一份 <code>WebProviderConfig</code>：</p>
+              <ul>
+                <li>登录页 URL 与生成页 URL</li>
+                <li>prompt 输入框与发送按钮选择器</li>
+                <li>结果提取方式（拦截响应 / 读取 DOM / 执行页面 JS）</li>
+                <li>cookie 健康检查接口</li>
+              </ul>
+              <p>无需逆向各家风控签名，平均 2 小时即可完成接入。</p>
+            </section>
+
+            <section className="docs-section" id="faq">
+              <h2>常见问题</h2>
+              {docsFaqs.map((item, idx) => (
+                <div className={`docs-faq-item${openFaq === idx ? " open" : ""}`} key={idx}>
+                  <button
+                    className="docs-faq-question"
+                    onClick={() => setOpenFaq(openFaq === idx ? -1 : idx)}
+                    aria-expanded={openFaq === idx}
+                  >
+                    {item.q}
+                    <ChevronDown size={16} className="docs-faq-icon" />
+                  </button>
+                  <div className="docs-faq-answer">
+                    <p>{item.a}</p>
+                  </div>
+                </div>
+              ))}
+            </section>
+          </main>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import DocsClient from "./DocsClient";
+
+export const metadata: Metadata = {
+  title: "文档 — Quota-Flow",
+  description: "Quota-Flow 文档中心。从下载安装到自部署，从厂商接入到团队共享，这里有你需要的全部指南。"
+};
+
+export default function DocsPage() {
+  return <DocsClient />;
+}

--- a/apps/web/src/app/download/DownloadClient.tsx
+++ b/apps/web/src/app/download/DownloadClient.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Download, ShieldCheck, Monitor, Apple, Server } from "lucide-react";
+
+type OS = "Windows" | "macOS" | "Linux";
+
+function detectOS(): OS {
+  if (typeof navigator === "undefined") return "Windows";
+  const ua = navigator.userAgent;
+  if (/Mac/i.test(ua) && !/iPhone|iPad/i.test(ua)) return "macOS";
+  if (/Linux/i.test(ua)) return "Linux";
+  return "Windows";
+}
+
+function osLabel(os: OS) {
+  switch (os) {
+    case "macOS":
+      return "下载 macOS 版";
+    case "Linux":
+      return "下载 Linux 版";
+    default:
+      return "下载 Windows 安装包";
+  }
+}
+
+const releaseNotes = [
+  "支持 mathmind、qwenwan、yuanbao 三家厂商调度生成",
+  "动态额度账本与等效次数换算",
+  "账号池化与智能 failover",
+  "桌面端基础 UI：调度台、历史、团队、设置",
+  "自动更新与代码签名（后续版本完善）"
+];
+
+export default function DownloadClient() {
+  const [os, setOs] = useState<OS>("Windows");
+
+  useEffect(() => {
+    setOs(detectOS());
+  }, []);
+
+  return (
+    <>
+      <section className="page-hero">
+        <div className="container">
+          <h1>下载 Quota-Flow</h1>
+          <p>桌面端是唯一的创作入口。选择你的系统，几分钟即可完成安装。</p>
+        </div>
+      </section>
+
+      <section className="download-main">
+        <div className="container">
+          <div className="download-card">
+            <div className="os-detected">
+              <ShieldCheck size={14} />
+              已检测到你的系统
+            </div>
+            <h2>{os}</h2>
+            <p className="version">
+              当前版本 <strong>v0.1.0</strong> · 发布于 2026-08-21
+            </p>
+            <div className="download-actions">
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases/latest"
+                className="btn btn-primary btn-lg"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Download size={18} />
+                {osLabel(os)}
+              </a>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases"
+                className="btn btn-secondary btn-lg"
+                target="_blank"
+                rel="noreferrer"
+              >
+                查看所有版本
+              </a>
+            </div>
+            <p className="download-note">
+              下载后运行安装程序即可。已安装旧版本的用户可在应用内「设置 → 检查更新」一键升级。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="platforms-section">
+        <div className="container">
+          <div className="section-title">
+            <h2>选择你的平台</h2>
+            <p>Windows 是主推平台，macOS 与 Linux 版本同步维护。</p>
+          </div>
+          <div className="platform-grid">
+            <div className="platform-card recommended">
+              <div className="platform-badge">推荐</div>
+              <div className="platform-icon">
+                <Monitor size={26} />
+              </div>
+              <h3>Windows</h3>
+              <p>Windows 10 / 11 64 位<br />安装包约 80 MB</p>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases/latest"
+                className="btn btn-primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                下载安装包
+              </a>
+            </div>
+            <div className="platform-card">
+              <div className="platform-icon">
+                <Apple size={26} />
+              </div>
+              <h3>macOS</h3>
+              <p>macOS 12 及以上<br />Intel / Apple Silicon 通用</p>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases/latest"
+                className="btn btn-secondary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                下载 .dmg
+              </a>
+            </div>
+            <div className="platform-card">
+              <div className="platform-icon">
+                <Server size={26} />
+              </div>
+              <h3>Linux</h3>
+              <p>Ubuntu / Debian / Fedora<br />AppImage 与 deb 包</p>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases/latest"
+                className="btn btn-secondary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                下载 Linux 版
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="install-section">
+        <div className="container">
+          <div className="section-title">
+            <h2>四步开始创作</h2>
+            <p>下载、安装、登录、绑定厂商，整个过程不超过 5 分钟。</p>
+          </div>
+          <div className="steps-grid">
+            <div className="step-card">
+              <h3>下载安装包</h3>
+              <p>根据系统选择对应安装包，双击运行安装向导。</p>
+            </div>
+            <div className="step-card">
+              <h3>完成首次启动</h3>
+              <p>打开应用后配置 Supabase 连接，官方托管用户直接登录即可。</p>
+            </div>
+            <div className="step-card">
+              <h3>登录厂商账号</h3>
+              <p>在「厂商」Tab 按引导登录各平台，额度将自动归集到账本。</p>
+            </div>
+            <div className="step-card">
+              <h3>一键生成视频</h3>
+              <p>回到调度台输入 prompt，系统会为你选择最优厂商并提交生成。</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="release-section">
+        <div className="container">
+          <div className="section-title">
+            <h2>最新发布</h2>
+            <p>v0.1.0 是 MVP 版本，包含核心调度与多家厂商接入。</p>
+          </div>
+          <div className="release-card">
+            <h3>v0.1.0</h3>
+            <ul>
+              {releaseNotes.map((note) => (
+                <li key={note}>
+                  <span className="dot" />
+                  {note}
+                </li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 16, fontSize: 14, color: "var(--text-secondary)" }}>
+              查看完整更新日志请访问{" "}
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases"
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub Releases
+              </a>
+              。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: 0, paddingBottom: 80 }}>
+        <div className="container">
+          <div className="cta-banner">
+            <h2>准备好把免费额度聚成一个池子了吗？</h2>
+            <p>下载桌面端，几分钟即可绑定第一家厂商，开始你的第一次智能调度。</p>
+            <div style={{ display: "flex", gap: 16, justifyContent: "center", flexWrap: "wrap" }}>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases/latest"
+                className="btn btn-lg btn-secondary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                立即下载
+              </a>
+              <Link href="/pricing" className="btn btn-lg btn-outline-white">
+                开源免费
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import DownloadClient from "./DownloadClient";
+
+export const metadata: Metadata = {
+  title: "下载 — Quota-Flow",
+  description: "下载 Quota-Flow 桌面端，支持 Windows、macOS 与 Linux。几分钟即可完成安装，开始调度你的免费额度。"
+};
+
+export default function DownloadPage() {
+  return <DownloadClient />;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,1248 @@
+@import url("https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;600;700;800&display=swap");
+
+:root {
+  --primary: #1E40AF;
+  --primary-dark: #1E3A8A;
+  --primary-light: #3B82F6;
+  --accent: #D97706;
+  --bg: #F8FAFC;
+  --bg-elevated: #FFFFFF;
+  --text: #0F172A;
+  --text-secondary: #475569;
+  --text-muted: #64748B;
+  --border: #DBEAFE;
+  --muted: #E9EEF6;
+  --success: #059669;
+  --warning: #D97706;
+  --code-bg: #F1F5F9;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --shadow-sm: 0 1px 2px rgba(30, 64, 175, 0.05);
+  --shadow-md: 0 4px 12px rgba(30, 64, 175, 0.08);
+  --shadow-lg: 0 12px 40px rgba(30, 64, 175, 0.14);
+  --max-width: 1200px;
+  --header-height: 68px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: 'Fira Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+
+.container {
+  width: min(100% - 48px, var(--max-width));
+  margin-inline: auto;
+}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: var(--header-height);
+  background: rgba(248, 250, 252, 0.82);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(219, 234, 254, 0.6);
+  z-index: 100;
+}
+.site-header .container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--primary-dark);
+}
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 14px;
+}
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+}
+.nav-links a {
+  padding: 8px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border-radius: var(--radius-md);
+  transition: all .2s ease;
+}
+.nav-links a:hover { color: var(--primary); background: var(--muted); }
+.header-cta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 600;
+  transition: all .2s ease;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+.btn-primary:hover { background: var(--primary-dark); transform: translateY(-1px); box-shadow: var(--shadow-md); }
+.btn-secondary {
+  background: #fff;
+  color: var(--primary);
+  border-color: var(--border);
+}
+.btn-secondary:hover { border-color: var(--primary); background: var(--muted); }
+.btn-lg { padding: 14px 28px; font-size: 16px; border-radius: var(--radius-lg); }
+.btn-ghost { color: var(--text-secondary); background: transparent; }
+.btn-ghost:hover { color: var(--primary); background: var(--muted); }
+.btn-outline-white {
+  background: rgba(255,255,255,0.12);
+  color: #fff;
+  border-color: rgba(255,255,255,0.35);
+}
+.btn-outline-white:hover { background: rgba(255,255,255,0.22); }
+.btn-full { width: 100%; }
+.mobile-menu-btn { display: none; }
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer {
+  padding: 60px 0 32px;
+  background: #fff;
+  border-top: 1px solid var(--border);
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1.6fr repeat(3, 1fr);
+  gap: 48px;
+  margin-bottom: 48px;
+}
+.footer-brand p {
+  margin-top: 14px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  max-width: 300px;
+  line-height: 1.7;
+}
+.footer-col h4 {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 16px;
+}
+.footer-col ul { list-style: none; }
+.footer-col li { margin-bottom: 10px; }
+.footer-col a { font-size: 14px; color: var(--text-secondary); }
+.footer-col a:hover { color: var(--primary); }
+.footer-bottom {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* ============================================================
+   PAGE HERO & SECTIONS
+   ============================================================ */
+.page-hero {
+  position: relative;
+  padding: calc(var(--header-height) + 80px) 0 64px;
+  text-align: center;
+  background:
+    radial-gradient(ellipse 70% 50% at 50% -10%, rgba(59, 130, 246, 0.16), transparent),
+    linear-gradient(180deg, #EFF6FF 0%, var(--bg) 70%);
+}
+.page-hero h1 {
+  font-size: clamp(36px, 4.6vw, 52px);
+  line-height: 1.1;
+  font-weight: 800;
+  color: var(--primary-dark);
+  letter-spacing: -0.02em;
+}
+.page-hero p {
+  margin: 20px auto 0;
+  font-size: 18px;
+  color: var(--text-secondary);
+  max-width: 640px;
+  line-height: 1.7;
+}
+.hero-badges {
+  display: inline-flex;
+  gap: 12px;
+  margin-top: 28px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--success);
+  background: rgba(5, 150, 105, 0.08);
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(5, 150, 105, 0.18);
+}
+
+.section { padding: 100px 0; }
+.section-title {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 64px;
+}
+.section-title h2 {
+  font-size: clamp(30px, 3.6vw, 42px);
+  font-weight: 700;
+  color: var(--primary-dark);
+  letter-spacing: -0.01em;
+}
+.section-title p {
+  margin-top: 16px;
+  font-size: 17px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.cta-banner {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+  border-radius: var(--radius-xl);
+  padding: 72px 40px;
+  text-align: center;
+  color: #fff;
+}
+.cta-banner h2 { font-size: clamp(28px, 3.6vw, 40px); font-weight: 700; margin-bottom: 16px; }
+.cta-banner p { font-size: 17px; opacity: .9; max-width: 560px; margin: 0 auto 32px; }
+.cta-banner .btn-secondary {
+  background: #fff;
+  color: var(--primary);
+  border-color: transparent;
+}
+.cta-banner .btn-secondary:hover { background: rgba(255,255,255,.92); }
+
+/* ============================================================
+   HOME
+   ============================================================ */
+.hero {
+  position: relative;
+  padding: calc(var(--header-height) + 80px) 0 100px;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(59, 130, 246, 0.18), transparent),
+    linear-gradient(180deg, #EFF6FF 0%, var(--bg) 60%);
+}
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(30, 64, 175, 0.08);
+  color: var(--primary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 24px;
+}
+.hero h1 {
+  font-size: clamp(40px, 5vw, 64px);
+  line-height: 1.08;
+  font-weight: 800;
+  color: var(--primary-dark);
+  letter-spacing: -0.02em;
+}
+.hero h1 .accent-text {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.hero-desc {
+  margin-top: 24px;
+  font-size: 18px;
+  color: var(--text-secondary);
+  max-width: 540px;
+  line-height: 1.7;
+}
+.hero-actions {
+  margin-top: 36px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.hero-stats {
+  margin-top: 40px;
+  display: flex;
+  gap: 40px;
+}
+.hero-stats .stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+.hero-stats .stat-label {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.dashboard-mockup {
+  position: relative;
+  border-radius: var(--radius-xl);
+  background: #fff;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  transform: perspective(1000px) rotateY(-4deg) rotateX(2deg);
+  transition: transform .4s ease;
+}
+.dashboard-mockup:hover { transform: perspective(1000px) rotateY(0deg) rotateX(0deg); }
+.mockup-header {
+  height: 44px;
+  background: var(--muted);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+}
+.mockup-dot { width: 10px; height: 10px; border-radius: 50%; background: #CBD5E1; }
+.mockup-title { font-size: 12px; color: var(--text-muted); margin-left: auto; }
+.mockup-body {
+  padding: 20px;
+  display: grid;
+  grid-template-columns: 1.2fr .8fr;
+  gap: 16px;
+}
+.mock-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+}
+.mock-card h4 { font-size: 13px; color: var(--text-secondary); margin-bottom: 12px; font-weight: 600; }
+.mock-input {
+  height: 72px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  margin-bottom: 12px;
+}
+.mock-row { display: flex; gap: 8px; margin-bottom: 8px; }
+.mock-select { flex: 1; height: 32px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); }
+.mock-btn { width: 96px; height: 34px; background: var(--accent); border-radius: var(--radius-sm); margin-top: 8px; }
+.provider-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.provider-item:last-child { border-bottom: none; }
+.provider-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--primary);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+}
+.provider-info { flex: 1; }
+.provider-name { font-size: 12px; font-weight: 600; color: var(--text); }
+.provider-quota { font-size: 11px; color: var(--text-muted); }
+.provider-bar { height: 5px; background: var(--muted); border-radius: 3px; margin-top: 4px; overflow: hidden; }
+.provider-bar span { display: block; height: 100%; background: linear-gradient(90deg, var(--primary), var(--primary-light)); border-radius: 3px; }
+
+.pain-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.pain-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  box-shadow: var(--shadow-sm);
+}
+.pain-card .icon-wrap {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: rgba(30, 64, 175, 0.08);
+  color: var(--primary);
+  display: grid;
+  place-items: center;
+  margin-bottom: 20px;
+}
+.pain-card h3 { font-size: 18px; font-weight: 700; margin-bottom: 10px; color: var(--primary-dark); }
+.pain-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.7; }
+
+.vendors-section { background: #fff; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+.vendor-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 16px;
+}
+.vendor-cell {
+  text-align: center;
+  padding: 24px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  transition: all .2s ease;
+}
+.vendor-cell:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: var(--primary-light); }
+.vendor-logo {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 12px;
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+}
+.vendor-cell h4 { font-size: 15px; font-weight: 700; color: var(--primary-dark); }
+.vendor-cell span { font-size: 12px; color: var(--text-muted); }
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.feature-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  transition: all .2s ease;
+}
+.feature-card:hover { box-shadow: var(--shadow-md); border-color: var(--primary-light); }
+.feature-card .icon-wrap {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.1), rgba(59, 130, 246, 0.1));
+  color: var(--primary);
+  display: grid;
+  place-items: center;
+  margin-bottom: 20px;
+}
+.feature-card h3 { font-size: 17px; font-weight: 700; margin-bottom: 10px; color: var(--primary-dark); }
+.feature-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.7; }
+
+.how-section { background: linear-gradient(180deg, #EFF6FF 0%, #fff 100%); }
+.how-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+  margin-bottom: 64px;
+}
+.how-step {
+  position: relative;
+  text-align: center;
+  padding: 0 16px;
+}
+.how-step .step-num {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  margin: 0 auto 18px;
+  font-size: 16px;
+}
+.how-step h3 { font-size: 18px; font-weight: 700; margin-bottom: 10px; color: var(--primary-dark); }
+.how-step p { font-size: 14px; color: var(--text-secondary); line-height: 1.7; }
+.architecture-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 40px;
+  box-shadow: var(--shadow-md);
+}
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.arch-node {
+  flex: 1;
+  min-width: 220px;
+  max-width: 280px;
+  text-align: center;
+  padding: 28px 24px;
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.arch-node .node-icon { color: var(--primary); margin-bottom: 14px; }
+.arch-node h4 { font-size: 16px; font-weight: 700; color: var(--primary-dark); margin-bottom: 6px; }
+.arch-node p { font-size: 13px; color: var(--text-secondary); }
+.arch-arrow { color: var(--primary-light); }
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+.pricing-grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.pricing-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  box-shadow: var(--shadow-sm);
+  transition: all .2s ease;
+  position: relative;
+}
+.pricing-card:hover { box-shadow: var(--shadow-md); }
+.pricing-card.featured {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(30, 64, 175, 0.08), var(--shadow-md);
+  transform: translateY(-6px);
+}
+.pricing-badge {
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+.pricing-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  margin: 0 auto 20px;
+}
+.pricing-card h3 { font-size: 18px; font-weight: 700; color: var(--primary-dark); margin-bottom: 8px; }
+.pricing-card .price { font-size: 36px; font-weight: 800; color: var(--text); margin: 16px 0 6px; }
+.pricing-card .price span { font-size: 14px; font-weight: 500; color: var(--text-muted); }
+.pricing-card .seat,
+.pricing-card .desc { font-size: 13px; color: var(--text-muted); margin-bottom: 20px; }
+.pricing-card ul { list-style: none; margin-bottom: 24px; }
+.pricing-card li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 6px 0;
+}
+.pricing-card li svg { flex-shrink: 0; color: var(--success); margin-top: 2px; }
+.pricing-card .btn { width: 100%; }
+
+/* ============================================================
+   DOWNLOAD
+   ============================================================ */
+.download-main { padding: 0 0 80px; }
+.download-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 48px;
+  box-shadow: var(--shadow-md);
+  text-align: center;
+}
+.os-detected {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(5, 150, 105, 0.08);
+  color: var(--success);
+  border: 1px solid rgba(5, 150, 105, 0.2);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 24px;
+}
+.download-card h2 {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 12px;
+}
+.download-card .version {
+  font-size: 15px;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+}
+.download-card .version strong { color: var(--text); font-weight: 600; }
+.download-actions {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+.download-note {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.platforms-section { padding: 80px 0; background: #fff; border-top: 1px solid var(--border); }
+.platform-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.platform-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  text-align: center;
+  transition: all .2s ease;
+}
+.platform-card:hover { box-shadow: var(--shadow-md); border-color: var(--primary-light); }
+.platform-card.recommended {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(30, 64, 175, 0.08), var(--shadow-sm);
+  position: relative;
+}
+.platform-badge {
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+.platform-icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 20px;
+  border-radius: var(--radius-md);
+  background: #fff;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  color: var(--primary);
+}
+.platform-card h3 { font-size: 18px; font-weight: 700; color: var(--primary-dark); margin-bottom: 8px; }
+.platform-card p { font-size: 14px; color: var(--text-secondary); margin-bottom: 20px; line-height: 1.6; }
+.platform-card .btn { width: 100%; }
+
+.install-section { padding: 80px 0; }
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+  counter-reset: step;
+}
+.step-card {
+  position: relative;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+}
+.step-card::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  top: -14px;
+  left: 24px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 13px;
+  font-weight: 700;
+}
+.step-card h3 { font-size: 16px; font-weight: 700; color: var(--primary-dark); margin: 8px 0 8px; }
+.step-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.6; }
+
+.release-section { padding: 80px 0; background: #fff; border-top: 1px solid var(--border); }
+.release-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+.release-card h3 { font-size: 18px; font-weight: 700; color: var(--primary-dark); margin-bottom: 16px; }
+.release-card ul { list-style: none; }
+.release-card li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.release-card li:last-child { border-bottom: none; }
+.release-card li .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary-light);
+  margin-top: 8px;
+  flex-shrink: 0;
+}
+.release-card a { color: var(--primary); font-weight: 500; }
+.release-card a:hover { text-decoration: underline; }
+
+/* ============================================================
+   PRICING / OPEN SOURCE
+   ============================================================ */
+.opensource-section { padding: 80px 0; background: #fff; border-top: 1px solid var(--border); }
+.opensource-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+.opensource-content h2 {
+  font-size: clamp(28px, 3.2vw, 38px);
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 16px;
+}
+.opensource-content p {
+  font-size: 16px;
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 20px;
+}
+.opensource-list {
+  list-style: none;
+  display: grid;
+  gap: 14px;
+  margin-top: 24px;
+}
+.opensource-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+.opensource-list li svg { flex-shrink: 0; color: var(--primary); margin-top: 2px; }
+.opensource-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 32px;
+}
+.opensource-card h3 {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 8px;
+}
+.opensource-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.7; margin-bottom: 20px; }
+.license-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary);
+  background: rgba(30, 64, 175, 0.08);
+  padding: 6px 12px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+.github-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 24px;
+}
+.github-stat {
+  text-align: center;
+  padding: 16px;
+  background: #fff;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+.github-stat .num { font-size: 24px; font-weight: 800; color: var(--primary-dark); }
+.github-stat .label { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
+
+.sponsor-section { padding: 80px 0; }
+.sponsor-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.sponsor-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  text-align: center;
+}
+.sponsor-card h3 { font-size: 17px; font-weight: 700; color: var(--primary-dark); margin-bottom: 8px; }
+.sponsor-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 20px; }
+.sponsor-card .amount { font-size: 32px; font-weight: 800; color: var(--text); margin-bottom: 16px; }
+.sponsor-card .amount span { font-size: 14px; font-weight: 500; color: var(--text-muted); }
+
+.faq-section { padding: 80px 0; background: #fff; border-top: 1px solid var(--border); }
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+}
+.faq-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+}
+.faq-card h3 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 10px;
+}
+.faq-card p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ============================================================
+   DOCS
+   ============================================================ */
+.docs-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 48px;
+  padding: 48px 0 80px;
+}
+.docs-sidebar {
+  position: sticky;
+  top: calc(var(--header-height) + 24px);
+  align-self: start;
+  max-height: calc(100vh - var(--header-height) - 48px);
+  overflow-y: auto;
+}
+.sidebar-section { margin-bottom: 24px; }
+.sidebar-title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  padding-left: 12px;
+}
+.sidebar-links { list-style: none; }
+.sidebar-links a {
+  display: block;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  color: var(--text-secondary);
+  transition: all .15s ease;
+  border-left: 3px solid transparent;
+}
+.sidebar-links a:hover { color: var(--primary); background: var(--muted); }
+.sidebar-links a.active {
+  color: var(--primary);
+  background: rgba(30, 64, 175, 0.06);
+  border-left-color: var(--primary);
+  font-weight: 600;
+}
+
+.docs-main { min-width: 0; }
+.docs-section {
+  margin-bottom: 64px;
+  scroll-margin-top: calc(var(--header-height) + 24px);
+}
+.docs-section h2 {
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 20px;
+  letter-spacing: -0.01em;
+}
+.docs-section h3 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 32px 0 14px;
+}
+.docs-section h4 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 24px 0 10px;
+}
+.docs-section p {
+  font-size: 15px;
+  color: var(--text-secondary);
+  margin-bottom: 14px;
+}
+.docs-section ul, .docs-section ol {
+  margin: 14px 0 14px 20px;
+  color: var(--text-secondary);
+  font-size: 15px;
+}
+.docs-section li { margin-bottom: 8px; }
+.docs-section strong { color: var(--text); font-weight: 600; }
+.docs-section a { color: var(--primary); font-weight: 500; }
+.docs-section a:hover { text-decoration: underline; }
+.docs-section code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+  background: var(--code-bg);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--primary-dark);
+}
+.docs-section pre {
+  background: #0F172A;
+  color: #E2E8F0;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+  margin: 16px 0 24px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.docs-section pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font-size: 13px;
+}
+
+.callout {
+  display: flex;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  margin: 20px 0;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+.callout.info { border-left: 4px solid var(--primary-light); }
+.callout.warning { border-left: 4px solid var(--warning); }
+.callout.success { border-left: 4px solid var(--success); }
+.callout-icon { flex-shrink: 0; margin-top: 2px; }
+.callout p { margin: 0; font-size: 14px; }
+
+.steps-list {
+  list-style: none;
+  margin-left: 0;
+  counter-reset: step;
+}
+.steps-list > li {
+  position: relative;
+  padding-left: 44px;
+  margin-bottom: 20px;
+  counter-increment: step;
+}
+.steps-list > li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  margin: 20px 0;
+}
+.table-wrap table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.table-wrap th, .table-wrap td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.table-wrap th {
+  background: var(--bg);
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+.table-wrap tr:last-child td { border-bottom: none; }
+.table-wrap td { color: var(--text-secondary); }
+
+.docs-faq-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+.docs-faq-question {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background: transparent;
+  border: none;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+.docs-faq-answer {
+  padding: 0 20px 18px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  display: none;
+}
+.docs-faq-item.open .docs-faq-answer { display: block; }
+.docs-faq-item.open .docs-faq-icon { transform: rotate(180deg); }
+.docs-faq-icon { transition: transform .2s ease; color: var(--text-muted); }
+
+/* ============================================================
+   REGISTER
+   ============================================================ */
+.register-main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 420px 1fr;
+  align-items: center;
+  padding: calc(var(--header-height) + 48px) 24px 64px;
+  background:
+    radial-gradient(ellipse 60% 40% at 80% 20%, rgba(59, 130, 246, 0.1), transparent),
+    radial-gradient(ellipse 50% 30% at 10% 90%, rgba(30, 64, 175, 0.06), transparent);
+}
+.register-card {
+  grid-column: 2;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 40px;
+  box-shadow: var(--shadow-lg);
+}
+.register-card h1 {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--primary-dark);
+  margin-bottom: 8px;
+  text-align: center;
+}
+.register-subtitle {
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 28px;
+}
+.github-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 20px;
+  background: #0F172A;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all .2s ease;
+}
+.github-btn:hover { background: #1E293B; transform: translateY(-1px); }
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 24px 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.divider::before, .divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.form-group { margin-bottom: 18px; }
+.form-group label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+.form-group input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--text);
+  background: #fff;
+  transition: all .2s ease;
+}
+.form-group input:focus {
+  outline: none;
+  border-color: var(--primary-light);
+  box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
+}
+.form-group input::placeholder { color: var(--text-muted); }
+.checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 20px;
+}
+.checkbox-row input {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  accent-color: var(--primary);
+}
+.checkbox-row a { color: var(--primary); }
+.register-footer {
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-top: 20px;
+}
+.register-footer a { color: var(--primary); font-weight: 600; }
+.mvp-note {
+  margin-top: 24px;
+  padding: 14px;
+  background: rgba(5, 150, 105, 0.06);
+  border: 1px solid rgba(5, 150, 105, 0.18);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  color: var(--success);
+  text-align: center;
+}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 1024px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 48px; }
+  .dashboard-mockup { transform: none; max-width: 720px; margin: 0 auto; }
+  .feature-grid, .pain-grid, .how-grid { grid-template-columns: repeat(2, 1fr); }
+  .vendor-grid { grid-template-columns: repeat(4, 1fr); }
+  .pricing-grid, .pricing-grid.cols-3 { grid-template-columns: repeat(2, 1fr); }
+  .opensource-grid { grid-template-columns: 1fr; }
+  .sponsor-grid { grid-template-columns: 1fr; max-width: 480px; margin: 0 auto; }
+  .faq-grid { grid-template-columns: 1fr; }
+  .platform-grid { grid-template-columns: 1fr; }
+  .steps-grid { grid-template-columns: repeat(2, 1fr); }
+  .docs-layout { grid-template-columns: 1fr; }
+  .docs-sidebar { display: none; }
+  .register-main { grid-template-columns: 1fr minmax(auto, 420px) 1fr; }
+  .footer-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 768px) {
+  .nav-links, .header-cta .btn-secondary { display: none; }
+  .mobile-menu-btn { display: grid; place-items: center; width: 38px; height: 38px; border-radius: var(--radius-md); color: var(--text-secondary); }
+  .hero { padding-top: calc(var(--header-height) + 56px); padding-bottom: 72px; }
+  .hero-actions { flex-direction: column; align-items: stretch; }
+  .hero-actions .btn { width: 100%; }
+  .hero-stats { gap: 24px; }
+  .mockup-body { grid-template-columns: 1fr; }
+  .feature-grid, .pain-grid, .how-grid, .pricing-grid, .pricing-grid.cols-3, .vendor-grid { grid-template-columns: 1fr; }
+  .architecture-card { padding: 24px; }
+  .arch-flow { flex-direction: column; }
+  .arch-arrow { transform: rotate(90deg); }
+  .download-card { padding: 32px 24px; }
+  .github-stats { grid-template-columns: 1fr; }
+  .register-main { display: block; padding: calc(var(--header-height) + 32px) 20px 40px; }
+  .register-card { padding: 28px; }
+  .footer-grid { grid-template-columns: 1fr; gap: 32px; }
+  .cta-banner { padding: 48px 24px; }
+  .section { padding: 72px 0; }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Quota-Flow — 把 7 家 AI 视频厂商的免费额度，聚成一个池子",
+  description: "Quota-Flow 是一站式 AI 视频免费额度调度平台。自动归集、智能路由、团队共享，告别反复登录与额度沉睡。"
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="zh-CN">
+      <body>
+        <Header />
+        {children}
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,376 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Zap,
+  Download,
+  Github,
+  Clock,
+  Sparkles,
+  Users,
+  Monitor,
+  ShieldCheck,
+  UserPlus,
+  Cookie,
+  Wrench,
+  LayoutGrid,
+  Database,
+  ArrowRight,
+  Check
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Quota-Flow — 让 7 家 AI 视频厂商的免费额度，为你所用",
+  description: "Quota-Flow 是一站式 AI 视频免费额度调度平台。自动归集、智能路由、团队共享，告别反复登录与额度沉睡。"
+};
+
+const vendors = [
+  { name: "豆包", unit: "次数", color: "#3B82F6", letter: "豆" },
+  { name: "即梦", unit: "灵感值", color: "#F59E0B", letter: "梦" },
+  { name: "通义万相", unit: "次数", color: "#8B5CF6", letter: "问" },
+  { name: "元宝混元", unit: "次数", color: "#10B981", letter: "元" },
+  { name: "可灵", unit: "积分", color: "#EF4444", letter: "灵" },
+  { name: "海螺", unit: "次数", color: "#06B6D4", letter: "螺" },
+  { name: "MathMind", unit: "次数 · API", color: "#6366F1", letter: "M" }
+];
+
+const painPoints = [
+  {
+    icon: Clock,
+    title: "账号切换的繁琐",
+    desc: "扫码、验证、切账号……生成一条视频，往往十分钟耗在登录与跳转上，创意被打断。"
+  },
+  {
+    icon: Sparkles,
+    title: "额度沉睡的浪费",
+    desc: "这家还剩 3 次，那家早已用完。免费额度像碎片，凑不出一次完整的创作。"
+  },
+  {
+    icon: Users,
+    title: "团队各自为战",
+    desc: "每人重复绑定同一厂商，额度不能叠加，协作成本居高不下，免费优势无从放大。"
+  }
+];
+
+const features = [
+  {
+    icon: Monitor,
+    title: "动态额度账本",
+    desc: "按次数、灵感值、积分等原生单位实时记账；按时长、分辨率、模型动态扣减，每日自动刷新。"
+  },
+  {
+    icon: ShieldCheck,
+    title: "智能调度 + 预检查",
+    desc: "提交前预估算本次消耗，自动跳过余额不足账号，为每一次创作挑选最划算的厂商。"
+  },
+  {
+    icon: UserPlus,
+    title: "多账号池化",
+    desc: "同一厂商绑定多个账号，额度自动叠加；单账号失效时无缝 failover，创作不中断。"
+  },
+  {
+    icon: Users,
+    title: "团队共享池",
+    desc: "多人多账号额度汇入团队池，统一配额与审计。小团队也能把免费创作力放大数倍。"
+  },
+  {
+    icon: Cookie,
+    title: "Cookie 自动续命",
+    desc: "隔离会话 + 实例池共享，凌晨静默续期。平均 1–2 个月才需重新登录一次，省心省力。"
+  },
+  {
+    icon: Wrench,
+    title: "快速接入新厂商",
+    desc: "声明式配置页面地址与 DOM 选择器，无需逆向 bx-ua 等风控签名，新厂商约 2 小时即可上线。"
+  }
+];
+
+export default function HomePage() {
+  return (
+    <>
+      <section className="hero">
+        <div className="container">
+          <div className="hero-grid">
+            <div className="hero-content">
+              <div className="eyebrow">
+                <Zap size={14} />
+                AI 视频免费额度调度平台
+              </div>
+              <h1>
+                让 7 家 AI 视频厂商的<br />
+                <span className="accent-text">免费额度，为你所用</span>
+              </h1>
+              <p className="hero-desc">
+                豆包、即梦、通义万相、元宝混元、可灵、海螺、MathMind —— 多家账号额度自动归集、智能路由、团队共享。告别反复登录与额度沉睡，把每一份免费创作力用到极致。
+              </p>
+              <div className="hero-actions">
+                <Link href="/download" className="btn btn-primary btn-lg">
+                  <Download size={18} />
+                  下载 Windows 版
+                </Link>
+                <a
+                  href="https://github.com/Shaun520/quota-flow"
+                  className="btn btn-secondary btn-lg"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <Github size={18} />
+                  GitHub
+                </a>
+              </div>
+              <div className="hero-stats">
+                <div>
+                  <div className="stat-value">7</div>
+                  <div className="stat-label">接入厂商</div>
+                </div>
+                <div>
+                  <div className="stat-value">∞</div>
+                  <div className="stat-label">账号叠加</div>
+                </div>
+                <div>
+                  <div className="stat-value">≈2h</div>
+                  <div className="stat-label">接入新厂商</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="dashboard-mockup" aria-hidden="true">
+              <div className="mockup-header">
+                <span className="mockup-dot" />
+                <span className="mockup-dot" />
+                <span className="mockup-dot" />
+                <span className="mockup-title">Quota-Flow 桌面端 · 调度台</span>
+              </div>
+              <div className="mockup-body">
+                <div className="mock-card">
+                  <h4>生成视频</h4>
+                  <div className="mock-input" />
+                  <div className="mock-row"><div className="mock-select" /><div className="mock-select" /></div>
+                  <div className="mock-row"><div className="mock-select" /><div className="mock-select" /></div>
+                  <div className="mock-btn" />
+                </div>
+                <div className="mock-card">
+                  <h4>厂商实时状态</h4>
+                  <div className="provider-item">
+                    <div className="provider-icon">豆</div>
+                    <div className="provider-info">
+                      <div className="provider-name">豆包 <span className="provider-quota">7 / 10 次</span></div>
+                      <div className="provider-bar"><span style={{ width: "70%" }} /></div>
+                    </div>
+                  </div>
+                  <div className="provider-item">
+                    <div className="provider-icon">梦</div>
+                    <div className="provider-info">
+                      <div className="provider-name">即梦 <span className="provider-quota">640 / 800 灵感值</span></div>
+                      <div className="provider-bar"><span style={{ width: "80%" }} /></div>
+                    </div>
+                  </div>
+                  <div className="provider-item">
+                    <div className="provider-icon">问</div>
+                    <div className="provider-info">
+                      <div className="provider-name">通义万相 <span className="provider-quota">8 / 10 次</span></div>
+                      <div className="provider-bar"><span style={{ width: "80%" }} /></div>
+                    </div>
+                  </div>
+                  <div className="provider-item">
+                    <div className="provider-icon">元</div>
+                    <div className="provider-info">
+                      <div className="provider-name">元宝混元 <span className="provider-quota">4 / 5 次</span></div>
+                      <div className="provider-bar"><span style={{ width: "80%" }} /></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" id="pain">
+        <div className="container">
+          <div className="section-title">
+            <h2>别让免费额度，散落在七个账号里</h2>
+            <p>每家厂商独立登录、独立刷新、独立额度单位。个人难以记清，团队无法复用。Quota-Flow 把零散额度汇成一本清晰的账。</p>
+          </div>
+          <div className="pain-grid">
+            {painPoints.map((item) => (
+              <div className="pain-card" key={item.title}>
+                <div className="icon-wrap">
+                  <item.icon size={22} />
+                </div>
+                <h3>{item.title}</h3>
+                <p>{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section vendors-section" id="vendors">
+        <div className="container">
+          <div className="section-title">
+            <h2>7 家主流厂商，一站接入</h2>
+            <p>按各平台原生单位自动记账，实时同步额度与状态。WebView 统一引擎接入，无需破解风控签名。</p>
+          </div>
+          <div className="vendor-grid">
+            {vendors.map((v) => (
+              <div className="vendor-cell" key={v.name}>
+                <div className="vendor-logo" style={{ background: v.color }}>{v.letter}</div>
+                <h4>{v.name}</h4>
+                <span>{v.unit}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section" id="features">
+        <div className="container">
+          <div className="section-title">
+            <h2>核心特性</h2>
+            <p>从额度归集到智能调度，从多账号池化到团队共享，让每一份免费额度都物尽其用。</p>
+          </div>
+          <div className="feature-grid">
+            {features.map((f) => (
+              <div className="feature-card" key={f.title}>
+                <div className="icon-wrap">
+                  <f.icon size={20} />
+                </div>
+                <h3>{f.title}</h3>
+                <p>{f.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section how-section" id="how">
+        <div className="container">
+          <div className="section-title">
+            <h2>三步开始调度</h2>
+            <p>桌面端是创作入口，WebView 引擎在后台完成厂商调用，Supabase 负责账本与团队协作。</p>
+          </div>
+          <div className="how-grid">
+            <div className="how-step">
+              <div className="step-num">1</div>
+              <h3>绑定账号</h3>
+              <p>在桌面端授权登录各厂商，额度自动归集到统一账本，Cookie 本地安全保存。</p>
+            </div>
+            <div className="how-step">
+              <div className="step-num">2</div>
+              <h3>一键生成</h3>
+              <p>输入创意与参数，系统自动预估消耗、选择厂商、提交任务；失败时无缝切换次优方案。</p>
+            </div>
+            <div className="how-step">
+              <div className="step-num">3</div>
+              <h3>额度共享</h3>
+              <p>个人账号本地解密自用，团队账号由 Edge Function 代调用，密钥始终留在云端之外。</p>
+            </div>
+          </div>
+          <div className="architecture-card">
+            <div className="arch-flow">
+              <div className="arch-node">
+                <div className="node-icon">
+                  <Monitor size={32} strokeWidth={1.5} />
+                </div>
+                <h4>桌面端 Electron</h4>
+                <p>React 交互界面 + 本地调度引擎，创作唯一入口</p>
+              </div>
+              <div className="arch-arrow">
+                <ArrowRight size={28} />
+              </div>
+              <div className="arch-node">
+                <div className="node-icon">
+                  <LayoutGrid size={32} strokeWidth={1.5} />
+                </div>
+                <h4>WebView 统一引擎</h4>
+                <p>Cookie 注入、自动提交、实例池共享与续期</p>
+              </div>
+              <div className="arch-arrow">
+                <ArrowRight size={28} />
+              </div>
+              <div className="arch-node">
+                <div className="node-icon">
+                  <Database size={32} strokeWidth={1.5} />
+                </div>
+                <h4>Supabase 账本</h4>
+                <p>Postgres 账本、Auth、Edge Functions 与 Realtime</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" id="pricing">
+        <div className="container">
+          <div className="section-title">
+            <h2>开源免费，人人可用</h2>
+            <p>个人、团队、自部署，全部功能永久免费。没有付费墙，没有席位上限，只有社区共同维护。</p>
+          </div>
+          <div className="pricing-grid">
+            <div className="pricing-card">
+              <h3>个人用户</h3>
+              <div className="price">免费</div>
+              <div className="seat">本地使用，数据不离本机</div>
+              <ul>
+                <li><Check size={16} strokeWidth={3} />完整核心功能</li>
+                <li><Check size={16} strokeWidth={3} />7 家厂商接入</li>
+                <li><Check size={16} strokeWidth={3} />无限账号池化</li>
+              </ul>
+              <Link href="/download" className="btn btn-secondary">免费下载</Link>
+            </div>
+            <div className="pricing-card featured">
+              <div className="pricing-badge">推荐</div>
+              <h3>团队用户</h3>
+              <div className="price">免费</div>
+              <div className="seat">共享额度池，无席位上限</div>
+              <ul>
+                <li><Check size={16} strokeWidth={3} />完整核心功能</li>
+                <li><Check size={16} strokeWidth={3} />团队共享额度池</li>
+                <li><Check size={16} strokeWidth={3} />成员与权限管理</li>
+              </ul>
+              <Link href="/register" className="btn btn-primary">免费注册团队</Link>
+            </div>
+            <div className="pricing-card">
+              <h3>自部署</h3>
+              <div className="price">免费</div>
+              <div className="seat">数据自主，完全掌控</div>
+              <ul>
+                <li><Check size={16} strokeWidth={3} />全部功能开放</li>
+                <li><Check size={16} strokeWidth={3} />无用户数限制</li>
+                <li><Check size={16} strokeWidth={3} />运营方不可见数据</li>
+              </ul>
+              <Link href="/docs#self-host" className="btn btn-secondary">查看自部署指南</Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: 0 }}>
+        <div className="container">
+          <div className="cta-banner">
+            <h2>让每一次免费额度，都物尽其用</h2>
+            <p>个人永久免费，小团队零成本起步。下载桌面端，几分钟即可绑定第一家厂商。</p>
+            <div style={{ display: "flex", gap: 16, justifyContent: "center", flexWrap: "wrap" }}>
+              <a
+                href="https://github.com/Shaun520/quota-flow/releases"
+                className="btn btn-lg btn-secondary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                下载 Windows 版
+              </a>
+              <a
+                href="https://github.com/Shaun520/quota-flow"
+                className="btn btn-lg btn-outline-white"
+                target="_blank"
+                rel="noreferrer"
+              >
+                在 GitHub 上查看
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Layers,
+  ShieldCheck,
+  Users,
+  User,
+  Server,
+  Check,
+  Github,
+  FileText
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "开源免费 — Quota-Flow",
+  description: "Quota-Flow 是公益性质的开源项目。所有功能对个人和团队永久免费，自部署用户更可无限制使用。"
+};
+
+const plans = [
+  {
+    icon: User,
+    title: "个人用户",
+    price: "免费",
+    desc: "本地使用，数据不离本机",
+    features: ["完整核心功能", "7 家厂商接入", "无限账号池化", "社区支持"],
+    cta: { text: "免费下载", href: "/download", primary: false }
+  },
+  {
+    icon: Users,
+    title: "团队用户",
+    price: "免费",
+    desc: "共享额度池，多人协作",
+    features: ["完整核心功能", "团队共享额度池", "成员与权限管理", "无席位上限"],
+    cta: { text: "免费注册团队", href: "/register", primary: true },
+    featured: true
+  },
+  {
+    icon: Server,
+    title: "自部署",
+    price: "免费",
+    desc: "数据自主，完全掌控",
+    features: ["全部功能开放", "无用户数限制", "运营方不可见数据", "完整源码可修改"],
+    cta: { text: "查看自部署指南", href: "/docs#self-host", primary: false }
+  }
+];
+
+const opensourcePoints = [
+  "不收集用户 Cookie 或额度数据（自部署模式下运营方完全不可见）",
+  "MIT 协议，可自由使用、修改、二次分发",
+  "欢迎贡献代码、文档、厂商适配或问题反馈"
+];
+
+const sponsors = [
+  {
+    title: "GitHub Sponsors",
+    amount: "$0+",
+    unit: "/月",
+    desc: "通过 GitHub 官方渠道进行一次性或周期性赞助，资金透明可查。",
+    cta: "前往赞助",
+    href: "https://github.com/sponsors/Shaun520"
+  },
+  {
+    title: "贡献代码",
+    amount: "免费",
+    unit: "",
+    desc: "提交 PR、修复 bug、撰写文档、适配新厂商，都是最有价值的支持。",
+    cta: "查看贡献指南",
+    href: "https://github.com/Shaun520/quota-flow/blob/main/CONTRIBUTING.md"
+  },
+  {
+    title: "分享给朋友",
+    amount: "免费",
+    unit: "",
+    desc: "把 Quota-Flow 推荐给需要的朋友，让更多人用得更顺手。",
+    cta: "复制项目链接",
+    href: "https://github.com/Shaun520/quota-flow"
+  }
+];
+
+const faqs = [
+  { q: "使用 Quota-Flow 真的完全免费吗？", a: "是的。无论是个人使用、团队协作还是自部署，所有核心功能均永久免费，没有隐藏收费，也没有额度抽成。" },
+  { q: "自部署需要服务器费用吗？", a: "自部署需要你自己准备 Supabase 或兼容后端，但 Quota-Flow 本身不收取任何费用。你也可以完全离线使用个人模式。" },
+  { q: "团队人数有上限吗？", a: "没有。免费团队版同样支持 unlimited 成员，功能与自部署完全一致。若团队规模很大，建议自部署以获得更好的数据掌控。" },
+  { q: "以后会收费吗？", a: "核心功能将始终保持免费。未来若提供官方托管等增值服务，也会保留完整的免费自部署路径，不会把已有功能变为付费。" },
+  { q: "商业化使用是否允许？", a: "允许。MIT 协议允许你在商业环境中自由使用、修改和分发，只需保留原始版权声明。" },
+  { q: "如何获得支持？", a: "优先通过 GitHub Issues 提交问题，社区会共同响应。你也可以发送邮件至 support@quota-flow.com。" }
+];
+
+export default function PricingPage() {
+  return (
+    <>
+      <section className="page-hero">
+        <div className="container">
+          <h1>完全免费，开源共享</h1>
+          <p>Quota-Flow 是一个公益性质的开源项目。所有功能对个人和团队永久免费，自部署用户更可无限制使用。</p>
+          <div className="hero-badges">
+            <span className="hero-badge"><Layers size={14} />MIT 协议开源</span>
+            <span className="hero-badge"><ShieldCheck size={14} />无功能限制</span>
+            <span className="hero-badge"><Users size={14} />无席位上限</span>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: 0 }}>
+        <div className="container">
+          <div className="pricing-grid cols-3">
+            {plans.map((plan) => (
+              <div className={`pricing-card${plan.featured ? " featured" : ""}`} key={plan.title}>
+                {plan.featured && <div className="pricing-badge">推荐</div>}
+                <div className="pricing-icon">
+                  <plan.icon size={28} />
+                </div>
+                <h3>{plan.title}</h3>
+                <div className="price">{plan.price}</div>
+                <div className="desc">{plan.desc}</div>
+                <ul>
+                  {plan.features.map((f) => (
+                    <li key={f}><Check size={16} strokeWidth={3} />{f}</li>
+                  ))}
+                </ul>
+                <Link href={plan.cta.href} className={`btn${plan.cta.primary ? " btn-primary" : " btn-secondary"}`}>
+                  {plan.cta.text}
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="opensource-section">
+        <div className="container">
+          <div className="opensource-grid">
+            <div className="opensource-content">
+              <h2>为什么免费？</h2>
+              <p>Quota-Flow 起源于一个朴素的观察：AI 视频厂商每天都在赠送免费额度，但用户却被困在反复登录和额度分散的麻烦里。</p>
+              <p>我们相信，把「薅免费额度」这件事做得更优雅，应该是每个人都能享有的工具，而不是付费墙后的特权。因此项目选择完全开源，由社区共同维护。</p>
+              <ul className="opensource-list">
+                {opensourcePoints.map((text) => (
+                  <li key={text}><ShieldCheck size={18} />{text}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="opensource-card">
+              <span className="license-tag">
+                <FileText size={14} />
+                MIT License
+              </span>
+              <h3>代码完全开放</h3>
+              <p>前端、桌面端、服务端逻辑全部托管在 GitHub。你可以审计每一行代码，也可以 fork 后按自己的需求定制。</p>
+              <a
+                href="https://github.com/Shaun520/quota-flow"
+                className="btn btn-primary btn-lg"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Github size={18} />
+                访问 GitHub 仓库
+              </a>
+              <div className="github-stats">
+                <div className="github-stat"><div className="num">—</div><div className="label">Stars</div></div>
+                <div className="github-stat"><div className="num">—</div><div className="label">Forks</div></div>
+                <div className="github-stat"><div className="num">—</div><div className="label">Contributors</div></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="sponsor-section">
+        <div className="container">
+          <div className="section-title">
+            <h2>支持项目持续运行</h2>
+            <p>如果你认可这个项目，可以通过赞助帮助维护者投入更多时间。所有赞助完全自愿，不影响任何功能使用。</p>
+          </div>
+          <div className="sponsor-grid">
+            {sponsors.map((s) => (
+              <div className="sponsor-card" key={s.title}>
+                <h3>{s.title}</h3>
+                <div className="amount">{s.amount}<span>{s.unit}</span></div>
+                <p>{s.desc}</p>
+                <a href={s.href} className="btn btn-secondary" target="_blank" rel="noreferrer">{s.cta}</a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="faq-section">
+        <div className="container">
+          <div className="section-title">
+            <h2>常见问题</h2>
+            <p>关于免费策略、开源协议与支持的说明。</p>
+          </div>
+          <div className="faq-grid">
+            {faqs.map((item) => (
+              <div className="faq-card" key={item.q}>
+                <h3>{item.q}</h3>
+                <p>{item.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: 0, paddingBottom: 80 }}>
+        <div className="container">
+          <div className="cta-banner">
+            <h2>开始使用，无需付费</h2>
+            <p>下载桌面端，几分钟内即可绑定第一家厂商，把散落的免费额度聚成一个池子。</p>
+            <div style={{ display: "flex", gap: 16, justifyContent: "center", flexWrap: "wrap" }}>
+              <Link href="/download" className="btn btn-lg btn-secondary">免费下载</Link>
+              <a
+                href="https://github.com/Shaun520/quota-flow"
+                className="btn btn-lg btn-outline-white"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Github size={18} />
+                Star on GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/app/register/RegisterClient.tsx
+++ b/apps/web/src/app/register/RegisterClient.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { Github } from "lucide-react";
+
+export default function RegisterClient() {
+  return (
+    <main className="register-main">
+      <div className="register-card">
+        <h1>创建账号</h1>
+        <p className="register-subtitle">注册后即可在桌面端登录，开始调度你的免费额度。</p>
+
+        <a
+          href="https://github.com/Shaun520/quota-flow"
+          className="github-btn"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Github size={20} />
+          通过 GitHub 注册
+        </a>
+
+        <div className="divider">或</div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            alert("MVP 阶段仅开放 GitHub 注册");
+          }}
+        >
+          <div className="form-group">
+            <label htmlFor="email">邮箱</label>
+            <input type="email" id="email" placeholder="you@example.com" required />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">密码</label>
+            <input type="password" id="password" placeholder="至少 8 位字符" required />
+          </div>
+          <div className="form-group">
+            <label htmlFor="confirm">确认密码</label>
+            <input type="password" id="confirm" placeholder="再次输入密码" required />
+          </div>
+          <div className="checkbox-row">
+            <input type="checkbox" id="terms" required />
+            <label htmlFor="terms">
+              我已阅读并同意 <Link href="#">服务条款</Link> 与 <Link href="#">隐私政策</Link>
+            </label>
+          </div>
+          <button type="submit" className="btn btn-primary btn-lg btn-full">
+            创建账号
+          </button>
+        </form>
+
+        <p className="register-footer">
+          已有账号？<Link href="#">直接登录</Link>
+        </p>
+
+        <div className="mvp-note">
+          MVP 阶段优先通过 GitHub 入口注册，邮箱注册将在后续版本接入 Supabase Auth 后开放。
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import RegisterClient from "./RegisterClient";
+
+export const metadata: Metadata = {
+  title: "注册 — Quota-Flow",
+  description: "注册 Quota-Flow 账号，开始调度多家 AI 视频厂商的免费额度。"
+};
+
+export default function RegisterPage() {
+  return <RegisterClient />;
+}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="container">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <Link href="/" className="brand">
+              <span className="brand-mark">Q</span>
+              Quota-Flow
+            </Link>
+            <p>一站式 AI 视频额度调度平台。将多家厂商的每日免费额度汇聚一处，让个人创作更从容，让团队协作更高效。</p>
+          </div>
+          <div className="footer-col">
+            <h4>产品</h4>
+            <ul>
+              <li><Link href="/download">下载</Link></li>
+              <li><Link href="/pricing">开源免费</Link></li>
+              <li><Link href="/#features">特性</Link></li>
+              <li><Link href="/">路线图</Link></li>
+            </ul>
+          </div>
+          <div className="footer-col">
+            <h4>开发者</h4>
+            <ul>
+              <li><a href="https://github.com/Shaun520/quota-flow" target="_blank" rel="noreferrer">GitHub</a></li>
+              <li><Link href="/docs#quickstart">快速开始</Link></li>
+              <li><Link href="/docs#self-host">自部署指南</Link></li>
+              <li><Link href="/">API 文档</Link></li>
+            </ul>
+          </div>
+          <div className="footer-col">
+            <h4>支持</h4>
+            <ul>
+              <li><a href="https://github.com/Shaun520/quota-flow/issues" target="_blank" rel="noreferrer">问题反馈</a></li>
+              <li><a href="mailto:support@quota-flow.com">support@quota-flow.com</a></li>
+              <li><Link href="/">合规声明</Link></li>
+            </ul>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <span>© 2026 Quota-Flow. Open source under MIT.</span>
+          <span>完全免费，开源共享。</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Download, Github, Menu, X } from "lucide-react";
+
+interface HeaderProps {
+  variant?: "default" | "transparent";
+}
+
+export default function Header({ variant = "default" }: HeaderProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <header className="site-header">
+      <div className="container">
+        <Link href="/" className="brand">
+          <span className="brand-mark">Q</span>
+          Quota-Flow
+        </Link>
+
+        <nav className="nav-links">
+          <Link href="/#features">特性</Link>
+          <Link href="/#vendors">厂商</Link>
+          <Link href="/#how">原理</Link>
+          <Link href="/pricing">开源免费</Link>
+          <Link href="/docs">文档</Link>
+          <Link href="/register">注册</Link>
+          <a href="https://github.com/Shaun520/quota-flow" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </nav>
+
+        <div className="header-cta">
+          <Link href="/pricing" className="btn btn-secondary">
+            开源免费
+          </Link>
+          <Link href="/download" className="btn btn-primary">
+            <Download size={16} />
+            免费下载
+          </Link>
+        </div>
+
+        <button
+          className="mobile-menu-btn btn-ghost"
+          aria-label="菜单"
+          onClick={() => setMobileOpen(!mobileOpen)}
+        >
+          {mobileOpen ? <X size={22} /> : <Menu size={22} />}
+        </button>
+      </div>
+
+      {mobileOpen && (
+        <div className="container" style={{ paddingBottom: 16 }}>
+          <nav style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Link href="/#features" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              特性
+            </Link>
+            <Link href="/#vendors" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              厂商
+            </Link>
+            <Link href="/#how" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              原理
+            </Link>
+            <Link href="/pricing" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              开源免费
+            </Link>
+            <Link href="/docs" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              文档
+            </Link>
+            <Link href="/register" className="btn btn-ghost" onClick={() => setMobileOpen(false)}>
+              注册
+            </Link>
+            <a
+              href="https://github.com/Shaun520/quota-flow"
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-ghost"
+            >
+              <Github size={16} />
+              GitHub
+            </a>
+            <Link href="/download" className="btn btn-primary" onClick={() => setMobileOpen(false)}>
+              <Download size={16} />
+              免费下载
+            </Link>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,33 @@ importers:
 
   apps/skill: {}
 
-  apps/web: {}
+  apps/web:
+    dependencies:
+      lucide-react:
+        specifier: ^0.474.0
+        version: 0.474.0(react@19.2.8)
+      next:
+        specifier: 15.5.23
+        version: 15.5.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.0
+        version: 20.19.43
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
 
   packages/auth:
     dependencies:
@@ -878,105 +904,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1034,7 +1044,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/env@15.5.23':
     resolution: {integrity: sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==}
@@ -1056,28 +1065,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.23':
     resolution: {integrity: sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.23':
     resolution: {integrity: sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.23':
     resolution: {integrity: sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.23':
     resolution: {integrity: sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==}
@@ -1150,79 +1155,66 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -2075,28 +2067,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2145,6 +2133,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@0.474.0:
+    resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.31.0:
     resolution: {integrity: sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==}
@@ -4633,6 +4626,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.474.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   lucide-react@1.31.0(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Closes #68 

## 变更内容
- 初始化 `apps/web` Next.js 15 项目结构
- 新增共享 `Header` / `Footer` 组件
- 新增 5 个落地页：首页、下载、定价、文档、注册
- 新增设计 token 与全局样式 `globals.css`
- 更新 `pnpm-lock.yaml` 与 `apps/web/package.json`

## 验证
- [x] `pnpm --filter @quota-flow/web typecheck` 通过
- [x] `pnpm --filter @quota-flow/web build` 通过，所有路由静态导出

## 说明
-  pricing 页已按“开源公益、永久免费”定位调整，不含付费档位。
- 注册页当前为 MVP 占位，后续接入 Supabase Auth 后开放邮箱注册。