### PR TITLE
feat(admin): 生成记录记录并展示桌面端版本号

### DIFF
--- a/apps/admin/src/app/(dashboard)/generation-jobs/page.tsx
+++ b/apps/admin/src/app/(dashboard)/generation-jobs/page.tsx
@@ -260,6 +260,7 @@ export default function GenerationJobsPage() {
                     <th>时间</th>
                     <th>用户</th>
                     <th>团队</th>
+                    <th>桌面端版本</th>
                     <th>厂商</th>
                     <th>模式</th>
                     <th>状态</th>
@@ -299,6 +300,7 @@ export default function GenerationJobsPage() {
                         </div>
                       </td>
                       <td>{item.team_name ?? "—"}</td>
+                      <td>{item.client_version ?? "—"}</td>
                       <td>{item.provider_name ?? item.provider_id ?? "—"}</td>
                       <td>{modeLabel(item.mode)}</td>
                       <td>

--- a/apps/admin/src/lib/api/generationJobs.ts
+++ b/apps/admin/src/lib/api/generationJobs.ts
@@ -23,6 +23,7 @@ export interface AdminGenerationJob {
   cost_unit: string | null;
   cost_amount: number | null;
   equivalent_count: number | null;
+  client_version: string | null;
   created_at: string;
   completed_at: string | null;
 }
@@ -148,6 +149,7 @@ function normalizeGenerationJob(it: Record<string, unknown>): AdminGenerationJob
     cost_unit: (it.cost_unit as string) ?? null,
     cost_amount: it.cost_amount as number | null,
     equivalent_count: it.equivalent_count as number | null,
+    client_version: (it.client_version as string) ?? null,
     created_at: String(it.created_at ?? ""),
     completed_at: (it.completed_at as string) ?? null
   };

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -374,6 +374,7 @@ export async function runGenerate(
   try {
     job = await jobSvc.insertJob(input.userId, {
       teamId: input.teamId,
+      clientVersion: app.getVersion(),
       mode: normalizeJobMode(input.mode),
 // 入库用不含「无需确认」兜底后缀的原始 prompt：该后缀仅用于实际发送给官网 webview，不该出现在记录/历史里
       prompt: dispatchPrompt,
@@ -773,6 +774,7 @@ async function runApiBranch(
   try {
     job = await jobSvc.insertJob(input.userId, {
       teamId: input.teamId,
+      clientVersion: app.getVersion(),
       mode: normalizeJobMode(input.mode),
       prompt: input.prompt,
       status: 'pending',

--- a/migrations/0038_admin_generation_jobs_rpc.sql
+++ b/migrations/0038_admin_generation_jobs_rpc.sql
@@ -77,6 +77,7 @@ BEGIN
       j.cost_unit,
       j.cost_amount,
       j.equivalent_count,
+      j.client_version,
       j.created_at,
       j.completed_at,
       pu.display_name AS user_name,

--- a/migrations/0039_add_jobs_client_version.sql
+++ b/migrations/0039_add_jobs_client_version.sql
@@ -1,0 +1,10 @@
+-- 0039_add_jobs_client_version.sql
+-- admin 查看「用户用哪个桌面端版本生成视频」：jobs 新增 client_version 列。
+-- 只在生成时写入一次（insert 时带上当前 app.getVersion()）；历史记录该列为 NULL。
+-- Idempotent: ADD COLUMN IF NOT EXISTS；在 Supabase SQL Editor 或迁移 runner 执行。
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS client_version TEXT;
+
+COMMENT ON COLUMN public.jobs.client_version
+  IS '桌面端生成该记录时的客户端版本号（app.getVersion()）；历史记录为 NULL，表示未知';

--- a/packages/db-supabase/src/index.ts
+++ b/packages/db-supabase/src/index.ts
@@ -1055,6 +1055,7 @@ export interface InsertJobInput {
   teamId?: string | null
   providerId?: string | null
   accountId?: string | null
+  clientVersion?: string | null
   mode: string
   prompt?: string | null
   options?: Record<string, unknown> | null
@@ -1164,6 +1165,7 @@ export class JobService {
     if (input.teamId) payload.team_id = input.teamId
     if (input.providerId) payload.provider_id = input.providerId
     if (input.accountId) payload.account_id = input.accountId
+    if (input.clientVersion) payload.client_version = input.clientVersion
     if (input.prompt) payload.prompt = input.prompt
     if (input.options) payload.options = input.options
     if (input.attempts) payload.attempts = input.attempts


### PR DESCRIPTION
记录用户生成视频时所用的桌面端版本：\n\n- jobs 新增 client_version 列，生成时写入 app.getVersion()（0039 迁移 + dispatch 两处 insertJob）\n- db-supabase insertJob 支持 clientVersion 可选字段\n- admin 生成记录：admin_list_generation_jobs 返回 client_version，列表新增「桌面端版本」列\n\n注意：历史记录该列为空（显示 —），需要桌面端发版升级后新生成才带版本；并需在 Supabase 执行 0039 迁移 + 重跑 0038 RPC。