### PR TITLE
feat(desktop): 允许 Dola 文生视频生成（多参考仍需传图）

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quota-flow/desktop",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "description": "Quota-Flow 桌面端（Electron + Vite + React）",
   "author": "Quota-Flow",
   "homepage": "https://github.com/Shaun520/quota-flow",

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -2,13 +2,15 @@
 // + 豆包执行（webview-engine）+ 额度扣减（quota_ledger）+ 视频下载落盘（URL 时效）
 
 import { app, safeStorage } from 'electron'
-import { copyFileSync, createWriteStream, mkdirSync, renameSync } from 'node:fs'
+import { execFile } from 'node:child_process'
+import { copyFileSync, createWriteStream, mkdirSync, renameSync, rmSync } from 'node:fs'
 import { get as httpsGet } from 'node:https'
 import { join } from 'node:path'
 import { createSupabaseClient, JobService, ProviderService, todayKey } from '@quota-flow/db-supabase'
 import type { QuotaLedgerRow } from '@quota-flow/db-supabase'
 import { runDoubaoGeneration } from './webview-engine'
 import type { ProviderCookie, OriginStorage } from './webview-engine'
+import { resolveFfmpegPath } from './watermark-remover/engine'
 import { parseStoredCredentials as parseProviderCredentials } from './providers'
 import { clearVolcModelUnavailable, markVolcModelUnavailable } from './providers'
 import { runQwenGeneration } from './qwen-webview'
@@ -246,6 +248,75 @@ function downloadVideo(url: string, jobId: string, providerId = 'doubao', redire
     })
     out.on('error', () => finish(false, null))
   })
