### PR TITLE
feat(admin): 新增生成记录管理模块

### DIFF
--- a/apps/admin/src/app/(dashboard)/generation-jobs/page.tsx
+++ b/apps/admin/src/app/(dashboard)/generation-jobs/page.tsx
@@ -1,0 +1,573 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  deleteGenerationJob,
+  deleteGenerationJobs,
+  formatCost,
+  listGenerationJobs,
+  modeLabel,
+  statusBadge,
+  type AdminGenerationJob,
+  type GenerationJobStatusFilter,
+  type GenerationJobTimeRange
+} from "@/lib/api/generationJobs";
+import { listProviderOptions, type ProviderOption } from "@/lib/api/cost-tables";
+import { avatarColor, formatDateTime, initials } from "@/lib/utils/format";
+import { Pagination } from "@/components/users/pagination";
+import { isSupabaseConfigured } from "@/lib/supabase/env";
+
+const PAGE_SIZE = 20;
+
+export default function GenerationJobsPage() {
+  const [items, setItems] = useState<AdminGenerationJob[]>([]);
+  const [total, setTotal] = useState(0);
+  const [providerId, setProviderId] = useState("");
+  const [status, setStatus] = useState<GenerationJobStatusFilter>("");
+  const [timeRange, setTimeRange] = useState<GenerationJobTimeRange>("7d");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [providers, setProviders] = useState<ProviderOption[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [batchModalOpen, setBatchModalOpen] = useState(false);
+  const [batchDeleting, setBatchDeleting] = useState(false);
+  const [deleting, setDeleting] = useState<AdminGenerationJob | null>(null);
+  const [detail, setDetail] = useState<AdminGenerationJob | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch((prev) => {
+        if (prev === search) return prev;
+        setPage(1);
+        return search;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    let mounted = true;
+    listProviderOptions()
+      .then((opts) => {
+        if (mounted) setProviders(opts);
+      })
+      .catch(() => {
+        /* 厂商下拉失败不阻塞页面 */
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listGenerationJobs({
+        providerId,
+        status,
+        timeRange,
+        search: debouncedSearch,
+        page,
+        pageSize: PAGE_SIZE
+      });
+      setItems(res.items);
+      setTotal(res.total);
+      setSelectedIds([]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [providerId, status, timeRange, debouncedSearch, page]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]));
+  }
+
+  function toggleSelectAll() {
+    setSelectedIds((prev) => (prev.length === items.length ? [] : items.map((item) => item.id)));
+  }
+
+  async function handleDelete(item: AdminGenerationJob) {
+    try {
+      await deleteGenerationJob(item.id);
+      setDeleting(null);
+      setToast("记录已删除");
+      void load();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "操作失败");
+      setDeleting(null);
+    }
+  }
+
+  async function handleBatchDelete() {
+    if (selectedIds.length === 0 || batchDeleting) return;
+    setBatchDeleting(true);
+    try {
+      await deleteGenerationJobs(selectedIds);
+      setToast(`已删除 ${selectedIds.length} 条记录`);
+      setBatchDeleting(false);
+      setBatchModalOpen(false);
+      setSelectedIds([]);
+      void load();
+    } catch (e) {
+      setBatchDeleting(false);
+      setToast(e instanceof Error ? e.message : "批量删除失败");
+    }
+  }
+
+  if (!isSupabaseConfigured()) {
+    return (
+      <div>
+        <div className="page-header">
+          <div>
+            <h1 className="page-title">生成记录</h1>
+            <p className="page-subtitle">请先配置 NEXT_PUBLIC_SUPABASE_URL 和 NEXT_PUBLIC_SUPABASE_ANON_KEY。</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">生成记录</h1>
+          <p className="page-subtitle">查看用户调用 AI 生成视频的历史记录，可筛选、删除与批量删除。</p>
+        </div>
+        <div className="page-actions">
+          {selectedIds.length > 0 ? (
+            <button className="btn btn-danger btn-sm" onClick={() => setBatchModalOpen(true)}>
+              批量删除（{selectedIds.length}）
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="filter-bar">
+        <div className="filter-group">
+          <span className="filter-label">搜索提示词/用户</span>
+          <input
+            className="form-input"
+            type="search"
+            placeholder="输入 Prompt、用户名或邮箱关键词"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="filter-group">
+          <span className="filter-label">状态</span>
+          <select
+            className="form-select"
+            value={status}
+            onChange={(e) => {
+              setStatus(e.target.value as GenerationJobStatusFilter);
+              setPage(1);
+            }}
+          >
+            <option value="">全部状态</option>
+            <option value="pending">排队中</option>
+            <option value="running">生成中</option>
+            <option value="success">成功</option>
+            <option value="failed">失败</option>
+            <option value="not_generated">无可用厂商</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <span className="filter-label">厂商</span>
+          <select
+            className="form-select"
+            value={providerId}
+            onChange={(e) => {
+              setProviderId(e.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">全部厂商</option>
+            {providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="filter-group">
+          <span className="filter-label">时间</span>
+          <select
+            className="form-select"
+            value={timeRange}
+            onChange={(e) => {
+              setTimeRange(e.target.value as GenerationJobTimeRange);
+              setPage(1);
+            }}
+          >
+            <option value="24h">近 24 小时</option>
+            <option value="7d">近 7 天</option>
+            <option value="30d">近 30 天</option>
+            <option value="all">全部时间</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body" style={{ paddingTop: "var(--space-3)" }}>
+          {loading ? (
+            <GenerationJobsSkeleton />
+          ) : error ? (
+            <div className="empty-state">
+              <h3>加载失败</h3>
+              <p>{error}</p>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="empty-state">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              <h3>暂无生成记录</h3>
+              <p>当前筛选条件下没有匹配的生成记录。</p>
+            </div>
+          ) : (
+            <div className="table-container">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 32 }}>
+                      <input
+                        type="checkbox"
+                        checked={items.length > 0 && selectedIds.length === items.length}
+                        onChange={toggleSelectAll}
+                        aria-label="选择当前页全部"
+                      />
+                    </th>
+                    <th>时间</th>
+                    <th>用户</th>
+                    <th>团队</th>
+                    <th>厂商</th>
+                    <th>模式</th>
+                    <th>状态</th>
+                    <th>费用</th>
+                    <th>结果</th>
+                    <th style={{ textAlign: "right" }}>操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <tr key={item.id}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.includes(item.id)}
+                          onChange={() => toggleSelect(item.id)}
+                          aria-label={`选择记录 ${userDisplay(item)}`}
+                        />
+                      </td>
+                      <td style={{ whiteSpace: "nowrap" }}>{formatDateTime(item.created_at)}</td>
+                      <td>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 140 }}>
+                          <div
+                            className="admin-avatar"
+                            style={{ width: 28, height: 28, fontSize: 11, background: avatarColor(item.user_id ?? item.id) }}
+                          >
+                            {initials(item.user_name, item.user_email)}
+                          </div>
+                          <div style={{ minWidth: 0 }}>
+                            <div className="cell-primary" style={{ maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              {item.user_name ?? "—"}
+                            </div>
+                            <div className="text-muted" style={{ fontSize: 12, maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              {item.user_email ?? "—"}
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                      <td>{item.team_name ?? "—"}</td>
+                      <td>{item.provider_name ?? item.provider_id ?? "—"}</td>
+                      <td>{modeLabel(item.mode)}</td>
+                      <td>
+                        <span className={`badge ${statusBadgeClass(item.status)}`}>{statusBadge(item.status)}</span>
+                      </td>
+                      <td>{formatCost(item)}</td>
+                      <td>
+                        {item.result_url ? (
+                          <a href={item.result_url} target="_blank" rel="noopener noreferrer" style={{ color: "var(--color-primary)" }}>
+                            查看
+                          </a>
+                        ) : (
+                          <span className="text-muted">—</span>
+                        )}
+                      </td>
+                      <td>
+                        <div className="cell-actions" style={{ justifyContent: "flex-end" }}>
+                          <button className="btn btn-secondary btn-sm" onClick={() => setDetail(item)}>
+                            详情
+                          </button>
+                          <button className="btn btn-danger btn-sm" onClick={() => setDeleting(item)}>
+                            删除
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <Pagination page={page} total={total} pageSize={PAGE_SIZE} onPageChange={setPage} />
+      </div>
+
+      {deleting ? (
+        <DeleteGenerationJobModal item={deleting} onCancel={() => setDeleting(null)} onConfirm={() => void handleDelete(deleting)} />
+      ) : null}
+
+      {batchModalOpen ? (
+        <BatchDeleteGenerationJobsModal
+          count={selectedIds.length}
+          onCancel={() => setBatchModalOpen(false)}
+          onConfirm={() => void handleBatchDelete()}
+          busy={batchDeleting}
+        />
+      ) : null}
+
+      {detail ? <GenerationJobDetailModal item={detail} onClose={() => setDetail(null)} /> : null}
+
+      {toast ? (
+        <div className="toast-container">
+          <div className="toast toast-info">
+            <div className="toast-content">
+              <div className="toast-message">{toast}</div>
+            </div>
+            <button className="toast-close" onClick={() => setToast(null)} aria-label="关闭">
+              <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function userDisplay(item: AdminGenerationJob): string {
+  return item.user_name ?? item.user_email ?? item.user_id ?? item.id;
+}
+
+function statusBadgeClass(status: string): string {
+  return (
+    {
+      pending: "badge-warning",
+      running: "badge-info",
+      success: "badge-success",
+      failed: "badge-danger",
+      not_generated: "badge-muted"
+    }[status] ?? "badge-muted"
+  );
+}
+
+function GenerationJobsSkeleton() {
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      {Array.from({ length: 6 }, (_, i) => (
+        <div key={i} style={{ height: 60, borderRadius: 8, background: "var(--color-muted)", opacity: 0.5 }} />
+      ))}
+    </div>
+  );
+}
+
+function DeleteGenerationJobModal({
+  item,
+  onCancel,
+  onConfirm
+}: {
+  item: AdminGenerationJob;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">删除生成记录</div>
+          <button className="modal-close" type="button" onClick={onCancel} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="modal-body">
+          <p style={{ margin: 0 }}>
+            确认删除 {userDisplay(item)} 的这条生成记录吗？
+          </p>
+          <p className="text-muted" style={{ margin: "8px 0 0", fontSize: 13 }}>
+            注意：删除将同时级联删除该记录关联的额度流水（quota_operations），此操作不可恢复。
+          </p>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" type="button" onClick={onCancel}>
+            取消
+          </button>
+          <button className="btn btn-danger" type="button" onClick={onConfirm}>
+            确认删除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BatchDeleteGenerationJobsModal({
+  count,
+  busy,
+  onCancel,
+  onConfirm
+}: {
+  count: number;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">批量删除生成记录</div>
+          <button className="modal-close" type="button" onClick={onCancel} disabled={busy} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="modal-body">
+          <p style={{ margin: 0 }}>确认删除选中的 {count} 条生成记录吗？</p>
+          <p className="text-muted" style={{ margin: "8px 0 0", fontSize: 13 }}>
+            注意：删除将同时级联删除这些记录关联的额度流水（quota_operations），此操作不可恢复。
+          </p>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" type="button" onClick={onCancel} disabled={busy}>
+            取消
+          </button>
+          <button className="btn btn-danger" type="button" onClick={onConfirm} disabled={busy}>
+            {busy ? "删除中..." : "确认删除"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GenerationJobDetailModal({ item, onClose }: { item: AdminGenerationJob; onClose: () => void }) {
+  return (
+    <div className="modal-overlay show" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal-header">
+          <div className="modal-title">生成记录详情</div>
+          <button className="modal-close" type="button" onClick={onClose} aria-label="关闭">
+            <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="modal-body">
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">用户</label>
+              <div style={{ fontSize: 14 }}>{userDisplay(item)}</div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">团队</label>
+              <div style={{ fontSize: 14 }}>{item.team_name ?? "—"}</div>
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">厂商</label>
+              <div style={{ fontSize: 14 }}>{item.provider_name ?? item.provider_id ?? "—"}</div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">模式</label>
+              <div style={{ fontSize: 14 }}>{modeLabel(item.mode)}</div>
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">状态</label>
+              <div style={{ fontSize: 14 }}>
+                <span className={`badge ${statusBadgeClass(item.status)}`}>{statusBadge(item.status)}</span>
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">费用</label>
+              <div className="cell-mono" style={{ fontSize: 14 }}>{formatCost(item)}</div>
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label className="form-label">创建时间</label>
+              <div style={{ fontSize: 14 }}>{formatDateTime(item.created_at)}</div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">完成时间</label>
+              <div style={{ fontSize: 14 }}>{formatDateTime(item.completed_at)}</div>
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label">Trace ID</label>
+            <div style={{ fontSize: 14, wordBreak: "break-all" }}>{item.trace_id ?? "—"}</div>
+          </div>
+          <div className="form-group">
+            <label className="form-label">结果链接</label>
+            <div style={{ fontSize: 14, wordBreak: "break-all" }}>
+              {item.result_url ? (
+                <a href={item.result_url} target="_blank" rel="noopener noreferrer" style={{ color: "var(--color-primary)" }}>
+                  {item.result_url}
+                </a>
+              ) : (
+                "—"
+              )}
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label">错误信息</label>
+            <div style={{ fontSize: 14, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{item.error ?? "—"}</div>
+          </div>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">Prompt</label>
+            <div style={{ fontSize: 14, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{item.prompt ?? "—"}</div>
+          </div>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" type="button" onClick={onClose}>
+            关闭
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/sidebar.tsx
+++ b/apps/admin/src/components/sidebar.tsx
@@ -116,6 +116,18 @@ const NAV_SECTIONS: Array<{
     title: "审计",
     items: [
       {
+        href: "/generation-jobs",
+        label: "生成记录",
+        icon: (
+          <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            <rect x="8" y="2" width="8" height="4" rx="1" />
+            <path d="M9 14h6" />
+            <path d="M9 18h6" />
+          </svg>
+        )
+      },
+      {
         href: "/audit",
         label: "审计日志",
         icon: (

--- a/apps/admin/src/lib/api/generationJobs.ts
+++ b/apps/admin/src/lib/api/generationJobs.ts
@@ -1,0 +1,154 @@
+import { createAdminBrowserClient } from "@/lib/supabase/client";
+
+export type GenerationJobStatusFilter = "" | "pending" | "running" | "success" | "failed" | "not_generated";
+export type GenerationJobTimeRange = "24h" | "7d" | "30d" | "all";
+
+export interface AdminGenerationJob {
+  id: string;
+  user_id: string | null;
+  user_name: string | null;
+  user_email: string | null;
+  team_id: string | null;
+  team_name: string | null;
+  provider_id: string | null;
+  provider_name: string | null;
+  provider_logo: string | null;
+  mode: string | null;
+  prompt: string | null;
+  status: string;
+  trace_id: string | null;
+  result_url: string | null;
+  quality_score: number | null;
+  error: string | null;
+  cost_unit: string | null;
+  cost_amount: number | null;
+  equivalent_count: number | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface GenerationJobListParams {
+  providerId?: string;
+  status?: GenerationJobStatusFilter;
+  mode?: string;
+  userId?: string;
+  timeRange?: GenerationJobTimeRange;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface GenerationJobListResult {
+  total: number;
+  items: AdminGenerationJob[];
+}
+
+function timeRangeToDates(range: GenerationJobTimeRange): { from: Date | null; to: Date | null } {
+  const now = new Date();
+  switch (range) {
+    case "24h":
+      return { from: new Date(now.getTime() - 24 * 60 * 60 * 1000), to: null };
+    case "7d":
+      return { from: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), to: null };
+    case "30d":
+      return { from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000), to: null };
+    default:
+      return { from: null, to: null };
+  }
+}
+
+export async function listGenerationJobs(params: GenerationJobListParams = {}): Promise<GenerationJobListResult> {
+  const supabase = createAdminBrowserClient();
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+  const { from, to } = timeRangeToDates(params.timeRange ?? "all");
+
+  const { data, error } = await supabase.rpc("admin_list_generation_jobs", {
+    p_provider_id: params.providerId?.trim() || null,
+    p_status: params.status || null,
+    p_mode: params.mode?.trim() || null,
+    p_user_id: params.userId || null,
+    p_from: from?.toISOString() || null,
+    p_to: to?.toISOString() || null,
+    p_search: params.search?.trim() || null,
+    p_limit: pageSize,
+    p_offset: (page - 1) * pageSize
+  });
+  if (error) throw error;
+
+  const raw = (data ?? { total: 0, items: [] }) as { total: number; items: unknown[] };
+  return {
+    total: Number(raw.total ?? 0),
+    items: (raw.items ?? []).map((it) => normalizeGenerationJob(it as Record<string, unknown>))
+  };
+}
+
+export async function deleteGenerationJob(id: string): Promise<void> {
+  const supabase = createAdminBrowserClient();
+  const { error } = await supabase.from("jobs").delete().eq("id", id);
+  if (error) throw error;
+}
+
+export async function deleteGenerationJobs(ids: string[]): Promise<void> {
+  const supabase = createAdminBrowserClient();
+  const { error } = await supabase.from("jobs").delete().in("id", ids);
+  if (error) throw error;
+}
+
+/** 状态 → 中文标签 + badge 样式。值来自 jobs.status 的 CHECK 约束。 */
+export const JOB_STATUS_LABELS: Record<string, { label: string; badge: string }> = {
+  pending: { label: "排队中", badge: "badge-warning" },
+  running: { label: "生成中", badge: "badge-info" },
+  success: { label: "成功", badge: "badge-success" },
+  failed: { label: "失败", badge: "badge-danger" },
+  not_generated: { label: "无可用厂商", badge: "badge-muted" }
+};
+
+export function statusBadge(status: string): string {
+  return JOB_STATUS_LABELS[status]?.label ?? status;
+}
+
+/** 已知模式 → 中文，未知回退原文。 */
+export function modeLabel(mode: string | null): string {
+  if (!mode) return "—";
+  const map: Record<string, string> = {
+    t2v: "文生视频",
+    img: "图生视频",
+    first_last: "首尾帧",
+    multi_ref: "多参考图",
+    image: "图生视频"
+  };
+  return map[mode] ?? mode;
+}
+
+/** 费用展示：cost_amount + cost_unit，无则 "—"。 */
+export function formatCost(job: AdminGenerationJob): string {
+  if (job.cost_amount == null) return "—";
+  return `${job.cost_amount}${job.cost_unit ?? ""}`;
+}
+
+function normalizeGenerationJob(it: Record<string, unknown>): AdminGenerationJob {
+  return {
+    id: String(it.id ?? ""),
+    user_id: (it.user_id as string) ?? null,
+    user_name: (it.user_name as string) ?? null,
+    user_email: (it.user_email as string) ?? null,
+    team_id: (it.team_id as string) ?? null,
+    team_name: (it.team_name as string) ?? null,
+    provider_id: (it.provider_id as string) ?? null,
+    provider_name: (it.provider_name as string) ?? null,
+    provider_logo: (it.provider_logo as string) ?? null,
+    mode: (it.mode as string) ?? null,
+    prompt: (it.prompt as string) ?? null,
+    status: String(it.status ?? ""),
+    trace_id: (it.trace_id as string) ?? null,
+    result_url: (it.result_url as string) ?? null,
+    quality_score: it.quality_score as number | null,
+    error: (it.error as string) ?? null,
+    cost_unit: (it.cost_unit as string) ?? null,
+    cost_amount: it.cost_amount as number | null,
+    equivalent_count: it.equivalent_count as number | null,
+    created_at: String(it.created_at ?? ""),
+    completed_at: (it.completed_at as string) ?? null
+  };
+}

--- a/migrations/0038_admin_generation_jobs_rpc.sql
+++ b/migrations/0038_admin_generation_jobs_rpc.sql
@@ -1,0 +1,124 @@
+-- 0038_admin_generation_jobs_rpc.sql
+-- 后台「生成记录」列表 RPC：查看用户调用 AI 生成视频的历史（jobs 表）。
+-- 只返回安全标量字段，不下发大字段 options / attempts / cost_breakdown（AGENTS 门禁#2）。
+-- Idempotent: CREATE OR REPLACE FUNCTION；在 Supabase SQL Editor 或迁移 runner 执行。
+
+-- ============ 1. 索引优化（status 是高频筛选） ============
+CREATE INDEX IF NOT EXISTS idx_jobs_status_created
+  ON jobs (status, created_at DESC);
+
+-- ============ 2. admin_list_generation_jobs ============
+-- 返回 json { total, items }，支持厂商/状态/模式/用户/时间/搜索 + 分页。
+-- item 中 join 出 user_name / user_email / team_name / provider_name / provider_logo，前端无需二次拼装。
+CREATE OR REPLACE FUNCTION public.admin_list_generation_jobs(
+  p_provider_id TEXT DEFAULT NULL,
+  p_status TEXT DEFAULT NULL,
+  p_mode TEXT DEFAULT NULL,
+  p_user_id UUID DEFAULT NULL,
+  p_from TIMESTAMPTZ DEFAULT NULL,
+  p_to TIMESTAMPTZ DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_total BIGINT;
+  v_items JSON;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden: admin only' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM public.jobs j
+  WHERE
+    (p_provider_id IS NULL OR p_provider_id = '' OR j.provider_id = p_provider_id)
+    AND (p_status IS NULL OR p_status = '' OR j.status = p_status)
+    AND (p_mode IS NULL OR p_mode = '' OR j.mode = p_mode)
+    AND (p_user_id IS NULL OR j.user_id = p_user_id)
+    AND (p_from IS NULL OR j.created_at >= p_from)
+    AND (p_to IS NULL OR j.created_at < p_to)
+    AND (
+      p_search IS NULL OR p_search = '' OR
+      j.prompt ILIKE '%' || p_search || '%' OR
+      EXISTS (
+        SELECT 1 FROM public.profiles pu
+        WHERE pu.id = j.user_id
+          AND (pu.display_name ILIKE '%' || p_search || '%' OR pu.email ILIKE '%' || p_search || '%')
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.teams t
+        WHERE t.id = j.team_id AND t.name ILIKE '%' || p_search || '%'
+      )
+    );
+
+  SELECT COALESCE(json_agg(item), '[]'::json)
+  INTO v_items
+  FROM (
+    SELECT
+      j.id,
+      j.user_id,
+      j.team_id,
+      j.provider_id,
+      j.mode,
+      j.prompt,
+      j.status,
+      j.trace_id,
+      j.result_url,
+      j.quality_score,
+      j.error,
+      j.cost_unit,
+      j.cost_amount,
+      j.equivalent_count,
+      j.created_at,
+      j.completed_at,
+      pu.display_name AS user_name,
+      pu.email AS user_email,
+      t.name AS team_name,
+      pr.name AS provider_name,
+      pr.logo AS provider_logo
+    FROM public.jobs j
+    LEFT JOIN public.profiles pu ON pu.id = j.user_id
+    LEFT JOIN public.teams t ON t.id = j.team_id
+    LEFT JOIN public.providers pr ON pr.id = j.provider_id
+    WHERE
+      (p_provider_id IS NULL OR p_provider_id = '' OR j.provider_id = p_provider_id)
+      AND (p_status IS NULL OR p_status = '' OR j.status = p_status)
+      AND (p_mode IS NULL OR p_mode = '' OR j.mode = p_mode)
+      AND (p_user_id IS NULL OR j.user_id = p_user_id)
+      AND (p_from IS NULL OR j.created_at >= p_from)
+      AND (p_to IS NULL OR j.created_at < p_to)
+      AND (
+        p_search IS NULL OR p_search = '' OR
+        j.prompt ILIKE '%' || p_search || '%' OR
+        EXISTS (
+          SELECT 1 FROM public.profiles pu2
+          WHERE pu2.id = j.user_id
+            AND (pu2.display_name ILIKE '%' || p_search || '%' OR pu2.email ILIKE '%' || p_search || '%')
+        ) OR
+        EXISTS (
+          SELECT 1 FROM public.teams t2
+          WHERE t2.id = j.team_id AND t2.name ILIKE '%' || p_search || '%'
+        )
+      )
+    ORDER BY j.created_at DESC, j.id DESC
+    LIMIT p_limit OFFSET p_offset
+  ) item;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'items', v_items
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_list_generation_jobs(text, text, text, uuid, timestamptz, timestamptz, text, integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.admin_list_generation_jobs(text, text, text, uuid, timestamptz, timestamptz, text, integer, integer)
+  IS '后台生成记录列表：join 用户/团队/厂商信息，不下发 options/attempts/cost_breakdown 大字段，支持多维度筛选与分页（仅 admin 可调用）。';


### PR DESCRIPTION
本次新增 Admin「生成记录」模块（审计分组 /generation-jobs），复用现有 jobs 表，支持查看/筛选/搜索/分页/详情/单删/批量删除。新增 admin_list_generation_jobs RPC，仅返回安全标量字段，不下发 options/attempts/cost_breakdown 大字段。