### PR TITLE
feat(admin): 用户管理新增最近登录时间

### DIFF
--- a/apps/admin/src/components/users/user-detail-modal.tsx
+++ b/apps/admin/src/components/users/user-detail-modal.tsx
@@ -103,6 +103,11 @@ export function UserDetailModal({
             </div>
           </div>
 
+          <div className="form-group" style={{ marginBottom: 20 }}>
+            <label className="form-label">最近登录</label>
+            <div style={{ fontSize: 14 }}>{formatDateTime(user.last_login_at)}</div>
+          </div>
+
           <div className="form-row" style={{ marginBottom: 20 }}>
             <div className="form-group" style={{ marginBottom: 0 }}>
               <label className="form-label">本月消费</label>

--- a/apps/admin/src/components/users/user-table.tsx
+++ b/apps/admin/src/components/users/user-table.tsx
@@ -2,7 +2,7 @@
 
 import type { AdminUser } from "@/lib/api/users";
 import { roleLabel, statusLabel } from "@/lib/api/users";
-import { avatarColor, formatCount, formatDate, initials } from "@/lib/utils/format";
+import { avatarColor, formatCount, formatDate, formatDateTime, initials } from "@/lib/utils/format";
 
 function statusTone(status: AdminUser["status"]): "success" | "danger" | "warning" {
   if (status === "banned") return "danger";
@@ -37,6 +37,7 @@ export function UserTable({
               <th>所属团队</th>
               <th>角色</th>
               <th>注册时间</th>
+              <th>最近登录</th>
               <th>本月消费</th>
               <th>累计消费</th>
               <th>状态</th>
@@ -46,19 +47,19 @@ export function UserTable({
           <tbody>
             {loading && users.length === 0 ? (
               <tr>
-                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                <td colSpan={9} className="empty-state" style={{ textAlign: "center" }}>
                   加载中...
                 </td>
               </tr>
             ) : error ? (
               <tr>
-                <td colSpan={8} className="empty-state" style={{ textAlign: "center", color: "var(--color-destructive)" }}>
+                <td colSpan={9} className="empty-state" style={{ textAlign: "center", color: "var(--color-destructive)" }}>
                   {error}
                 </td>
               </tr>
             ) : users.length === 0 ? (
               <tr>
-                <td colSpan={8} className="empty-state" style={{ textAlign: "center" }}>
+                <td colSpan={9} className="empty-state" style={{ textAlign: "center" }}>
                   暂无匹配的用户
                 </td>
               </tr>
@@ -91,6 +92,7 @@ export function UserTable({
                     <span className={`badge badge-${roleTone(user.team_role)}`}>{roleLabel(user.team_role)}</span>
                   </td>
                   <td>{formatDate(user.created_at)}</td>
+                  <td>{formatDateTime(user.last_login_at)}</td>
                   <td className="cell-mono">{formatCount(user.month_usage)}</td>
                   <td className="cell-mono">{formatCount(user.total_usage)}</td>
                   <td>

--- a/apps/admin/src/lib/api/users.ts
+++ b/apps/admin/src/lib/api/users.ts
@@ -1,6 +1,6 @@
 import { createAdminBrowserClient } from "@/lib/supabase/client";
 import { insertAuditLog } from "@/lib/utils/audit";
-import { formatDate } from "@/lib/utils/format";
+import { formatDate, formatDateTime } from "@/lib/utils/format";
 
 export type UserStatus = "active" | "banned" | "exhausted";
 export type TeamRole = "admin" | "member";
@@ -15,6 +15,7 @@ export interface AdminUser {
   is_admin: boolean;
   status: UserStatus;
   created_at: string;
+  last_login_at: string | null;
   team_name: string | null;
   team_role: TeamRole | null;
   month_usage: number;
@@ -110,13 +111,14 @@ export function roleLabel(role: TeamRole | null): string {
 }
 
 export function toCsv(users: AdminUser[]): string {
-  const header = ["邮箱", "姓名", "所属团队", "角色", "注册时间", "本月消费", "累计消费", "状态"];
+  const header = ["邮箱", "姓名", "所属团队", "角色", "注册时间", "最近登录", "本月消费", "累计消费", "状态"];
   const rows = users.map((u) => [
     u.email ?? "",
     u.display_name ?? "",
     u.team_name ?? "个人",
     u.team_role === "admin" ? "Admin" : u.team_role === "member" ? "Member" : "—",
     formatDate(u.created_at),
+    formatDateTime(u.last_login_at),
     String(u.month_usage),
     String(u.total_usage),
     statusLabel(u.status)
@@ -146,6 +148,7 @@ function normalizeUser(it: Record<string, unknown>): AdminUser {
     is_admin: Boolean(it.is_admin),
     status: (it.status as UserStatus) ?? "active",
     created_at: String(it.created_at ?? ""),
+    last_login_at: (it.last_login_at as string) ?? null,
     team_name: (it.team_name as string) ?? null,
     team_role: (it.team_role as TeamRole) ?? null,
     month_usage: Number(it.month_usage ?? 0),

--- a/migrations/0010_admin_users_rpc.sql
+++ b/migrations/0010_admin_users_rpc.sql
@@ -51,6 +51,7 @@ BEGIN
       p.is_admin,
       p.status,
       p.created_at,
+      au.last_sign_in_at AS last_login_at,
       t.name AS team_name,
       tm.role AS team_role,
       COALESCE((
@@ -67,6 +68,7 @@ BEGIN
     FROM profiles p
     LEFT JOIN team_members tm ON tm.user_id = p.id
     LEFT JOIN teams t ON t.id = tm.team_id
+    LEFT JOIN auth.users au ON au.id = p.id
     WHERE
       (p_search IS NULL OR p_search = '' OR p.email ILIKE '%' || p_search || '%' OR p.display_name ILIKE '%' || p_search || '%')
       AND (p_status IS NULL OR p_status = '' OR p.status = p_status)
@@ -89,4 +91,4 @@ $$;
 GRANT EXECUTE ON FUNCTION public.admin_list_users(text, text, text, integer, integer) TO authenticated;
 
 COMMENT ON FUNCTION public.admin_list_users(text, text, text, integer, integer)
-  IS '后台用户管理列表：聚合 profiles/团队/消费统计，支持搜索、角色、状态过滤与分页（仅 admin 可调用）';
+  IS '后台用户管理列表：聚合 profiles/团队/消费统计，含最近登录时间（auth.users.last_sign_in_at），支持搜索、角色、状态过滤与分页（仅 admin 可调用）';


### PR DESCRIPTION
用户管理列表/详情新增「最近登录」字段，数据源为 Supabase auth.users.last_sign_in_at。\n\n- admin_list_users RPC：LEFT JOIN auth.users，select 增加 last_login_at\n- AdminUser 类型/映射：新增 last_login_at\n- 用户表：新增「最近登录」列（含 CSV 导出）\n- 用户详情弹窗：新增「最近登录」展示