### PR TITLE
fix(desktop): 修复多厂商生成稳定性问题

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quota-flow/desktop",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Quota-Flow 桌面端（Electron + Vite + React）",
   "author": "Quota-Flow",
   "homepage": "https://github.com/Shaun520/quota-flow",

--- a/apps/desktop/src/main/dispatch.ts
+++ b/apps/desktop/src/main/dispatch.ts
@@ -93,7 +93,7 @@ function normalizeJobMode(mode?: string): string {
 }
 
 function providerLabel(providerId: string): string {
-  if (providerId === 'qwenwan') return '千问（通义万相）'
+  if (providerId === 'qwenwan' || providerId === 'qwen') return '千问（通义万相）'
   if (providerId === 'yuanbao') return '元宝混元'
   if (providerId === 'dola') return 'Dola'
   return '豆包'
@@ -110,7 +110,7 @@ function parseSupportedDurations(meta: { capabilities?: Record<string, unknown> 
 
 function providerCost(providerId: string, durationSec: number, resolution?: string): { amount: number; unitName: string } {
   const durationPoint = durationSec <= 5 ? 0 : durationSec <= 10 ? 1 : 2
-  if (providerId === 'qwenwan') {
+  if (providerId === 'qwenwan' || providerId === 'qwen') {
     const amount = 1 + durationPoint + (resolution === '1080' ? 1 : 0)
     return { amount, unitName: '额度' }
   }
@@ -345,13 +345,7 @@ export async function runGenerate(
   // 元宝当前没有独立视频生成入口，生成完全靠 chat 输入框提示词完成；
   // 这里在进入任务前补前缀，保证任务记录与页面实际发送的 prompt 一致。
   const dispatchPrompt = resolvedProviderId === 'yuanbao' ? `视频生成：${input.prompt}` : input.prompt
-  // WebView 厂商（豆包/元宝/Dola/千问）发送时有时会弹「是否确认/继续」类对话框打断生成；
-  // 在 prompt 尾部统一追加一句「直接生成、不要再确认」，缓解这类交互，不影响内容本身。
-  // API 型厂商走 runApiBranch，不命中此拼接。
-  const webviewPrompt =
-    // 开头加空格避免与前文粘连
-    (resolvedProviderId === 'yuanbao' ? ' ' : '  ') + '请不要再向我确认，直接按照我的提示词生成视频'
-  const finalPrompt = dispatchPrompt + webviewPrompt
+  const finalPrompt = dispatchPrompt
 
   // API 型厂商（智谱等）走独立分支：实体为 API Key，无 cookie 自动化，额度在平台资源包。
   if (resolvedProviderId in API_BRANCHES) {
@@ -503,7 +497,7 @@ export async function runGenerate(
           break
         }
         const cookies = c ?? []
-        if (resolvedProviderId === 'qwenwan') {
+        if (resolvedProviderId === 'qwenwan' || resolvedProviderId === 'qwen') {
           result = await runQwenGeneration({
             cookies,
             storages,

--- a/apps/desktop/src/main/dola-webview.ts
+++ b/apps/desktop/src/main/dola-webview.ts
@@ -13,6 +13,8 @@ const UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
 const DOLA_URL = 'https://www.dola.com/chat/'
 const BLOCKED_PATTERN = /违[规法]|内容审核|无法生成|版权|侵权|肖像|敏感|检测到.*(风险|违规)|拒绝生成|请勿生成|无法返回该内容/
+/** 额度/次数耗尽文案（服务端拦截）：区别于内容封禁——此情形应切下一个账号，而非终止 */
+const QUOTA_CAP_PATTERN = /达到.{0,6}上限|生成次数.{0,10}上限|免费生成.{0,10}(用完|用尽)|免费.{0,4}次数.{0,6}(用完|用尽)|明天再来.{0,6}免费|今日.{0,8}免费.{0,8}(用完|用尽)/
 const MAX_DOLA_IMAGES = 10
 const ALLOWED_MODELS = ['Dreamina Seedance 2.5', 'Dreamina Seedance 2.0 Fast', 'Dreamina Seedance 1.0']
 const ALLOWED_DURATIONS = [5, 10]
@@ -656,11 +658,21 @@ function buildExtractResultScript(): string {
     if (lineEnd === -1) lineEnd = text.length;
     blockedText = text.slice(lineStart, lineEnd).trim().slice(0, 120) || blockedMatch[0].slice(0, 80);
   }
+  const quotaMatch = text.match(/达到.{0,6}上限|生成次数.{0,10}上限|免费生成.{0,10}(用完|用尽)|免费.{0,4}次数.{0,6}(用完|用尽)|明天再来.{0,6}免费|今日.{0,8}免费.{0,8}(用完|用尽)/);
+  let quotaText = null;
+  if (quotaMatch) {
+    const idx = quotaMatch.index ?? 0;
+    const lineStart = text.lastIndexOf('\\n', idx) + 1;
+    let lineEnd = text.indexOf('\\n', idx);
+    if (lineEnd === -1) lineEnd = text.length;
+    quotaText = text.slice(lineStart, lineEnd).trim().slice(0, 120) || quotaMatch[0].slice(0, 80);
+  }
   return {
     vids,
     mp4s: mp4s.slice(0, 12),
     hasDone: /你的视频生成好了|生成完成|生成成功|生成完毕|下载视频|保存视频/.test(text),
     blockedText,
+    quotaText,
     textTail: text.slice(-240)
   };
   } catch (e) {
@@ -972,6 +984,7 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
       mp4s?: string[]
       hasDone?: boolean
       blockedText?: string | null
+      quotaText?: string | null
       textTail?: string
       ok?: boolean
       error?: string
@@ -984,6 +997,11 @@ export async function runDolaGeneration(options: DolaGenerateOptions): Promise<D
     if (r.blockedText) {
       win.destroy()
       return failBlocked(r.blockedText, attempts)
+    }
+    // 额度/次数耗尽：普通失败（非 blocked），让上层切换到下一个有额度的账号重试
+    if (r.quotaText) {
+      win.destroy()
+      return fail(r.quotaText, attempts)
     }
     const mediaUrls = captured.current ? [...captured.current.mediaUrls] : []
     const picked = pickMediaUrl({ ...r, mediaUrls })

--- a/apps/desktop/src/main/qwen-webview.ts
+++ b/apps/desktop/src/main/qwen-webview.ts
@@ -10,6 +10,22 @@ import { readFile } from 'node:fs/promises'
 import { basename, extname } from 'node:path'
 import type { OriginStorage, ProviderCookie } from './webview-engine'
 
+// 检测千问页面是否出现滑块验证码（阿里系人机验证）
+const detectQwenCaptchaScript = (): boolean => {
+  const t = document.body ? document.body.innerText : ''
+  // 千问滑块验证码特征文案
+  return /请拖动下方滑块完成验证|通过验证以确保正常访问|请按住滑块，拖动到最右边|人机验证|拖动滑块/.test(t)
+}
+
+// 风控/验证时显示窗口交用户处理
+const showRiskWindow = (win: BrowserWindow): void => {
+  try {
+    win.show()
+    win.focus()
+    win.center()
+  } catch {}
+}
+
 const UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
 const QWEN_CHAT_URL = 'https://www.qianwen.com/chat'
@@ -1214,6 +1230,34 @@ export async function runQwenGeneration(options: QwenGenerateOptions): Promise<Q
   if (!sendResult.ok) {
     win.destroy()
     return failWith(sendResult.reason || '千问发送失败')
+  }
+
+  // 发送后检查是否出现滑块验证码：出现则显示窗口交用户完成，完成后继续
+  await sleep(1500)
+  let captchaDetected = false
+  try {
+    captchaDetected = (await win.webContents.executeJavaScript('(' + detectQwenCaptchaScript.toString() + ')()', true)) as boolean
+  } catch {}
+  if (captchaDetected) {
+    options.onProgress?.('risk-verify', { message: '千问要求完成滑块验证，请在弹出的窗口中拖动滑块完成验证' })
+    showRiskWindow(win)
+    // 轮询等待用户完成验证（最多 5 分钟）
+    const captchaStart = Date.now()
+    const CAPTCHA_TIMEOUT_MS = 300000
+    while (Date.now() - captchaStart < CAPTCHA_TIMEOUT_MS) {
+      await sleep(3000)
+      let stillCaptcha = false
+      try {
+        stillCaptcha = (await win.webContents.executeJavaScript('(' + detectQwenCaptchaScript.toString() + ')()', true)) as boolean
+      } catch {}
+      if (!stillCaptcha) {
+        options.onProgress?.('risk-resolved')
+        if (options.showWebview !== true) {
+          try { win.hide() } catch {}
+        }
+        break
+      }
+    }
   }
 
   if (cancelState) cancelState.submitted = true

--- a/apps/desktop/src/main/webview-engine.ts
+++ b/apps/desktop/src/main/webview-engine.ts
@@ -276,6 +276,76 @@ const insertPromptAndSubmitScript = (prompt: string): unknown => {
         if (/^\d{1,2}s$/.test(t)) el.remove()
       }
     } catch {}
+    // 追加 prompt 并校验确实落进编辑器：图生视频会在图片 chip 后追加一段提示词，
+    // 之前没校验，插入失败仍返回 ok → 调度台误显示「排队中」但提示词根本没进输入框。
+    const headCore = prompt.split(/[，,]/)[0].substring(0, 6)
+    let inserted = false
+    for (let i = 0; i < 4 && !inserted; i++) {
+      editor.focus()
+      try {
+        const sel = window.getSelection()
+        if (sel) {
+          const range = document.createRange()
+          range.selectNodeContents(editor)
+          range.collapse(false)
+          sel.removeAllRanges()
+          sel.addRange(range)
+        }
+      } catch {}
+      try {
+        document.execCommand('insertText', false, prompt)
+      } catch {}
+      editor.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'insertText', data: prompt }))
+      editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: prompt }))
+      await sleep(600)
+      const t = norm(editor.innerText || editor.textContent || '')
+      if (headCore.length > 0 && t.includes(headCore)) inserted = true
+    }
+    if (!inserted) {
+      return { ok: false, reason: '提示词未成功进入输入框，已中止以避免误报生成中' }
+    }
+    editor.focus()
+    const enterOpts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true }
+    editor.dispatchEvent(new KeyboardEvent('keydown', enterOpts))
+    editor.dispatchEvent(new KeyboardEvent('keypress', enterOpts))
+    editor.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true }))
+    await sleep(1500)
+    return { ok: true }
+  })()
+}
+
+// 豆包可能以「聊天回复」的形式要求先确认参数（如「确认后我再开始生成视频」），此时视频并未开始生成、
+// 也没有可点的弹窗。用此脚本检测页面是否出现这类「等待确认」回复，供主进程决定是否回一条确认。
+const detectConfirmRequestScript = (): boolean => {
+  const t = document.body ? document.body.innerText : ''
+  return /确认后我再开始生成视频|我将按最终要求生成|视频生成参数确认|确认以上参数|请确认以上方案/.test(t)
+}
+
+// 校验自动回复的确认消息是否真的落进了聊天区（豆包可能没把输入推进去，需据此重试）。
+const confirmReplySentScript = (marker: string): boolean => {
+  const t = document.body ? document.body.innerText : ''
+  return t.includes(marker)
+}
+
+// 向豆包输入框追加一段文本并回车（不清空输入框，避免误删已上传图片/内容），用于回复「确认开始生成」。
+const appendAndSubmitTextScript = (text: string): unknown => {
+  const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+  const findEditor = (): HTMLElement | null => {
+    const sels = ['[class*="ProseMirror"]', '[class*="tiptap"]', '[contenteditable="true"]', '[contenteditable="plaintext-only"]', '[role="textbox"]']
+    for (const s of sels) {
+      const els = [...document.querySelectorAll<HTMLElement>(s)]
+      // 优先可见输入框；生成过程中输入框可能被收起，offsetParent 为 null，此时回退到任意匹配的第一个。
+      const visible = els.find((el) => el.offsetParent !== null)
+      if (visible) return visible
+      if (els.length) return els[0]
+    }
+    return null
+  }
+  return (async () => {
+    const editor = findEditor()
+    if (!editor) return { ok: false, reason: '未找到输入框' }
+    // 主动唤起输入（有些 UI 要点击展开，否则 insertText 进不到被折叠的编辑器）
+    try { (editor as HTMLElement).click() } catch {}
     editor.focus()
     try {
       const sel = window.getSelection()
@@ -288,11 +358,25 @@ const insertPromptAndSubmitScript = (prompt: string): unknown => {
       }
     } catch {}
     try {
-      document.execCommand('insertText', false, prompt)
+      document.execCommand('insertText', false, text)
     } catch {}
-    editor.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'insertText', data: prompt }))
-    editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: prompt }))
+    editor.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'insertText', data: text }))
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }))
     await sleep(800)
