### PR TITLE
fix(desktop): install 后自动补下载 Electron 二进制，修复 dev 报 Electron uninstall

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -276,6 +276,8 @@ pnpm --filter @quota-flow/desktop dev   # Dev mode
 pnpm release                            # Build and package desktop installer
 ```
 
+> Note: Electron 43+ no longer downloads its binary with the npm package (lazy download). The root `postinstall` (`scripts/install-electron.cjs`) re-fetches it after every `pnpm install`, defaulting to the npmmirror mirror (override via the `ELECTRON_MIRROR` env var). If `dev` still reports `Electron uninstall`, run `node scripts/install-electron.cjs` manually.
+
 ## Open Source Policy
 
 | Repository | Open Source |

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ pnpm --filter @quota-flow/desktop dev   # 开发模式
 pnpm release                            # 构建并打包桌面端安装包
 ```
 
+> 说明：Electron 43+ 不再随 npm 包自动下载二进制（lazy download）。根目录 `postinstall`（`scripts/install-electron.cjs`）会在每次 `pnpm install` 后自动补下载，国内网络默认走 npmmirror 镜像（可用环境变量 `ELECTRON_MIRROR` 覆盖）。若 `dev` 仍报 `Electron uninstall`，手动执行 `node scripts/install-electron.cjs` 即可。
+
 ## 开源策略
 
 | 仓库 | 开源 |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "vitest",
     "lint": "eslint \"packages/*/src/**/*.ts\" \"apps/*/src/**/*.ts\"",
     "format": "prettier --write .",
+    "postinstall": "node scripts/install-electron.cjs",
     "release": "pnpm --filter @quota-flow/desktop run release",
     "release:publish": "git fetch --tags origin && pnpm --filter @quota-flow/desktop run release:publish"
   },

--- a/scripts/install-electron.cjs
+++ b/scripts/install-electron.cjs
@@ -1,0 +1,19 @@
+// Electron 43+ 采用 lazy download（electron/rfcs#0022），npm 包内不再带 postinstall 钩子，
+// pnpm install 后二进制不会自动下载，electron-vite dev 会报 "Electron uninstall"。
+// 本脚本作为根 postinstall 钩子：每次 pnpm install 后补齐二进制（幂等，已安装则秒退）。
+
+const { execFileSync } = require('node:child_process')
+const path = require('node:path')
+
+// 未显式设置时默认走 npmmirror 镜像（实测可用）；可用环境变量 ELECTRON_MIRROR 覆盖
+process.env.ELECTRON_MIRROR ||= 'https://npmmirror.com/mirrors/electron/'
+
+try {
+  const installJs = require.resolve('electron/install.js', {
+    paths: [path.join(__dirname, '..', 'apps', 'desktop')],
+  })
+  execFileSync(process.execPath, [installJs], { stdio: 'inherit' })
+} catch (err) {
+  // 选择性安装（如 --filter 只装 web）时 electron 可能未安装，跳过即可，不阻断安装
+  console.warn('[install-electron] 跳过：', err.message)
+}


### PR DESCRIPTION
>>
>> Electron 43.x 移除包内 postinstall（lazy download，electron/rfcs#0022），
>> pnpm install 不再自动下载二进制，导致 electron-vite dev 报 "Electron uninstall"。
>>
>> - 新增 scripts/install-electron.cjs：幂等调用 electron/install.js，
>>   未设置 ELECTRON_MIRROR 时默认 npmmirror 镜像，避免国内直连 GitHub 失败
>> - 根 package.json 增加 postinstall 钩子，每次 pnpm install 后自动执行
>> - README/README.en 补充说明