### PR TITLE
feat(desktop): 历史记录详情懒加载与社区视频刷新优化

### DIFF
--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/desktop/src/renderer/src/components/History.tsx
+++ b/apps/desktop/src/renderer/src/components/History.tsx
@@ -146,7 +146,7 @@ export default function History({
   features?: Partial<DesktopFeatureFlags>
   onRegenerate?: (item: JobItem) => void
 }) {
-  const { loading, error, items, total, page, setPage, setFilters, reload, remove, removeMany } = jobs
+  const { loading, error, items, total, page, setPage, setFilters, reload, remove, removeMany, getDetail } = jobs
   const { user } = useAuth()
   const canDetail = features['history.detail'] !== false
   const canRegenerate = features['history.regenerate'] !== false && !!onRegenerate
@@ -241,6 +241,16 @@ export default function History({
     else if (p?.audio === 'off') items.push(['配音', '关闭'])
     if (p?.resolution) items.push(['分辨率', `${p.resolution}p`])
     return items
+  }
+
+  // 打开详情：列表只回 summary，点开时按 id 懒加载完整字段（model/params/images/error/audio）
+  const openDetail = async (item: JobItem): Promise<void> => {
+    try {
+      const full = await getDetail(item.id)
+      if (full) setDetail(full)
+    } catch {
+      // 详情拉取失败不阻断；保持弹窗关闭，用户可重试
+    }
   }
 
   const removeJob = async (item: JobItem): Promise<void> => {
@@ -755,7 +765,7 @@ export default function History({
                               className="action-btn"
                               title="查看详情（提示词/参数/图片）"
                               aria-label="查看详情"
-                              onClick={() => setDetail(item)}
+                              onClick={() => void openDetail(item)}
                             >
                               <IconInfo size={12} />
                             </button>

--- a/apps/desktop/src/renderer/src/hooks/useCommunityVideos.ts
+++ b/apps/desktop/src/renderer/src/hooks/useCommunityVideos.ts
@@ -109,13 +109,5 @@ export function useCommunityVideos(userId?: string): CommunityVideosResult {
     }
   }, [userId, load])
 
-  useEffect(() => {
-    const onFocus = (): void => {
-      void load()
-    }
-    window.addEventListener('focus', onFocus)
-    return () => window.removeEventListener('focus', onFocus)
-  }, [load])
-
   return { loading, error, items, reload }
 }

--- a/apps/desktop/src/renderer/src/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/src/hooks/useJobs.ts
@@ -152,6 +152,8 @@ export interface JobsResult {
   setPage: (page: number) => void
   setFilters: (filters: Partial<JobFilters>) => void
   reload: () => void
+  /** 懒加载单条任务完整详情（model/params/images/error/audio），供详情弹窗与重新生成使用 */
+  getDetail: (jobId: string) => Promise<JobItem | null>
   remove: (jobId: string) => Promise<boolean>
   removeMany: (ids: string[]) => Promise<number>
 }
@@ -176,6 +178,20 @@ export function useJobs(): JobsResult {
   const loadedRef = useRef(false)
 
   const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  const getDetail = useCallback(
+    async (jobId: string): Promise<JobItem | null> => {
+      const svc = getJobService()
+      if (!svc || !user) return null
+      try {
+        const row = await svc.getJobDetail(user.id, jobId)
+        return row ? toJobItem(row) : null
+      } catch {
+        return null
+      }
+    },
+    [user]
+  )
   const setFilters = useCallback((next: Partial<JobFilters>) => {
     setFiltersState((prev) => ({ ...prev, ...next }))
     setPage(1)
@@ -285,5 +301,5 @@ export function useJobs(): JobsResult {
     [reload, user]
   )
 
-  return { loading, error, items, total, page, hasAnySuccess, setPage, setFilters, reload, remove, removeMany }
+  return { loading, error, items, total, page, hasAnySuccess, setPage, setFilters, reload, getDetail, remove, removeMany }
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -1098,7 +1098,7 @@ export class JobService {
     const to = from + pageSize - 1
     let builder = this.client
       .from('jobs')
-      .select('id, team_id, provider_id, mode, prompt, model:options->model, accountName:options->accountName, localPath:options->localPath, cleanLocalPath:options->cleanLocalPath, watermarkStatus:options->watermarkStatus, watermarkMethod:options->watermarkMethod, watermarkError:options->watermarkError, watermarkBBox:options->watermarkBBox, watermarkBBoxes:options->watermarkBBoxes, durationSec:options->durationSec, ratio:options->ratio, audio:options->audio, resolution:options->resolution, audioLocalPath:options->audioLocalPath, audioUrl:options->audioUrl, images:options->images, videos:options->videos, status, trace_id, result_url, error, cost_unit, cost_amount, created_at', { count: 'exact' })
+      .select('id, team_id, provider_id, mode, prompt, accountName:options->accountName, localPath:options->localPath, cleanLocalPath:options->cleanLocalPath, watermarkStatus:options->watermarkStatus, watermarkMethod:options->watermarkMethod, watermarkError:options->watermarkError, watermarkBBox:options->watermarkBBox, watermarkBBoxes:options->watermarkBBoxes, status, trace_id, result_url, cost_unit, cost_amount, created_at', { count: 'estimated' })
       .eq('user_id', userId)
       .order('created_at', { ascending: false })
     const search = query.search?.trim()
@@ -1113,6 +1113,22 @@ export class JobService {
       page,
       pageSize
     }
+  }
+
+  /**
+   * 列表被裁剪为 summary 后，详情/重新生成等需要完整字段（model、params、images、error、audio）的路径
+   * 通过此方法按 task 懒加载完整数据。字段以 options-> 别名展开成与 JobListItem 相同的扁平结构，
+   * 复用渲染层的 toJobItem 映射。仅下载一次，避免列表页随整行带回大字段。
+   */
+  async getJobDetail(userId: string, jobId: string): Promise<JobListItem | null> {
+    const { data, error } = await this.client
+      .from('jobs')
+      .select('id, team_id, provider_id, mode, prompt, model:options->model, accountName:options->accountName, localPath:options->localPath, cleanLocalPath:options->cleanLocalPath, watermarkStatus:options->watermarkStatus, watermarkMethod:options->watermarkMethod, watermarkError:options->watermarkError, watermarkBBox:options->watermarkBBox, watermarkBBoxes:options->watermarkBBoxes, durationSec:options->durationSec, ratio:options->ratio, audio:options->audio, resolution:options->resolution, audioLocalPath:options->audioLocalPath, audioUrl:options->audioUrl, images:options->images, status, trace_id, result_url, error, cost_unit, cost_amount, created_at')
+      .eq('id', jobId)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    return (data ?? null) as unknown as JobListItem | null
   }
 
   /** 详情/去水印/重试等需要完整 options、attempts、cost_breakdown 的路径使用。 */


### PR DESCRIPTION
桌面端优化关联改动：\n\n- 历史详情懒加载：列表只取 summary 字段，点开详情时按 id 加载完整字段（model/params/images/error/audio）。新增 JobService.getJobDetail，useJobs 暴露 getDetail，History 详情按钮改为懒加载。\n- 社区视频：移除窗口聚焦时的重复刷新。\n- 更新 Next 自动生成的 next-env.d.ts 类型引用。