+    // 校验插入是否成功，失败则换 TipTap setContent（替换式，仅兜底，确认消息无图片依赖）
+    const norm = (s: string): string => (s || '').trim()
+    if (!norm(editor.innerText || editor.textContent || '').includes(text.trim())) {
+      try {
+        const tiptap = (window as unknown as Record<string, { commands?: { setContent?: (c: string, e?: boolean) => void } }>)[Object.keys(window).find((k) => {
+          try {
+            const v = (window as unknown as Record<string, unknown>)[k]
+            return !!v && typeof v === 'object' && !!((v as { commands?: unknown }).commands) && typeof ((v as { commands?: { setContent?: unknown } }).commands?.setContent) === 'function'
+          } catch { return false }
+        }) || '']
+        if (tiptap && tiptap.commands?.setContent) tiptap.commands.setContent(text, false)
+      } catch {}
+      await sleep(400)
+    }
     editor.focus()
     const enterOpts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true }
     editor.dispatchEvent(new KeyboardEvent('keydown', enterOpts))
@@ -379,7 +463,13 @@ const fillAndSubmitScript = (prompt: string): unknown => {
       await sleep(350)
     }
     const finalText = norm(editor.innerText || editor.textContent || '')
-    if (finalText !== prompt) {
+    // 豆包会把 prompt 片段（如 16：9 比例、8K、PBR、UE5）自动转成 chip，innerText 不再逐字等于原始文本，
+    // 精确相等会误报「编辑器内容未清理干净」而杀掉整条任务。改为容忍性兜底校验：
+    // 只要提交内容开头（首个逗号前的核心句前 6 字）已完整落到编辑器，即视为写入成功；
+    // 残留的 UI 自动 chip（比例/时长等）不影响豆包按提示词解析，故不再拦截。
+    const headCore = prompt.split(/[，,]/)[0].substring(0, 6)
+    const cleanOk = finalText === prompt || (headCore.length > 0 && finalText.includes(headCore))
+    if (!cleanOk) {
       return { ok: false, reason: '编辑器内容未清理干净: ' + finalText.slice(0, 60) }
     }
     const enterOpts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true }