+}
+
+/**
+ * 判断本地视频是否为 HEVC/H.265 编码。
+ * Dola（Dreamina）导出多为 HEVC，桌面 Chromium 无 HEVC 解码器，应用内 <video> 会报“不支持的格式”。
+ */
+function isHevcVideo(ffmpeg: string, file: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const child = execFile(ffmpeg, ['-hide_banner', '-i', file], { windowsHide: true }, (_err, _stdout, stderr) => {
+        resolve(/Video:\s*(hevc|h265|hvc1|hev1)(\s|,|$)/i.test(stderr || ''))
+      })
+      child.on('error', () => resolve(true)) // 探测异常保守按 HEVC 处理（宁可转码）
+    } catch {
+      resolve(true)
+    }
+  })
+}
+
+/** 用 ffmpeg 重编码为 H.264 + AAC（yuv420p + faststart），输出写入 dest；成功返回 true。 */
+function reencodeTo264(ffmpeg: string, src: string, dest: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (ok: boolean): void => {
+      if (settled) return
+      settled = true
+      resolve(ok)
+    }
+    try {
+      const child = execFile(
+        ffmpeg,
+        [
+          '-y', '-hide_banner', '-loglevel', 'error',
+          '-i', src,
+          '-c:v', 'libx264', '-preset', 'veryfast', '-crf', '20', '-pix_fmt', 'yuv420p',
+          '-c:a', 'aac', '-b:a', '128k',
+          '-movflags', '+faststart',
+          dest
+        ],
+        { windowsHide: true },
+        (err) => finish(!err)
+      )
+      child.on('error', () => finish(false))
+    } catch {
+      finish(false)
+    }
+  })
+}
+
+/**
+ * 让本地视频可在应用内 Chromium 播放：仅对 Dola，检测到 HEVC 则转码为 H.264 并原地替换。
+ * 转码失败不阻断生成；其它厂商直接跳过。
+ */
+async function ensurePlayableVideo(providerId: string, file: string): Promise<void> {
+  if (providerId !== 'dola') return
+  const ffmpeg = resolveFfmpegPath()
+  if (!ffmpeg) return
+  try {
+    if (!(await isHevcVideo(ffmpeg, file))) return
+    const tmp = file + '.h264tmp.mp4'
+    if (await reencodeTo264(ffmpeg, file, tmp)) {
+      rmSync(file, { force: true })
+      renameSync(tmp, file)
+    } else {
+      rmSync(tmp, { force: true })
+    }
+  } catch {
+    // 转码失败不阻断，保留原始文件
+  }
 }
 
 export async function runGenerate(
@@ -491,11 +562,11 @@ export async function runGenerate(
         }
         if (result.ok && result.videoUrl) break
         lastError = result.error || '生成失败'
-        // 用户手动终止（提示词未发送）：标记为意外中断，不再换号
+        // 用户手动终止（提示词未发送）：标记为失败，不再换号
         if (result.cancelled) {
           try {
             await jobSvc.updateJob(input.userId, job.id, {
-              status: 'interrupted',
+              status: 'failed',
               error: '已手动终止生成（提示词未发送）',
               options: jobOptions,
               completedAt: new Date().toISOString()
@@ -567,6 +638,8 @@ export async function runGenerate(
     })
   }
   const resultUrl = localPath || result.videoUrl
+  // Dola（Dreamina）导出多为 HEVC，Chromium 无 HEVC 解码器 → 检测为 HEVC 时转码为 H.264，保证应用内可播
+  if (localPath) await ensurePlayableVideo(resolvedProviderId, localPath)
 
   // 先扣额度（原子 RPC），成功后再写 job success；
   // 失败则 job 标记 failed，通过 reconciliation 兜底追记
@@ -811,7 +884,7 @@ async function runApiBranch(
 
   if (runCancelState.aborted) {
     await jobSvc.updateJob(input.userId, job.id, {
-      status: 'interrupted',
+      status: 'failed',
       error: '已手动终止生成',
       options: jobOptions,
       completedAt: new Date().toISOString()

--- a/apps/desktop/src/main/dola-webview.ts
+++ b/apps/desktop/src/main/dola-webview.ts
@@ -3,9 +3,10 @@
 //       → 通过 Ctrl+V 粘贴多参考图片（最多 10 张）→ 追加 prompt → 点击生成 → 轮询页面/网络媒体地址提取 mp4 URL
 // 说明：Dola 视频生成有独立入口与参数控件，参数不拼入 prompt。
 
-import { BrowserWindow, clipboard, nativeImage, session } from 'electron'
-import { readFile } from 'node:fs/promises'
-import { basename, extname } from 'node:path'
+import { app, BrowserWindow, clipboard, session } from 'electron'
+import { existsSync, mkdirSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import type { OriginStorage, ProviderCookie } from './webview-engine'
 
 const UA =
@@ -427,33 +428,30 @@ function buildFocusInputScript(): string {
 })()`
 }
 
-interface DolaImageData {
-  name: string
-  mime: string
-  dataUrl: string
-}
-
-async function readDolaImages(images: string[]): Promise<DolaImageData[]> {
-  const out: DolaImageData[] = []
-  for (const imagePath of images) {
-    try {
-      const ext = extname(imagePath).toLowerCase()
-      const mime =
-        ext === '.png' ? 'image/png' :
-        ext === '.gif' ? 'image/gif' :
-        ext === '.webp' ? 'image/webp' :
-        'image/jpeg'
-      const data = await readFile(imagePath)
-      out.push({
-        name: basename(imagePath),
-        mime,
-        dataUrl: `data:${mime};base64,${data.toString('base64')}`
-      })
-    } catch {
-      // 单张失败不阻断，只要至少有一张可上传即可
-    }
+/**
+ * 构造 Windows CF_HDROP（DROPFILES）剪贴板数据：把多张图片的本地路径以「多文件」方式一次写入剪贴板，
+ * 这样 Dola 输入框一次 Ctrl+V 即可把多张图全部贴进来（而非逐张粘贴导致只保留一张）。
+ */
+function buildCFHDrop(paths: string[]): Buffer {
+  const enc: Buffer[] = []
+  for (const p of paths) {
+    enc.push(Buffer.from(p, 'utf16le'))
+    enc.push(Buffer.alloc(2)) // 每个路径以 NUL 结尾
   }
-  return out
+  const filesLen = enc.reduce((n, b) => n + b.length, 0)
+  const buf = Buffer.alloc(20 + filesLen + 2)
+  buf.writeUInt32LE(20, 0) // pFiles：文件列表相对头部的偏移（20 = 头部长度）
+  buf.writeUInt32LE(0, 4)  // pt.x
+  buf.writeUInt32LE(0, 8)  // pt.y
+  buf.writeUInt32LE(0, 12) // fNC
+  buf.writeUInt32LE(1, 16) // fWide：使用 UTF-16
+  let o = 20
+  for (const b of enc) {
+    b.copy(buf, o)
+    o += b.length
+  }
+  buf.writeUInt16LE(0, o) // 列表末尾补双 NUL
+  return buf
 }
 
 async function uploadDolaImages(
@@ -461,12 +459,21 @@ async function uploadDolaImages(
   images: string[],
   cancelState?: { aborted: boolean; submitted: boolean }
 ): Promise<{ ok: boolean; cancelled?: boolean; reason?: string }> {
-  const data = await readDolaImages(images)
-  if (data.length === 0) {
+  const files = (images || []).filter((p) => existsSync(p))
+  if (files.length === 0) {
     return { ok: false, reason: '读取 Dola 素材图片失败，请确认图片文件仍存在' }
   }
   const savedText = clipboard.readText()
   const savedImage = clipboard.readImage()
+  // paste() 依赖窗口可见可聚焦，隐藏窗口下 Ctrl+V 粘贴图片不生效；
+  // 上传素材阶段临时显示窗口，传完再恢复隐藏。
+  const wasVisible = win.isVisible()
+  if (!wasVisible) {
+    win.show()
+    win.center()
+  }
+  win.webContents.focus()
+  win.focus()
   const sleepOrAbort = async (ms: number): Promise<boolean> => {
     const step = 150
     const end = Date.now() + ms
@@ -477,35 +484,24 @@ async function uploadDolaImages(
     return cancelState?.aborted === true
   }
   try {
-    let pasted = 0
-    for (const item of data) {
-      if (cancelState?.aborted) {
-        return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
-      }
-      const image = nativeImage.createFromDataURL(item.dataUrl)
-      if (image.isEmpty()) {
-        return { ok: false, reason: `Dola 素材图片读取失败：${item.name}` }
-      }
-      const focus = (await win.webContents.executeJavaScript(
-        buildFocusInputScript(),
-        true
-      )) as { ok: boolean; reason?: string }
-      if (!focus.ok) {
-        return { ok: false, reason: focus.reason || '未找到 Dola 输入框，无法通过 Ctrl+V 上传素材' }
-      }
-      if (cancelState?.aborted) {
-        return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
-      }
-      win.webContents.focus()
-      clipboard.writeImage(image)
-      win.webContents.paste()
-      if (await sleepOrAbort(2200)) {
-        return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
-      }
-      pasted += 1
+    if (cancelState?.aborted) {
+      return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
     }
-
-    return { ok: true, reason: `已在 Dola 输入框通过 Ctrl+V 上传 ${pasted} 张素材图片` }
+    const focus = (await win.webContents.executeJavaScript(
+      buildFocusInputScript(),
+      true
+    )) as { ok: boolean; reason?: string }
+    if (!focus.ok) {
+      return { ok: false, reason: focus.reason || '未找到 Dola 输入框，无法通过 Ctrl+V 上传素材' }
+    }
+    win.webContents.focus()
+    // 多张图一次写入剪贴板的文件列表，再粘贴一次（Dola 支持一次粘贴多张图）
+    clipboard.writeBuffer('CF_HDROP', buildCFHDrop(files))
+    win.webContents.paste()
+    if (await sleepOrAbort(2500)) {
+      return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
+    }
+    return { ok: true, reason: `已在 Dola 输入框通过 Ctrl+V 粘贴 ${files.length} 张素材图片（多图一次粘贴）` }
   } catch (e) {
     return { ok: false, reason: scriptError('Dola 素材上传', e) }
   } finally {
@@ -516,6 +512,29 @@ async function uploadDolaImages(
         clipboard.clear()
       }
     } catch {}
+    // 上传阶段临时显示的窗口恢复隐藏（原本就隐藏才 hide）
+    if (!wasVisible) {
+      try {
+        win.hide()
+      } catch {}
+    }
+  }
+}
+
+/**
+ * 参数设置失败/进入视频界面异常时自动截屏保存到 userData/dola-debug/，便于定位页面实际状态。
+ */
+async function captureDolaDebug(win: BrowserWindow, tag: string): Promise<string | null> {
+  try {
+    const image = await win.webContents.capturePage()
+    if (image.isEmpty()) return null
+    const dir = join(app.getPath('userData'), 'dola-debug')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, `${Date.now()}-${tag}.png`)
+    await writeFile(file, image.toPNG())
+    return file
+  } catch {
+    return null
   }
 }
 
@@ -850,8 +869,9 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
     if (await waitOrAbort(1000)) return abortNow()
   }
   if (loadError || !videoEntryFound) {
+    const shot = await captureDolaDebug(win, 'entry')
     win.destroy()
-    return failWith(loadError ? `页面加载失败 (${loadError.code}: ${loadError.desc})` : 'Dola 页面未出现「视频生成」入口（可能未登录或页面结构变化）')
+    return failWith((loadError ? `页面加载失败 (${loadError.code}: ${loadError.desc})` : 'Dola 页面未出现「视频生成」入口（可能未登录或定位不到入口）') + (shot ? ` [截图:${shot}]` : ''))
   }
 
   {
@@ -870,8 +890,9 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
     prepareResult = { ok: false, reason: scriptError('Dola 参数设置', e) }
   }
   if (!prepareResult.ok) {
+    const shot = await captureDolaDebug(win, 'params')
     win.destroy()
-    return failWith(prepareResult.reason || 'Dola 页面参数设置失败')
+    return failWith((prepareResult.reason || 'Dola 页面参数设置失败') + (shot ? ` [截图:${shot}]` : ''))
   }
 
   {

--- a/apps/desktop/src/main/dola-webview.ts
+++ b/apps/desktop/src/main/dola-webview.ts
@@ -165,157 +165,124 @@ async function injectStorages(win: BrowserWindow, storages: OriginStorage[]): Pr
   }
 }
 
-function buildPrepareDolaScript(options: DolaGenerateOptions): string {
-  const targetModel = options.model || ALLOWED_MODELS[0]
-  const targetDuration = options.durationSec === 10 ? '10s' : '5s'
-  const targetRatio = options.ratio || '9:16'
-  return `(async () => {
-  try {
-  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-  const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim();
-  const targetModel = ${JSON.stringify(targetModel)};
-  const targetDuration = ${JSON.stringify(targetDuration)};
-  const targetRatio = ${JSON.stringify(targetRatio)};
-  const visible = (el) => {
-    const r = el.getBoundingClientRect();
-    const cs = getComputedStyle(el);
-    return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
-  };
+/** 参数分步脚本共用的页面内 DOM 辅助。脚本只「定位返回坐标」，真实点击由主进程 sendInputEvent 完成，
+ *  以兼容 Dola 的 Radix 受控菜单（合成事件无法展开下拉）。 */
+const DOLA_PARAM_HELPERS = `
+  const norm = (s) => (s || '').replace(/[\\s\\n\\u{3000}]/gu, ' ').trim();
+  const visible = (el) => { const r = el.getBoundingClientRect(); const cs = getComputedStyle(el); return r.width > 0 && r.height > 0 && cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0'; };
   const canClick = (el) => el.disabled !== true && el.getAttribute('aria-disabled') !== 'true';
   const labelOf = (el) => norm((el.getAttribute('aria-label') || '') + ' ' + (el.getAttribute('title') || '') + ' ' + (el.textContent || ''));
   const keyOf = (s) => (s || '').replace(/[\\s·•]/g, '').toLowerCase();
-  const clickEl = (el) => {
-    el.style.pointerEvents = 'auto';
-    el.style.zIndex = '999';
-    try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
-    const r = el.getBoundingClientRect();
-    const x = r.left + r.width / 2;
-    const y = r.top + r.height / 2;
-    const events = [];
-    if (typeof PointerEvent !== 'undefined') {
-      events.push(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
-      events.push(new PointerEvent('pointerup', { bubbles: true, cancelable: true, clientX: x, clientY: y, pointerId: 1, pointerType: 'mouse', view: window }));
-    }
-    events.push(new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
-    events.push(new MouseEvent('mouseup', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
-    events.push(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
-    for (const ev of events) el.dispatchEvent(ev);
-  };
-  const findButton = (matcher) => [...document.querySelectorAll('button, [role="button"], a, [class*="button" i], [class*="btn" i]')]
-    .filter((el) => visible(el) && canClick(el))
-    .find(matcher);
-  const findMenuItem = (matcher) => [...document.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')]
-    .filter(visible)
-    .find(matcher);
-  const findMenuItemInOpenMenu = (matcher) => {
+  const findButton = (m) => [...document.querySelectorAll('button, [role="button"], a, [class*="button" i], [class*="btn" i]')].filter((el) => visible(el) && canClick(el)).find(m);
+  const findAny = (m) => [...document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"], a, div, span')].filter(visible).find(m);
+  const findMenuItemInOpenMenu = (m) => {
     const menus = [...document.querySelectorAll('[role="menu"], [role="listbox"], [role="menubar"], [data-radix-menu-content], [data-radix-popper-content-wrapper]')].filter(visible);
-    for (const menu of menus) {
-      const hit = [...menu.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')]
-        .filter(visible)
-        .find(matcher);
-      if (hit) return hit;
-    }
-    return findMenuItem(matcher);
+    for (const menu of menus) { const hit = [...menu.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')].filter(visible).find(m); if (hit) return hit; }
+    return [...document.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')].filter(visible).find(m);
   };
-  const findAny = (matcher) => [...document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"], a, div, span')]
-    .filter(visible)
-    .find(matcher);
-  const dismissCookieBanner = async () => {
-    const el = findButton((node) => {
-      const t = labelOf(node);
-      return t === '我知道了' || t === '我知道了cookie政策' || (t.includes('我知道了') && /cookie|政策|使用/.test(t));
-    });
-    if (!el) return { ok: true, reason: '无 Cookie 提示' };
-    clickEl(el);
-    await sleep(700);
-    return { ok: true, reason: '已关闭 Cookie 提示' };
-  };
-  const clickVideoEntry = async () => {
-    const hasToolbar = [...document.querySelectorAll('button, [role="button"]')].filter(visible).some((el) => {
-      const t = labelOf(el);
-      const k = keyOf(t);
-      return (k.includes('模型') && /seedance|2\\.5|2\\.0|1\\.0/.test(k)) || /(10s|5s)/.test(k) || k.includes('比例');
-    });
-    if (hasToolbar) return { ok: true, reason: '已在视频生成界面' };
-    const entry = findButton((el) => {
-      const t = labelOf(el);
-      const cls = (typeof el.className === 'string' ? el.className : '').toLowerCase();
-      return t === '视频生成' || (cls.includes('skill-bar-button') && t.includes('视频生成') && !/额度|计算|说明|帮助|历史/.test(t));
-    });
-    if (!entry) return { ok: false, reason: '未找到「视频生成」入口' };
-    clickEl(entry);
-    await sleep(2000);
-    return { ok: true, reason: '已点击视频生成' };
-  };
-  const openMenuAndChoose = async (triggerMatcher, itemMatcher) => {
-    const trigger = findButton(triggerMatcher) || findAny(triggerMatcher);
-    if (!trigger) return { ok: false, reason: '未找到参数触发按钮' };
-    clickEl(trigger);
-    await sleep(1200);
-    const item = findMenuItemInOpenMenu(itemMatcher) || findAny(itemMatcher);
-    if (!item) {
-      try { clickEl(trigger); } catch {}
-      await sleep(500);
-      return { ok: false, reason: '下拉中未找到目标项' };
-    }
-    clickEl(item);
-    await sleep(900);
-    return { ok: true };
-  };
-  const chooseModel = async () => {
-    const targetKey = keyOf(targetModel);
-    const current = findButton((el) => {
-      const t = keyOf(labelOf(el));
-      return t.includes('模型') || t.includes('seedance');
-    });
-    if (current && keyOf(labelOf(current)).includes(targetKey)) return { ok: true, reason: '模型已为目标模型' };
-    return openMenuAndChoose(
-      (el) => keyOf(labelOf(el)).includes('seedance') || keyOf(labelOf(el)).includes('模型'),
-      (el) => {
-        const t = keyOf(labelOf(el));
-        return t.includes(targetKey) || t.includes(targetKey.replace('dreamina', '').trim());
-      }
-    );
-  };
-  const chooseDuration = async () => {
-    const current = findButton((el) => {
-      const t = keyOf(labelOf(el));
-      return /(10s|5s|10秒|5秒|时长)/.test(t);
-    });
-    if (current && keyOf(labelOf(current)).includes(targetDuration)) return { ok: true, reason: '时长已为目标时长' };
-    return openMenuAndChoose(
-      (el) => /(10s|5s|10秒|5秒|时长)/.test(keyOf(labelOf(el))),
-      (el) => keyOf(labelOf(el)).includes(targetDuration) || keyOf(labelOf(el)).includes(targetDuration.replace('s', '秒'))
-    );
-  };
-  const chooseRatio = async () => {
-    const targetKey = keyOf(targetRatio);
-    const current = findButton((el) => {
-      const t = keyOf(labelOf(el));
-      return t.includes(targetKey) || /(比例|16:9|9:16|1:1)/.test(t);
-    });
-    if (current && keyOf(labelOf(current)).includes(targetKey)) return { ok: true, reason: '比例已为目标比例' };
-    return openMenuAndChoose(
-      (el) => /(比例|16:9|9:16|1:1)/.test(keyOf(labelOf(el))),
-      (el) => keyOf(labelOf(el)).includes(targetKey)
-    );
-  };
-  const cookie = await dismissCookieBanner();
-  if (!cookie.ok) return cookie;
-  const entry = await clickVideoEntry();
-  if (!entry.ok) return entry;
-  await sleep(800);
-  const model = await chooseModel();
-  if (!model.ok) return { ok: false, reason: 'Dola 模型设置失败：' + model.reason };
-  const duration = await chooseDuration();
-  if (!duration.ok) return { ok: false, reason: 'Dola 时长设置失败：' + duration.reason };
-  const ratio = await chooseRatio();
-  if (!ratio.ok) return { ok: false, reason: 'Dola 比例设置失败：' + ratio.reason };
-  return { ok: true, reason: 'Dola 视频生成参数已设置' };
-  } catch (e) {
-    return { ok: false, reason: 'Dola 参数设置脚本异常: ' + (e && e.message ? e.message : String(e)) };
+  const pt = (el) => { const r = el.getBoundingClientRect(); return [Math.round(r.left + r.width / 2), Math.round(r.top + r.height / 2)]; };
+  const cands = () => [...document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="option"], a, div, span')].filter(visible).map((el) => labelOf(el)).filter((t) => t && /seedance|模型|2\s*\.?\s*5|1\s*\.?\s*0|fast|比例|时长/i.test(t)).slice(0, 18).join(' | ');
+`
+
+/** 参数单步脚本包装：body 返回 { ok, points:[[x,y]...], reason } */
+function paramStepScript(body: string): string {
+  return `(async () => { const run = async () => { ${DOLA_PARAM_HELPERS} ${body} }; try { return await run(); } catch (e) { return { ok: false, reason: 'step: ' + (e && e.message ? e.message : String(e)) }; } })()`
+}
+
+/** 主进程发送真实鼠标输入事件完成点击（受信事件，可展开 Dola Radix 菜单） */
+async function realClickDola(win: BrowserWindow, points: number[][]): Promise<void> {
+  for (const [x, y] of points) {
+    win.webContents.sendInputEvent({ type: 'mouseMove', x, y })
+    win.webContents.sendInputEvent({ type: 'mouseDown', x, y, button: 'left', clickCount: 1 })
+    win.webContents.sendInputEvent({ type: 'mouseUp', x, y, button: 'left', clickCount: 1 })
+    await sleep(300)
   }
-})()`
+}
+
+/**
+ * 进入 Dola 视频生成界面并设置模型/时长/比例（真实点击）。
+ * 每步：页面脚本定位元素并返回中心坐标 → 主进程 sendInputEvent 真实点击 → 等菜单展开再点目标项。
+ */
+async function setupDolaParams(
+  win: BrowserWindow,
+  opts: { model?: string; durationSec?: number; ratio?: string },
+  cancelState?: { aborted: boolean; submitted: boolean }
+): Promise<{ ok: boolean; reason?: string }> {
+  const modelName = opts.model || ALLOWED_MODELS[0]
+  const tModelKey = modelName.replace(/[\s·•]/g, '').toLowerCase()
+  const tModelKey2 = tModelKey.replace(/^dreamina/, '')
+  const tDur = opts.durationSec === 10 ? '10s' : '5s'
+  const tRatioKey = (opts.ratio || '9:16').replace(/[\s·•]/g, '').toLowerCase()
+
+  const runStep = async (body: string, waitMs: number, label: string): Promise<{ ok: boolean; cancelled?: boolean; reason?: string }> => {
+    if (cancelState?.aborted) return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
+    const r = (await win.webContents.executeJavaScript(paramStepScript(body), true)) as { ok?: boolean; reason?: string; points?: number[][] }
+    if (r?.ok === false) return { ok: false, reason: (label ? label + '：' : '') + (r.reason || '定位失败') }
+    await realClickDola(win, r?.points ?? [])
+    if (waitMs) await sleep(waitMs)
+    return { ok: true }
+  }
+
+  // 1) 关闭 Cookie 提示（有则点击）
+  const cookie = await runStep(
+    `const el = findButton((node) => { const t = labelOf(node); return t === '我知道了' || t === '我知道了cookie政策' || (t.includes('我知道了') && /cookie|政策|使用/.test(t)); }); if (!el) return { ok: true, points: [] }; return { ok: true, points: [pt(el)] };`,
+    700,
+    '关闭 Cookie 提示'
+  )
+  if (!cookie.ok) return cookie
+
+  // 2) 进入视频生成界面
+  const entry = await runStep(
+    `const hasToolbar = [...document.querySelectorAll('button,[role="button"]')].filter(visible).some((el)=>{ const t=labelOf(el); const k=keyOf(t); return (k.includes('模型') && /seedance|2\\.5|2\\.0|1\\.0/.test(k)) || /(10s|5s)/.test(k) || k.includes('比例'); }); if (hasToolbar) return { ok: true, points: [] }; const en=findButton((el)=>{ const t=labelOf(el); const cls=(typeof el.className==='string'?el.className:'').toLowerCase(); return t==='视频生成'||(cls.includes('skill-bar-button')&&t.includes('视频生成')&&!/额度|计算|说明|帮助|历史/.test(t)); }); if(!en) return { ok:false, points:[], reason:'未找到「视频生成」入口；候选:'+cands() }; return { ok:true, points:[pt(en)] };`,
+    2000,
+    '进入视频生成'
+  )
+  if (!entry.ok) return entry
+  await sleep(500)
+
+  // 3) 模型：触发按钮 → 展开 → 目标项
+  const model = await runStep(
+    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型')||t.includes('seedance'); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tModelKey)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('seedance')||t.includes('模型'); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return t.includes('seedance')||t.includes('模型'); }); if(!tr) return { ok:false, points:[], reason:'未找到模型触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    1200,
+    'Dola 模型设置失败'
+  )
+  if (!model.ok) return model
+  const modelItem = await runStep(
+    `const it=findMenuItemInOpenMenu((el)=>{ const t=keyOf(labelOf(el)); return t.includes(${JSON.stringify(tModelKey)}) || t.includes(${JSON.stringify(tModelKey2)}); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return t.includes(${JSON.stringify(tModelKey)}) || t.includes(${JSON.stringify(tModelKey2)}); }); if(!it) return { ok:false, points:[], reason:'下拉中未找到目标项；候选:'+cands() }; return { ok:true, points:[pt(it)] };`,
+    900,
+    'Dola 模型设置失败'
+  )
+  if (!modelItem.ok) return modelItem
+
+  // 4) 时长
+  const dur = await runStep(
+    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tDur)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到时长触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    1200,
+    'Dola 时长设置失败'
+  )
+  if (!dur.ok) return dur
+  const durItem = await runStep(
+    `const it=findMenuItemInOpenMenu((el)=>keyOf(labelOf(el)).includes(${JSON.stringify(tDur)})) || findAny((el)=>keyOf(labelOf(el)).includes(${JSON.stringify(tDur)})); if(!it) return { ok:false, points:[], reason:'下拉中未找到目标项；候选:'+cands() }; return { ok:true, points:[pt(it)] };`,
+    900,
+    'Dola 时长设置失败'
+  )
+  if (!durItem.ok) return durItem
+
+  // 5) 比例
+  const ratioStep = await runStep(
+    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes(${JSON.stringify(tRatioKey)}) || /(比例|16:9|9:16|1:1)/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tRatioKey)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到比例触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    1200,
+    'Dola 比例设置失败'
+  )
+  if (!ratioStep.ok) return ratioStep
+  const ratioItem = await runStep(
+    `const it=findMenuItemInOpenMenu((el)=>keyOf(labelOf(el)).includes(${JSON.stringify(tRatioKey)})) || findAny((el)=>keyOf(labelOf(el)).includes(${JSON.stringify(tRatioKey)})); if(!it) return { ok:false, points:[], reason:'下拉中未找到目标项；候选:'+cands() }; return { ok:true, points:[pt(it)] };`,
+    900,
+    'Dola 比例设置失败'
+  )
+  if (!ratioItem.ok) return ratioItem
+
+  return { ok: true, reason: 'Dola 视频生成参数已设置' }
 }
 
 function buildFillPromptScript(prompt: string): string {
@@ -882,14 +849,15 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
   options.onProgress?.('apply-params', { prompt: options.prompt, model, durationSec, ratio: options.ratio })
   let prepareResult: { ok?: boolean; reason?: string } = {}
   try {
-    prepareResult = (await win.webContents.executeJavaScript(
-      buildPrepareDolaScript({ ...options, model, durationSec }),
-      true
-    )) as typeof prepareResult
+    prepareResult = await setupDolaParams(win, { model, durationSec, ratio: options.ratio }, cancelState)
   } catch (e) {
     prepareResult = { ok: false, reason: scriptError('Dola 参数设置', e) }
   }
   if (!prepareResult.ok) {
+    if (prepareResult.reason === '已手动终止生成（提示词未发送）') {
+      win.destroy()
+      return failCancelled(attempts)
+    }
     const shot = await captureDolaDebug(win, 'params')
     win.destroy()
     return failWith((prepareResult.reason || 'Dola 页面参数设置失败') + (shot ? ` [截图:${shot}]` : ''))

--- a/apps/desktop/src/main/dola-webview.ts
+++ b/apps/desktop/src/main/dola-webview.ts
@@ -5,7 +5,7 @@
 
 import { app, BrowserWindow, clipboard, session } from 'electron'
 import { existsSync, mkdirSync } from 'node:fs'
-import { writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { OriginStorage, ProviderCookie } from './webview-engine'
 
@@ -175,13 +175,16 @@ const DOLA_PARAM_HELPERS = `
   const keyOf = (s) => (s || '').replace(/[\\s·•]/g, '').toLowerCase();
   const findButton = (m) => [...document.querySelectorAll('button, [role="button"], a, [class*="button" i], [class*="btn" i]')].filter((el) => visible(el) && canClick(el)).find(m);
   const findAny = (m) => [...document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"], a, div, span')].filter(visible).find(m);
+  // Radix 下拉触发器都带 [aria-haspopup="menu"]，用它精确定位模型/时长/比例，避免误点「Seedance 视频生成」这类入口
+  const findTrigger = (m) => [...document.querySelectorAll('[aria-haspopup="menu"]')].filter((el) => visible(el) && canClick(el)).find(m);
   const findMenuItemInOpenMenu = (m) => {
     const menus = [...document.querySelectorAll('[role="menu"], [role="listbox"], [role="menubar"], [data-radix-menu-content], [data-radix-popper-content-wrapper]')].filter(visible);
     for (const menu of menus) { const hit = [...menu.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')].filter(visible).find(m); if (hit) return hit; }
     return [...document.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="option"]')].filter(visible).find(m);
   };
   const pt = (el) => { const r = el.getBoundingClientRect(); return [Math.round(r.left + r.width / 2), Math.round(r.top + r.height / 2)]; };
-  const cands = () => [...document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="option"], a, div, span')].filter(visible).map((el) => labelOf(el)).filter((t) => t && /seedance|模型|2\s*\.?\s*5|1\s*\.?\s*0|fast|比例|时长/i.test(t)).slice(0, 18).join(' | ');
+  // 简洁候选：只取下拉触发器与当前菜单项文本，去重、限长，避免报错刷屏
+  const cands = () => { const out=[]; const seen=new Set(); const push=(el)=>{ const t=norm(labelOf(el)); if(!t||seen.has(t))return; seen.add(t); if(t.length<=40) out.push(t); }; document.querySelectorAll('[aria-haspopup="menu"]').forEach((el)=>{ if(visible(el))push(el); }); [...document.querySelectorAll('[role="menu"]')].filter(visible).forEach((m)=>{ m.querySelectorAll('[role="menuitem"],[role="option"]').forEach(push); }); document.querySelectorAll('button,[role="button"]').forEach((el)=>{ if(visible(el)&&/模型|时长|比例|seedance|dreamina/i.test(labelOf(el)))push(el); }); return (out.length?out:['无']).slice(0,8).join(' | '); };
 `
 
 /** 参数单步脚本包装：body 返回 { ok, points:[[x,y]...], reason } */
@@ -240,9 +243,9 @@ async function setupDolaParams(
   if (!entry.ok) return entry
   await sleep(500)
 
-  // 3) 模型：触发按钮 → 展开 → 目标项
+  // 3) 模型：触发按钮 → 展开 → 目标项（优先 Radix 触发器，避免误点「Seedance 视频生成」入口）
   const model = await runStep(
-    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型')||t.includes('seedance'); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tModelKey)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('seedance')||t.includes('模型'); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return t.includes('seedance')||t.includes('模型'); }); if(!tr) return { ok:false, points:[], reason:'未找到模型触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    `const cur=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型'); }) || findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型')&&!t.includes('视频'); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tModelKey)})) return { ok:true, points:[] }; const tr=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型'); }) || findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型')&&!/视频|生成/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return t.includes('模型')&&!/视频|生成|seedance/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到模型触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
     1200,
     'Dola 模型设置失败'
   )
@@ -254,9 +257,9 @@ async function setupDolaParams(
   )
   if (!modelItem.ok) return modelItem
 
-  // 4) 时长
+  // 4) 时长（优先 Radix 触发器）
   const dur = await runStep(
-    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tDur)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到时长触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    `const cur=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }) || findButton((el)=>{ const t=keyOf(labelOf(el)); return /^(10s|5s|10秒|5秒)$/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tDur)})) return { ok:true, points:[] }; const tr=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }) || findButton((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(10s|5s|10秒|5秒|时长)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到时长触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
     1200,
     'Dola 时长设置失败'
   )
@@ -268,9 +271,9 @@ async function setupDolaParams(
   )
   if (!durItem.ok) return durItem
 
-  // 5) 比例
+  // 5) 比例（优先 Radix 触发器）
   const ratioStep = await runStep(
-    `const cur=findButton((el)=>{ const t=keyOf(labelOf(el)); return t.includes(${JSON.stringify(tRatioKey)}) || /(比例|16:9|9:16|1:1)/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tRatioKey)})) return { ok:true, points:[] }; const tr=findButton((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到比例触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
+    `const cur=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return t.includes('比例')||/(16:9|9:16|1:1|21:9|3:4|4:3)/.test(t); }); if(cur && keyOf(labelOf(cur)).includes(${JSON.stringify(tRatioKey)})) return { ok:true, points:[] }; const tr=findTrigger((el)=>{ const t=keyOf(labelOf(el)); return t.includes('比例'); }) || findButton((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }) || findAny((el)=>{ const t=keyOf(labelOf(el)); return /(比例|16:9|9:16|1:1)/.test(t); }); if(!tr) return { ok:false, points:[], reason:'未找到比例触发按钮；候选:'+cands() }; return { ok:true, points:[pt(tr)] };`,
     1200,
     'Dola 比例设置失败'
   )
@@ -375,6 +378,9 @@ function buildFocusInputScript(): string {
   };
   const input = findInput();
   if (!input) return { ok: false, reason: '未找到 Dola 输入框，无法通过 Ctrl+V 上传素材，请开启显示窗口确认页面正常' };
+  const r = input.getBoundingClientRect();
+  const cx = Math.round(r.left + r.width / 2);
+  const cy = Math.round(Math.min(r.top + r.height / 2, r.top + 40));
   input.focus();
   if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
     const len = (input.value || '').length;
@@ -387,8 +393,8 @@ function buildFocusInputScript(): string {
     }
   }
   try { input.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
-  await sleep(300);
-  return { ok: true, reason: 'Dola 输入框已聚焦，准备通过 Ctrl+V 上传素材' };
+  await sleep(200);
+  return { ok: true, x: cx, y: cy, reason: 'Dola 输入框已定位，准备通过 Ctrl+V 上传素材' };
   } catch (e) {
     return { ok: false, reason: 'Dola 素材上传脚本异常: ' + (e && e.message ? e.message : String(e)) };
   }
@@ -421,6 +427,37 @@ function buildCFHDrop(paths: string[]): Buffer {
   return buf
 }
 
+/**
+ * 把本地图片字节构造为真实 File 对象，写入 Dola 隐藏的 <input type="file" multiple> 并触发 change，
+ * 从而走 Dola 官方上传逻辑（比注入剪贴板粘贴更可靠）。
+ */
+function buildUploadVideoInputScript(
+  items: Array<{ name: string; type: string; base64: string }>
+): string {
+  const arrJson = JSON.stringify(
+    items.map((it) => ({ name: it.name, type: it.type, base64: it.base64 }))
+  )
+  return `(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const items = ${arrJson};
+  const inp = document.querySelector('input[type="file"]') || document.querySelector('input[accept*="image"], input[accept*="jpg"], input[accept*="png"], input[accept*="jpeg"], input[accept*="webp"]');
+  if (!inp) return { ok: false, reason: '未找到 Dola 图片上传 input' };
+  const dt = new DataTransfer();
+  for (const it of items) {
+    const bin = atob(it.base64);
+    const u8 = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+    const f = new File([u8], it.name, { type: it.type });
+    dt.items.add(f);
+  }
+  // 覆盖 files 并派发 change，触发 React 的 onChange 上传处理
+  Object.defineProperty(inp, 'files', { value: dt.files, configurable: true });
+  inp.dispatchEvent(new Event('change', { bubbles: true }));
+  await sleep(500);
+  return { ok: true, reason: '已向 Dola 文件上传框写入 ' + dt.files.length + ' 个文件' };
+})()`
+}
+
 async function uploadDolaImages(
   win: BrowserWindow,
   images: string[],
@@ -430,17 +467,6 @@ async function uploadDolaImages(
   if (files.length === 0) {
     return { ok: false, reason: '读取 Dola 素材图片失败，请确认图片文件仍存在' }
   }
-  const savedText = clipboard.readText()
-  const savedImage = clipboard.readImage()
-  // paste() 依赖窗口可见可聚焦，隐藏窗口下 Ctrl+V 粘贴图片不生效；
-  // 上传素材阶段临时显示窗口，传完再恢复隐藏。
-  const wasVisible = win.isVisible()
-  if (!wasVisible) {
-    win.show()
-    win.center()
-  }
-  win.webContents.focus()
-  win.focus()
   const sleepOrAbort = async (ms: number): Promise<boolean> => {
     const step = 150
     const end = Date.now() + ms
@@ -454,37 +480,29 @@ async function uploadDolaImages(
     if (cancelState?.aborted) {
       return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
     }
-    const focus = (await win.webContents.executeJavaScript(
-      buildFocusInputScript(),
-      true
-    )) as { ok: boolean; reason?: string }
-    if (!focus.ok) {
-      return { ok: false, reason: focus.reason || '未找到 Dola 输入框，无法通过 Ctrl+V 上传素材' }
+    // 读取每张图片的原始字节，注入页面构造成真实 File 对象。
+    // 直接喂给 Dola 隐藏的 <input type="file" multiple> 并触发 change，绕开剪贴板/粘贴的不确定性。
+    const items: Array<{ name: string; type: string; base64: string }> = []
+    for (const p of files) {
+      const name = p.split(/[\\/]/).pop() || 'image'
+      const type = /\.png$/i.test(p) ? 'image/png' : /\.gif$/i.test(p) ? 'image/gif' : /\.webp$/i.test(p) ? 'image/webp' : /\.jpe?g$/i.test(p) ? 'image/jpeg' : 'application/octet-stream'
+      const base64 = (await readFile(p)).toString('base64')
+      items.push({ name, type, base64 })
     }
-    win.webContents.focus()
-    // 多张图一次写入剪贴板的文件列表，再粘贴一次（Dola 支持一次粘贴多张图）
-    clipboard.writeBuffer('CF_HDROP', buildCFHDrop(files))
-    win.webContents.paste()
-    if (await sleepOrAbort(2500)) {
+    const upload = (await win.webContents.executeJavaScript(
+      buildUploadVideoInputScript(items),
+      true
+    )) as { ok: boolean; reason?: string; inputCls?: string; files?: number }
+    if (!upload.ok) {
+      return { ok: false, reason: upload.reason || '未找到 Dola 图片上传入口' }
+    }
+    if (await sleepOrAbort(3000)) {
       return { ok: false, cancelled: true, reason: '已手动终止生成（提示词未发送）' }
     }
-    return { ok: true, reason: `已在 Dola 输入框通过 Ctrl+V 粘贴 ${files.length} 张素材图片（多图一次粘贴）` }
+    const shot = await captureDolaDebug(win, 'uploaded')
+    return { ok: true, reason: `已向 Dola 上传 ${items.length} 张素材图片` + (shot ? `[截图:${shot}]` : '') }
   } catch (e) {
     return { ok: false, reason: scriptError('Dola 素材上传', e) }
-  } finally {
-    try {
-      if (!savedImage.isEmpty() || savedText) {
-        clipboard.write({ text: savedText, image: savedImage })
-      } else {
-        clipboard.clear()
-      }
-    } catch {}
-    // 上传阶段临时显示的窗口恢复隐藏（原本就隐藏才 hide）
-    if (!wasVisible) {
-      try {
-        win.hide()
-      } catch {}
-    }
   }
 }
 

--- a/apps/desktop/src/main/dola-webview.ts
+++ b/apps/desktop/src/main/dola-webview.ts
@@ -739,11 +739,13 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
   const abortNow = (): DolaGenerateResult => abortIfCancelled() ?? failCancelled(attempts)
 
   const mode = options.mode ?? 'multi_ref'
-  if (mode !== 'multi_ref') {
-    return failWith('Dola 当前仅支持多参考生成，请选择多参考生成并上传素材图片')
+  // Dola 支持文生视频 + 多参考生成；多参考必须传图，文生视频不要求素材
+  if (mode !== 'multi_ref' && mode !== 'text2video' && mode !== 't2v') {
+    return failWith('Dola 不支持该生成模式，请选择「文生视频」或「多参考生成」')
   }
+  const isMultiRef = mode === 'multi_ref'
   const images = (options.images ?? []).slice(0, MAX_DOLA_IMAGES)
-  if (mode === 'multi_ref' && images.length === 0) {
+  if (isMultiRef && images.length === 0) {
     return failWith('Dola 多参考生成需要至少上传一张素材图片')
   }
   const durationSec = options.durationSec === 10 ? 10 : 5

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,11 +39,6 @@ let pendingCancel = false
 let lastDispatchCtx: { supabaseUrl: string; supabaseAnonKey: string; userId: string } | null = null
 import { createSupabaseClient, JobService, ProviderService, todayKey } from '@quota-flow/db-supabase'
 
-// 禁用 GPU 硬件加速：Windows 上 Chromium 合成器在频繁重绘（如快速点击 tab 切换页面）时
-// 偶发丢帧/显示旧缓冲，导致整窗"时不时闪一下"。切到软件合成可根治。
-// 必须在 app ready 之前调用。
-app.disableHardwareAcceleration()
-
 // 本地媒体预览服务：127.0.0.1 随机端口
 //  - 根路径：userData/videos 下 <uuid>.mp4（视频，支持 Range）
 //  - /images/：userData/images 下 <jobId>-<n>.<ext>（图生视频上传的图片副本）

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,8 @@ let allowClose = false
 let isGenerating = false
 /** 任务注册前用户已点停止 → 注册后立即置 aborted */
 let pendingCancel = false
+/** 最近一次生成的 Supabase 上下文：优雅关闭时把运行中任务改写为 failed（等下次启动 reconcile 兜底） */
+let lastDispatchCtx: { supabaseUrl: string; supabaseAnonKey: string; userId: string } | null = null
 import { createSupabaseClient, JobService, ProviderService, todayKey } from '@quota-flow/db-supabase'
 
 // 禁用 GPU 硬件加速：Windows 上 Chromium 合成器在频繁重绘（如快速点击 tab 切换页面）时
@@ -247,6 +249,42 @@ function clearStoredSession(): void {
   }
 }
 
+/**
+ * 优雅关闭时把仍在运行的生成任务 best-effort 改写为 failed，
+ * 这样无需等下次启动 reconcile，admin 端/下次查看即可看到「失败」而非「排队/生成中」。
+ * 写失败不阻断退出（服务端已接单的任务仍由下次启动 reconcile 兜底清扫）。
+ */
+async function markActiveRunsFailed(): Promise<void> {
+  const ctx = lastDispatchCtx
+  const jobs = [...activeRuns.keys()]
+  if (!ctx || jobs.length === 0) return
+  try {
+    const session = readStoredSession()
+    if (!session) return
+    const client = createSupabaseClient({
+      supabaseUrl: ctx.supabaseUrl,
+      supabaseAnonKey: ctx.supabaseAnonKey
+    })
+    await client.auth.setSession({ access_token: session.accessToken, refresh_token: session.refreshToken })
+    const jobSvc = new JobService(client)
+    await Promise.all(
+      jobs.map(async (jobId) => {
+        try {
+          await jobSvc.updateJob(ctx.userId, jobId, {
+            status: 'failed',
+            error: '应用已关闭，生成中断',
+            completedAt: new Date().toISOString()
+          })
+        } catch {
+          // 单条写失败不阻断，reconcile 下次启动兜底
+        }
+      })
+    )
+  } catch {
+    // 会话/网络异常不阻断退出
+  }
+}
+
 function createWindow(): void {
   const win = new BrowserWindow({
     width: 1200,
@@ -285,8 +323,9 @@ function createWindow(): void {
         cancelId: 0,
         noLink: true
       })
-      .then(({ response }) => {
+      .then(async ({ response }) => {
         if (response === 1) {
+          await markActiveRunsFailed()
           allowClose = true
           win.close()
         }
@@ -451,6 +490,7 @@ app.whenReady().then(() => {
     let registeredJobId: string | null = null
     isGenerating = true
     pendingCancel = false
+    lastDispatchCtx = { supabaseUrl: input.supabaseUrl, supabaseAnonKey: input.supabaseAnonKey, userId: input.userId }
     try {
       return await runGenerate(input, emit, (jobId, state) => {
         registeredJobId = jobId
@@ -577,7 +617,8 @@ app.whenReady().then(() => {
       const providerSvc = new ProviderService(client)
       let recovered = false
 
-      // 1. 恢复崩溃残留：上次会话遗留的 pending/running → 标记「意外中断」（不做自动恢复）
+      // 1. 恢复崩溃残留：上次会话遗留的 pending/running → 标记为失败（不做自动恢复）。
+      //    注意 jobs.status 的 DB CHECK 约束不含 'interrupted'，写失败(含约束)不报错。
       const { data: stuckJobs } = await client
         .from('jobs')
         .select('id, created_at')
@@ -587,7 +628,7 @@ app.whenReady().then(() => {
         .limit(20)
       for (const j of (stuckJobs ?? [])) {
         await jobSvc.updateJob(params.userId, j.id, {
-          status: 'interrupted',
+          status: 'failed',
           error: '应用意外退出，生成中断',
           completedAt: new Date().toISOString()
         })

--- a/apps/desktop/src/main/system-browser-login.ts
+++ b/apps/desktop/src/main/system-browser-login.ts
@@ -422,7 +422,7 @@ export async function collectDolaSystemBrowserLogin(
     const authState = await readDolaAuthState(client, sessionId)
     if (!isSessionReady(cookies, authState)) {
       throw new Error(
-        '未检测到已登录的 dola 会话。请先在浏览器中完成 dola 登录（需在未附加调试的浏览器里登录，否则会被 Google 拦截），然后重新点击「抓取浏览器登录态」'
+        '未检测到已登录的 dola 会话。请先在浏览器中完成 dola 登录（谷歌账号需在未附加调试的浏览器里登录，否则会被 Google 拦截），然后重新点击「系统浏览器登录」'
       )
     }
     const storages = await collectDolaStorage(client, sessionId)

--- a/apps/desktop/src/main/webview-engine.ts
+++ b/apps/desktop/src/main/webview-engine.ts
@@ -1502,7 +1502,6 @@ export async function runDoubaoGeneration(options: DoubaoGenerateOptions): Promi
   // 比例：真实 UI 网格点击；失败时回退文本拼接（页面结构变化时不阻断任务）
   let ratioViaDom = false
   if (options.ratio) {
-    progress(options, 'apply-ratio', { ratio: options.ratio })
     const ratioApply = await applyDoubaoRatio(win, options.ratio)
     if (ratioApply.ok) ratioViaDom = true
   }

--- a/apps/desktop/src/main/webview-engine.ts
+++ b/apps/desktop/src/main/webview-engine.ts
@@ -409,17 +409,22 @@ const extractResultScript = (): unknown => {
     }
   } catch {}
   const text = document.body ? document.body.innerText : ''
+  // 内容政策拒绝，但其并非"免责声明/承诺"弹窗文案：
+  // 免责声明（"均已获充分授权…相关责任需由你自行承担"）只是用户确认弹窗，不应判失败。
+  const isDisclaimer = /均已获充分授权|无侵权违法风险|责任需由你自行承担|自行承担|免责声明/.test(text)
   // 豆包内容政策拒绝：侵权/肖像/版权等拒绝文案（非视频结果）→ 直接判失败
-  const blockedMatch = text.match(
-    /生成内容中疑似包含侵权[^，。\n]{0,80}|出于肖像保护考虑[^，。\n]{0,80}|由于版权相关限制[^，。\n]{0,80}|无法返回该内容|换个主题|分身认证|侵权|违规|肖像保护|版权相关限制/
-  )
   let blockedText: string | null = null
-  if (blockedMatch) {
-    const idx = blockedMatch.index ?? 0
-    const lineStart = text.lastIndexOf('\n', idx) + 1
-    let lineEnd = text.indexOf('\n', idx)
-    if (lineEnd === -1) lineEnd = text.length
-    blockedText = text.slice(lineStart, lineEnd).trim().slice(0, 120) || blockedMatch[0].slice(0, 80)
+  if (!isDisclaimer) {
+    const blockedMatch = text.match(
+      /生成内容中疑似包含侵权[^，。\n]{0,80}|出于肖像保护考虑[^，。\n]{0,80}|由于版权相关限制[^，。\n]{0,80}|无法返回该内容|换个主题|分身认证|侵权|违规|肖像保护|版权相关限制/
+    )
+    if (blockedMatch) {
+      const idx = blockedMatch.index ?? 0
+      const lineStart = text.lastIndexOf('\n', idx) + 1
+      let lineEnd = text.indexOf('\n', idx)
+      if (lineEnd === -1) lineEnd = text.length
+      blockedText = text.slice(lineStart, lineEnd).trim().slice(0, 120) || blockedMatch[0].slice(0, 80)
+    }
   }
   return {
     vids,
@@ -1165,10 +1170,15 @@ const riskProbeScript = (): unknown => {
     const mo = new MutationObserver(() => {
       try {
         const t = document.body ? document.body.innerText : ''
-        if (
-          /安全验证|滑块验证|请完成验证|拖动滑块|人机验证|完成验证|验证码/.test(t) ||
+        const riskShown = /安全验证|滑块验证|请完成验证|拖动滑块|人机验证|完成验证|验证码/.test(t) ||
           document.querySelector('[class*="captcha" i], [class*="verify" i], iframe[src*="captcha" i]')
-        ) {
+        // 免责/安全确认弹窗：只标记为 disclaimer（实时），不进持久 verify，避免窗口点完不恢复
+        const disclaimerShown = /免责声明|安全确认|充分授权|素材授权|内容授权/.test(t)
+        if (disclaimerShown) {
+          if ((window.__qfRisk as { type?: string }).type !== 'limit') {
+            window.__qfRisk = { type: 'disclaimer', at: Date.now() }
+          }
+        } else if (riskShown) {
           if ((window.__qfRisk as { type?: string }).type !== 'ok') {
             window.__qfRisk = { type: 'verify', detail: 'dom-verify', at: Date.now() }
           }
@@ -1183,13 +1193,20 @@ const riskProbeScript = (): unknown => {
 const readRiskScript = (): unknown => {
   const w = (window.__qfRisk || { type: 'none' }) as { type?: string; detail?: string | null }
   let domVerify = false
+  let disclaimer = false
   try {
     const t = document.body ? document.body.innerText : ''
     if (/安全验证|滑块验证|请完成验证|拖动滑块|人机验证|完成验证/.test(t)) domVerify = true
+    // 免责/安全确认弹窗：完全由实时 DOM 判断（弹窗消失即不再命中），避免类型残留导致窗口不恢复
+    if (/免责声明|安全确认|充分授权|素材授权|内容授权/.test(t)) disclaimer = true
     if (document.querySelector('[class*="captcha" i], iframe[src*="captcha" i]')) domVerify = true
   } catch {}
-  const type = w.type === 'verify' || w.type === 'limit' ? w.type : domVerify ? 'verify' : 'none'
-  return { type, detail: w.detail || null, domVerify }
+  let type: 'verify' | 'limit' | 'disclaimer' | 'none' = 'none'
+  if (w.type === 'limit') type = 'limit'
+  else if (domVerify) type = 'verify'
+  else if (disclaimer) type = 'disclaimer'
+  else if (w.type === 'verify') type = 'verify'
+  return { type, detail: w.detail || null, domVerify, disclaimer }
 }
 
 /** 读取风控状态（主进程） */
@@ -1667,18 +1684,18 @@ export async function runDoubaoGeneration(options: DoubaoGenerateOptions): Promi
     try {
       riskTick = await readDoubaoRisk(win)
     } catch {}
-    if (riskTick.type === 'verify' && !riskMode) {
+    if ((riskTick.type === 'verify' || riskTick.type === 'disclaimer') && !riskMode) {
       riskMode = true
       riskSince = Date.now()
       showRiskWindow(win)
-      progress(options, 'risk-verify', { message: '豆包要求验证，请在弹出的豆包窗口中完成验证' })
+      progress(options, 'risk-verify', { message: riskTick.type === 'disclaimer' ? '豆包弹出安全确认，请在弹出的豆包窗口点确认' : '豆包要求验证，请在弹出的豆包窗口中完成验证' })
     }
     if (riskTick.type === 'limit') {
       win.destroy()
       return fail('豆包风控/限流：' + (riskTick.detail || '请稍后再试'))
     }
     if (riskMode) {
-      if (riskTick.type !== 'verify') {
+      if (riskTick.type !== 'verify' && riskTick.type !== 'disclaimer') {
         riskMode = false
         if (options.showWebview !== true) {
           try {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -339,6 +339,27 @@ function MainApp({
     }
   }, [resolvedTab, tab])
 
+  // GPU 合成下快速切 tab 偶发「显示旧缓冲」闪屏：切完后强制一次重绘，
+  // 促使合成器立即输出新帧（styles.css 已用 translateZ(0) 让各 pane 独立合成层）。
+  useEffect(() => {
+    if (!resolvedTab) return
+    let cancelled = false
+    requestAnimationFrame(() => {
+      if (cancelled) return
+      const el = document.querySelector<HTMLElement>('.content-inner')
+      if (!el) return
+      // 读取布局强制一次 reflow；短暂提升 will-change 促使该层立即重合成
+      void el.offsetHeight
+      el.style.willChange = 'transform'
+      requestAnimationFrame(() => {
+        if (!cancelled) el.style.willChange = ''
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [resolvedTab])
+
   return (
     <div className="app-shell">
       <TitleBar />

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -204,8 +204,8 @@ function MainApp({
     location.hash = 'tab=dispatch'
   }, [])
 
-  const handleUseMaterial = useCallback((path: string, url: string): void => {
-    setMaterialImages([{ path, url }])
+  const handleUseMaterial = useCallback((materials: Array<{ path: string; url: string }>): void => {
+    setMaterialImages(materials)
     setTab('dispatch')
     location.hash = 'tab=dispatch'
   }, [])

--- a/apps/desktop/src/renderer/src/components/CreationCenter.tsx
+++ b/apps/desktop/src/renderer/src/components/CreationCenter.tsx
@@ -67,7 +67,7 @@ interface CreationCenterProps {
   features: DesktopFeatureFlags
   userId?: string
   onReferenceGenerate?: (draft: RegenerateDraft) => void
-  onUseMaterial?: (path: string, url: string) => void
+  onUseMaterial?: (materials: Array<{ path: string; url: string }>) => void
   onNotify?: (message: string) => void
 }
 

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -196,7 +196,7 @@ function normalizeRegenerateMode(providerId: string, rawMode?: string): string {
   if (rawMode === 'text2video' || rawMode === 't2v') return 't2v'
   if (rawMode === 'img2video' || rawMode === 'img') return 'img'
   if (rawMode === 'multi_ref' || rawMode === 'first_last' || rawMode === 'first_frame') return rawMode
-  if (providerId === 'dola' || providerId === 'qwenwan') return 'multi_ref'
+  if (providerId === 'qwenwan') return 'multi_ref'
   return 't2v'
 }
 
@@ -949,7 +949,7 @@ export default function Dashboard({
   }, [preview, imagePreview, promptPreview, refVideoPreviewing])
 
   const handleGenerate = useCallback(async (): Promise<void> => {
-    const currentMode = provider === 'dola' ? 'multi_ref' : mode
+    const currentMode = mode
     if (generating) return
     // 开放平台 API 型厂商（智谱/火山）：图生/多参考/首尾帧需公网 https 图片，上传未完成时禁用，避免提交空图报错
     if ((provider === 'zhipu' || provider === 'volcengine') && uploadingCount > 0) {

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -1216,35 +1216,42 @@ export default function Dashboard({
     [savedImagePaths]
   )
 
-  const onFilesSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? [])
-    const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
-    const picked = files.slice(0, remaining)
+  // 图片上传的共享入口：过滤图片类型 + 数量限制，API 型厂商走公网 URL 上传，否则本地 blob 预览。
+  // 选择文件 / 粘贴 / 拖拽三处共用，保证行为一致。
+  const appendImageFiles = useCallback((files: File[]) => {
+    const picked = files
+      .filter((f) => f.type.startsWith('image/'))
+      .slice(0, Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length))
+    if (picked.length === 0) return
     if (API_IMAGE_PROVIDERS.includes(provider)) {
       void appendApiImages(picked)
-      e.target.value = ''
       return
     }
     const urls = picked.map((f) => URL.createObjectURL(f))
     setImages((prev) => [...prev, ...urls])
     setImageFiles((prev) => [...prev, ...picked])
-    e.target.value = ''
   }, [provider, model, savedImagePaths, appendApiImages])
 
+  const onFilesSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    appendImageFiles(files)
+    e.target.value = ''
+  }, [appendImageFiles])
+
   const onPasteImages = useCallback((e: ReactClipboardEvent<HTMLDivElement>) => {
-    const files = Array.from(e.clipboardData.files ?? []).filter((f) => f.type.startsWith('image/'))
-    if (files.length === 0) return
+    const files = Array.from(e.clipboardData.files ?? [])
+    if (!files.some((f) => f.type.startsWith('image/'))) return
     e.preventDefault()
-    const remaining = Math.max(0, maxImageUploadCount(provider, model) - savedImagePaths.length)
-    const picked = files.slice(0, remaining)
-    if (API_IMAGE_PROVIDERS.includes(provider)) {
-      void appendApiImages(picked)
-      return
-    }
-    const urls = picked.map((f) => URL.createObjectURL(f))
-    setImages((prev) => [...prev, ...urls])
-    setImageFiles((prev) => [...prev, ...picked])
-  }, [provider, model, savedImagePaths, appendApiImages])
+    appendImageFiles(files)
+  }, [appendImageFiles])
+
+  // 拖拽上传图片
+  const handleImagesDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    const files = Array.from(e.dataTransfer.files ?? [])
+    if (!files.some((f) => f.type.startsWith('image/'))) return
+    e.preventDefault()
+    appendImageFiles(files)
+  }, [appendImageFiles])
 
   const onRemoveImage = useCallback((idx: number) => {
     setImages((prev) => prev.filter((_, i) => i !== idx))
@@ -1764,6 +1771,8 @@ export default function Dashboard({
               className={'upload-zone' + (images.length > 0 ? ' has-images' : '')}
               onClick={onPickFiles}
               onPaste={onPasteImages}
+              onDragOver={(e) => { e.preventDefault() }}
+              onDrop={(e) => { e.preventDefault(); void handleImagesDrop(e) }}
             >
               {images.length > 0 ? (
                 <div className="thumb-strip">

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -188,16 +188,20 @@ export interface RegenerateDraft {
 }
 
 function normalizeRegenerateMode(providerId: string, rawMode?: string): string {
-  // 元宝仅图生/文生：历史 multi_ref（多参考）记录归为图生视频
+  // 历史入库 mode 统一为完整值（text2video / img2video / multi_ref / first_last / first_frame）。
+  // 这里只做规范化，返回完整值，杜绝与 providerModeOptions 的简写(value='t2v'/'img')不匹配。
+  const m = (rawMode || '').trim()
   if (providerId === 'yuanbao') {
-    if (rawMode === 'text2video' || rawMode === 't2v') return 't2v'
-    return 'img'
+    // 元宝仅图生/文生：历史 multi_ref（多参考）记录归为图生视频
+    if (m === 'text2video' || m === 't2v') return 'text2video'
+    return 'img2video'
   }
-  if (rawMode === 'text2video' || rawMode === 't2v') return 't2v'
-  if (rawMode === 'img2video' || rawMode === 'img') return 'img'
-  if (rawMode === 'multi_ref' || rawMode === 'first_last' || rawMode === 'first_frame') return rawMode
-  if (providerId === 'qwenwan') return 'multi_ref'
-  return 't2v'
+  if (m === 'text2video' || m === 't2v') return 'text2video'
+  if (m === 'img2video' || m === 'img') return 'img2video'
+  if (m === 'multi_ref' || m === 'first_last' || m === 'first_frame' || m === 'firstlast') {
+    return m === 'firstlast' ? 'first_last' : m
+  }
+  return 'text2video'
 }
 
 /** 桌面子模式键归一为 admin 目录扁平键，用于与 caps.modes 求交集 */
@@ -396,7 +400,7 @@ export default function Dashboard({
     }
     // 百炼文生音频参考：有本地副本则重传取新公网 URL（原 https URL 生成后已删），供生成时透传 input.audio_url
     const audioLocal = regenerateDraft.audioLocalPath ?? null
-    if (nextProvider === 'bailian' && normalizedMode === 't2v' && audioLocal) {
+    if (nextProvider === 'bailian' && normalizedMode === 'text2video' && audioLocal) {
       const aExt = audioExt(audioLocal)
       window.api.storage
         .readImageLocal(audioLocal)

--- a/apps/desktop/src/renderer/src/components/MaterialLibrary.tsx
+++ b/apps/desktop/src/renderer/src/components/MaterialLibrary.tsx
@@ -12,7 +12,7 @@ function formatBytes(bytes: number): string {
 }
 
 interface MaterialLibraryProps {
-  onUseMaterial?: (path: string, url: string) => void
+  onUseMaterial?: (materials: Array<{ path: string; url: string }>) => void
   onNotify?: (message: string) => void
 }
 
@@ -23,7 +23,30 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
   const [urls, setUrls] = useState<Record<string, string>>({})
   const [selected, setSelected] = useState<MaterialRecord | null>(null)
   const [removing, setRemoving] = useState<string | null>(null)
+  /** 多选「用作参考」的素材 id 集合（仅图片可勾选） */
+  const [multiSel, setMultiSel] = useState<ReadonlySet<string>>(new Set())
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const toggleMulti = (id: string): void => {
+    setMultiSel((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const clearMulti = (): void => setMultiSel(new Set())
+
+  // 批量回填调度台（多张图片一次用作参考）
+  const useSelected = (): void => {
+    const picked = visibleItems
+      .filter((m) => multiSel.has(m.id) && !!urls[m.id])
+      .map((m) => ({ path: m.path, url: urls[m.id]! }))
+    if (picked.length === 0) return
+    clearMulti()
+    onUseMaterial?.(picked)
+  }
 
   const visibleItems = useMemo(() => {
     const kw = keyword.trim().toLowerCase()
@@ -83,6 +106,13 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
     try {
       await remove(item.id)
       if (selected?.id === item.id) setSelected(null)
+      // 从多选中剔除已删除项，避免计数残留
+      setMultiSel((prev) => {
+        if (!prev.has(item.id)) return prev
+        const next = new Set(prev)
+        next.delete(item.id)
+        return next
+      })
       onNotify?.('已删除素材')
     } catch (err) {
       onNotify?.(err instanceof Error ? err.message : '删除失败')
@@ -174,17 +204,41 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
       ) : visibleItems.length === 0 ? (
         <div className="community-state">没有匹配的素材。</div>
       ) : (
-        <div className="material-grid">
+        <>
+          {multiSel.size > 0 && (
+            <div className="material-batch-bar">
+              <div className="hint">
+                <span className="count">已选 {multiSel.size} 张图片</span>
+              </div>
+              <div className="material-card-actions" style={{ margin: 0 }}>
+                <button className="btn-sm" onClick={clearMulti}>取消选择</button>
+                <button className="btn-sm primary" onClick={useSelected}>用作参考（{multiSel.size}）</button>
+              </div>
+            </div>
+          )}
+          <div className="material-grid">
           {visibleItems.map((m) => {
             const src = urls[m.id]
             const canUse = m.type === 'image'
+            const isSel = multiSel.has(m.id)
             return (
               <article
                 key={m.id}
-                className="material-card"
+                className={'material-card' + (isSel ? ' selected' : '')}
                 onClick={() => src && setSelected(m)}
               >
-                <div className="material-card-cover">{renderThumb(m)}</div>
+                <div className="material-card-cover">
+                  {renderThumb(m)}
+                  {canUse && (
+                    <div
+                      className={'material-select' + (isSel ? ' on' : '')}
+                      title={isSel ? '取消选择' : '选择用作参考'}
+                      onClick={(e) => { e.stopPropagation(); toggleMulti(m.id) }}
+                    >
+                      {isSel ? '✓' : '+'}
+                    </div>
+                  )}
+                </div>
                 <div className="material-card-body">
                   <h4 title={m.name}>{m.name}</h4>
                   <div className="material-meta">
@@ -198,7 +252,7 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
                         title="回填到调度台作为参考图"
                         onClick={() => {
                           if (!src) return
-                          onUseMaterial?.(m.path, src)
+                          onUseMaterial?.([{ path: m.path, url: src }])
                         }}
                       >
                         用作参考
@@ -212,7 +266,8 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
               </article>
             )
           })}
-        </div>
+          </div>
+        </>
       )}
 
       {selected &&
@@ -253,7 +308,7 @@ export default function MaterialLibrary({ onUseMaterial, onNotify }: MaterialLib
                       const src = urls[selected.id]
                       if (!src) return
                       setSelected(null)
-                      onUseMaterial?.(selected.path, src)
+                      onUseMaterial?.([{ path: selected.path, url: src }])
                     }}
                   >
                     用作参考

--- a/apps/desktop/src/renderer/src/components/Modals.tsx
+++ b/apps/desktop/src/renderer/src/components/Modals.tsx
@@ -1445,20 +1445,20 @@ export function AddProviderModal({
               <>
                 <p style={{ margin: '0 0 12px', fontSize: '13px', color: 'var(--fg-secondary)' }}>
                   {selected?.providerId === 'dola'
-                    ? '先在浏览器中打开 dola.com 并完成登录（真实浏览器登录不会被 Google 拦截），登录后回这里点「抓取浏览器登录态」。首次需在浏览器 chrome://inspect/#remote-debugging 开启一次「Enable remote debugging」开关。'
+                    ? '谷歌邮箱等账号登录需用「系统浏览器登录」（谷歌邮箱安全限制问题）；Dola扫码登录可直接用「内置浏览器登录」扫码完成'
                     : `点击按钮将打开 ${selected?.name ?? '厂商'} 登录窗口。请在窗口中完成登录，登录成功后点击「已完成登录」。`}
                 </p>
                 {selected?.providerId === 'dola' && (
                   <>
-                    <button className="btn-sm primary" onClick={() => void handleLoginClick('system')}>
-                      抓取浏览器登录态 →
+                    <button className="btn-sm" onClick={() => void handleLoginClick('window')}>
+                      内置浏览器登录
                     </button>
                     <button
-                      className="btn-sm"
-                      onClick={() => void handleLoginClick('window')}
+                      className="btn-sm primary"
+                      onClick={() => void handleLoginClick('system')}
                       style={{ marginLeft: 8 }}
                     >
-                      内置窗口登录
+                      系统浏览器登录 →
                     </button>
                   </>
                 )}
@@ -1473,7 +1473,7 @@ export function AddProviderModal({
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--fg-muted)' }}>
                 <span className="spinner" style={{ width: 14, height: 14, border: '2px solid var(--border)', borderTopColor: 'var(--accent)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
                 {selected?.providerId === 'dola' && loginMode === 'system'
-                  ? '正在抓取浏览器中的 dola 登录态…（若弹出「允许调试」提示，请点击允许）'
+                  ? '正在系统浏览器登录 dola…（若弹出「允许调试」，请点击允许）'
                   : '正在获取登录状态，请在登录窗口完成登录…'}
               </div>
             )}

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -312,7 +312,11 @@ export function providerModeOptions(provider: string, model = ''): Array<{ value
     ]
   }
   if (provider === 'dola') {
-    return [{ value: 'multi_ref', label: '多参考生成' }]
+    // 默认保持「多参考生成」（Dola 原默认、脚本适配的界面）；文生视频为可选能力
+    return [
+      { value: 'multi_ref', label: '多参考生成' },
+      { value: 'text2video', label: '文生视频' }
+    ]
   }
   if (provider === 'tokenhub') {
     // 腾讯云 TokenHub 各模型模式与主进程 TOKENHUB_MODEL_MODES 一致；FX 待模板选择器，暂无入口

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2140,10 +2140,11 @@ body {
 }
 .material-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(136px, 1fr));
+  gap: 8px;
 }
 .material-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--bg-card);
@@ -2155,6 +2156,10 @@ body {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .material-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+}
+.material-card.selected {
   border-color: var(--accent);
   box-shadow: var(--shadow-md);
 }
@@ -2182,11 +2187,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 8px 10px;
+  padding: 6px 8px;
 }
 .material-card-body h4 {
   margin: 0;
-  font-size: 0.85em;
+  font-size: 0.78em;
   font-weight: 600;
   color: var(--fg-primary);
   white-space: nowrap;
@@ -2197,14 +2202,60 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.75em;
+  font-size: 0.7em;
   color: var(--fg-muted);
 }
 .material-card-actions {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 4px;
+  margin-top: 2px;
+}
+.material-card-actions .btn-sm {
+  padding: 2px 6px;
+  font-size: 0.72em;
+}
+.material-select {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+.material-select.on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* 批量多选工具条（勾选后浮在素材网格上方） */
+.material-batch-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 6px 10px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.material-batch-bar .hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82em;
+  color: var(--fg-primary);
+}
+.material-batch-bar .hint .count {
+  font-weight: 600;
 }
 .material-detail {
   background: var(--bg-card);

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -704,6 +704,8 @@ body {
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  /* 独立 GPU 合成层：切 tab（display 切换）时各 pane 各自合成，避免共用层在 Windows GPU 下显示旧缓冲闪屏 */
+  transform: translateZ(0);
 }
 
 .dashboard-wrap,


### PR DESCRIPTION
## 变更
- Dola 引擎放开模式校验：支持「多参考生成 / 文生视频」；多参考仍需至少上传一张图，文生视频不要求素材。
- 调度台 Dola 模式下拉新增「文生视频」，默认仍为「多参考生成」。
- handleGenerate / 历史模式归一不再强制 Dola 走 multi_ref。

## 验证
- typecheck 通过。
- 建议在桌面端实机验证文生视频与多参考两条路径。