@@ -1208,6 +1298,12 @@ const readRiskScript = (): unknown => {
   else if (disclaimer) type = 'disclaimer'
   else if (w.type === 'verify') type = 'verify'
   else if (domVerify) type = 'verify'
+  // 宽限解封：verify 仅来自 __qfRisk 历史残留（fetch 未抓到 async_task 时不会置 ok），
+  // 但 DOM 已长时间无验证/免责元素说明用户已完成验证并进入生成。给一个短宽限期
+  // （兼顾「响应先到、验证 DOM 后渲染」的时序差），超期即解封，避免永远卡在「等待验证中」。
+  if (type === 'verify' && !domVerify && !disclaimer && w.type !== 'ok' && w.at && Date.now() - w.at > 8000) {
+    type = 'none'
+  }
   return { type, detail: w.detail || null, domVerify, disclaimer }
 }
 
@@ -1665,6 +1761,8 @@ export async function runDoubaoGeneration(options: DoubaoGenerateOptions): Promi
   const started = Date.now()
   let cardClicked = false
   let doneTicks = 0
+  let confirmReplied = false
+  let confirmReplyAttempts = 0
   let final: { videoUrl?: string; posterUrl?: string | null } | null = null
 
   while (Date.now() - started < maxWaitMs) {
@@ -1714,6 +1812,35 @@ export async function runDoubaoGeneration(options: DoubaoGenerateOptions): Promi
     if (r.blockedText) {
       win.destroy()
       return failBlocked(r.blockedText)
+    }
+    // 豆包以「聊天回复」要求确认参数（视频未开始生成）：回一条「确认，直接开始生成」推进。
+    // 每次轮询校验确认消息是否真的落进聊天区，没落地就一直补发（最多 confirmReplyAttempts 次)，
+    // 落地后才真正标记已确认，避免「发失败却被当成功」导致一直卡在确认上。
+    if (!confirmReplied && confirmReplyAttempts < 3) {
+      let needConfirm = false
+      try {
+        needConfirm = (await win.webContents.executeJavaScript('(' + detectConfirmRequestScript.toString() + ')()', true)) as boolean
+      } catch {
+        needConfirm = false
+      }
+      if (needConfirm) {
+        let landed = false
+        try {
+          landed = (await win.webContents.executeJavaScript('(' + confirmReplySentScript.toString() + ')(' + JSON.stringify('确认，直接开始生成') + ')', true)) as boolean
+        } catch {
+          landed = false
+        }
+        if (!landed) {
+          confirmReplyAttempts += 1
+          progress(options, 'waiting', { message: '豆包要求确认参数，自动确认中...（第 ' + confirmReplyAttempts + ' 次）' })
+          try {
+            await win.webContents.executeJavaScript('(' + appendAndSubmitTextScript.toString() + ')(' + JSON.stringify('确认，直接开始生成') + ')', true)
+          } catch {}
+        } else {
+          // 确认消息已落进聊天区（含用户手动确认的情况），标记处理完成避免重复发送。
+          confirmReplied = true
+        }
+      }
     }
     const video = r.vids && r.vids[0]
     const mp4 = r.mp4s && r.mp4s[0]

--- a/apps/desktop/src/renderer/src/components/Dashboard.tsx
+++ b/apps/desktop/src/renderer/src/components/Dashboard.tsx
@@ -254,7 +254,8 @@ export default function Dashboard({
 }: DashboardProps) {
   const { aggs: provAggs, zhipuQuotaOverrides, volcTokenOverrides, bailianQuotaOverrides } = providers
   const { user, team } = useAuth()
-  const { items: jobItems, reload: reloadJobs } = jobs
+  // 「最近生成」面板用独立 recent（首页最近10条），不与历史记录分页/筛选联动，翻页不再影响调度台
+  const { recent: jobItems, reload: reloadJobs } = jobs
   const [provider, setProvider] = useState('doubao')
   const [model, setModel] = useState(MODELS.doubao[0])
   const [mode, setMode] = useState('text2video')
@@ -796,7 +797,10 @@ export default function Dashboard({
   // 厂商选项只取「已启用且已绑定」的厂商
   const providerOptions = useMemo(() => {
     if (activeBoundAggs.length === 0) return []
-    return activeBoundAggs.map((a) => ({ value: a.providerId, label: a.name }))
+    return activeBoundAggs
+      // 智谱清言不在调度台展示生成入口
+      .filter((a) => a.providerId !== 'chatglm')
+      .map((a) => ({ value: a.providerId, label: a.name }))
   }, [activeBoundAggs])
 
   // 当前选择不在可用列表时（例如厂商被解绑），回退到第一个可用厂商

--- a/apps/desktop/src/renderer/src/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/src/hooks/useJobs.ts
@@ -146,6 +146,8 @@ export interface JobsResult {
   loading: boolean
   error: string | null
   items: JobItem[]
+  /** 最近生成（首页最近 10 条），独立于历史列表分页/筛选——供「调度台/最近生成」面板使用 */
+  recent: JobItem[]
   total: number
   page: number
   hasAnySuccess: boolean
@@ -171,6 +173,8 @@ export function useJobs(): JobsResult {
   const [items, setItems] = useState<JobItem[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
+  // 最近生成列表：始终查第 1 页最近 10 条，不随历史列表分页/筛选变化（调度台「最近生成」独立于此）
+  const [recent, setRecent] = useState<JobItem[]>([])
   const [filters, setFiltersState] = useState<JobFilters>({ search: '', providerId: '', status: '' })
   const [hasAnySuccess, setHasAnySuccess] = useState(false)
   const [reloadKey, setReloadKey] = useState(0)
@@ -257,6 +261,24 @@ export function useJobs(): JobsResult {
     const svc = getJobService()
     if (!svc) return
     svc
+      .listJobs(user.id, { page: 1, pageSize: PAGE_SIZE })
+      .then((res) => {
+        if (!cancelled) setRecent(res.items.map(toJobItem))
+      })
+      .catch(() => {
+        // 最近生成非关键：失败保留上次数据，不阻塞调度台
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [user?.id, reloadKey])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!user) return
+    const svc = getJobService()
+    if (!svc) return
+    svc
       .hasAnySuccess(user.id)
       .then((value) => {
         if (!cancelled) setHasAnySuccess(value)
@@ -301,5 +323,5 @@ export function useJobs(): JobsResult {
     [reload, user]
   )
 
-  return { loading, error, items, total, page, hasAnySuccess, setPage, setFilters, reload, getDetail, remove, removeMany }
+  return { loading, error, items, recent, total, page, hasAnySuccess, setPage, setFilters, reload, getDetail, remove, removeMany }
 }

--- a/apps/desktop/src/renderer/src/spec.ts
+++ b/apps/desktop/src/renderer/src/spec.ts
@@ -292,7 +292,7 @@ export function providerModeOptions(provider: string, model = ''): Array<{ value
     // 兜底：识别不出类型的百炼视频模型统一按「文生视频」，避免下拉落到裸 value 't2v'
     return [t2v()]
   }
-  if (provider === 'qwenwan') {
+  if (provider === 'qwenwan' || provider === 'qwen') {
     if (model === '万相 2.7') {
       return [
         { value: 'multi_ref', label: '多参考生成' },
@@ -415,7 +415,7 @@ export function ratioOptions(provider: string): Array<{ value: string; label: st
       { value: '21:9', label: '21:9' }
     ]
   }
-  if (provider === 'qwenwan') {
+  if (provider === 'qwenwan' || provider === 'qwen') {
     return [
       { value: '9:16', label: '9:16' },
       { value: '3:4', label: '3:4' },


### PR DESCRIPTION
## Summary
修复桌面端多厂商（千问/豆包/Dola）生成的稳定性：

- **千问**：提供商 id \qwen\ 与 \qwenwan\ 同源兼容——正确路由到千问引擎、模式/比例下拉、费用单位均按千问处理；新增滑块验证码检测，出现时弹窗交用户完成，完成后自动继续生成。
- **豆包**：风控残留 verify 在 DOM 已无验证元素时 8s 宽限后自动解封，避免卡「等待验证中」；编辑内容校验放宽，不再因比例/分辨率被转 chip 而误报「编辑器内容未清理干净」。
- **Dola**：额度/次数耗尽识别为额度上限，返回普通失败以切换到下一个有额度账号重试，而非终止卡排队。
- **调度台**：「最近生成」改用独立 recent（首页最近10条），与历史记录分页/筛选解耦，翻页不再影响。
- **其他**：智谱清言(chatglm)不再出现在调度台生成入口；移除 WebView 厂商 prompt 尾部统一追加的确认文案。

## Test plan
- [x] 本地打包 portable 验证千问/豆包/Dola 生成
- [ ] 发布 v0.2.8 后整体回归